### PR TITLE
fix(macOS): fix unexpected behavior in server select

### DIFF
--- a/src/input/sdl_to_vk.h
+++ b/src/input/sdl_to_vk.h
@@ -314,6 +314,11 @@ inline int sdlKeyToMacNative(int sdlKey) {
         case SDLK_Y: return kVK::ANSI_Y;
         case SDLK_Z: return kVK::ANSI_Z;
 
+        // On MacOS, 0 and 3 SDL codes do not correspond to the correct kVK
+        // codes and must be mapped manually
+        case SDLK_0: return kVK::ANSI_0;
+        case SDLK_3: return kVK::ANSI_3;
+
         default: return sdlKey;
     }
 }


### PR DESCRIPTION
On the initial server select, 3 becomes backspace, and 0 becomes ESC. This is due to the SDL keycodes not mapping directly with the kVK keycodes. The mapping is updated to reflect the correct codes.

Fixes #36