### PR TITLE
Feature/macos pip

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ if(APPLE)
     find_library(QUARTZCORE_FRAMEWORK QuartzCore REQUIRED)
     find_library(IOSURFACE_FRAMEWORK IOSurface REQUIRED)
     find_library(MEDIAPLAYER_FRAMEWORK MediaPlayer REQUIRED)
+    find_library(PIP_FRAMEWORK PIP PATHS /System/Library/PrivateFrameworks REQUIRED)
 
     set(PLATFORM_SOURCES
         src/platform/macos_layer.mm
@@ -85,6 +86,7 @@ if(APPLE)
         src/compositor/metal_compositor.mm
         src/player/media_session.cpp
         src/player/macos/media_session_macos.mm
+        src/player/macos/pip_helper.mm
         src/player/mpv/mpv_player.cpp
         src/player/vulkan_subsurface_renderer.cpp
     )
@@ -99,6 +101,7 @@ if(APPLE)
         ${QUARTZCORE_FRAMEWORK}
         ${IOSURFACE_FRAMEWORK}
         ${MEDIAPLAYER_FRAMEWORK}
+        ${PIP_FRAMEWORK}
         letsmove
     )
 elseif(WIN32)
@@ -445,6 +448,7 @@ if(APPLE)
         src/platform/macos_app.mm
         src/compositor/metal_compositor.mm
         src/player/macos/media_session_macos.mm
+        src/player/macos/pip_helper.mm
         PROPERTIES COMPILE_FLAGS "-fobjc-arc"
     )
 endif()

--- a/src/cef/cef_app.cpp
+++ b/src/cef/cef_app.cpp
@@ -155,7 +155,6 @@ void App::OnContextCreated(CefRefPtr<CefBrowser> browser,
     jmpNative->SetValue("setOsdVisible", CefV8Value::CreateFunction("setOsdVisible", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
     jmpNative->SetValue("togglePiP", CefV8Value::CreateFunction("togglePiP", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
     jmpNative->SetValue("isPiPSupported", CefV8Value::CreateFunction("isPiPSupported", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
-    jmpNative->SetValue("isPiPActive", CefV8Value::CreateFunction("isPiPActive", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
     window->SetValue("jmpNative", jmpNative, V8_PROPERTY_ATTRIBUTE_READONLY);
 
     // Inject the JavaScript shim that creates window.api, window.NativeShell, etc.
@@ -544,14 +543,6 @@ bool NativeV8Handler::Execute(const CefString& name,
 #else
         retval = CefV8Value::CreateBool(false);
 #endif
-        return true;
-    }
-
-    if (name == "isPiPActive") {
-        // PiP active state is managed on the browser process side.
-        // For simplicity, return false here — the JS side uses togglePiP()
-        // and the PiP button toggles state. The web UI handles this.
-        retval = CefV8Value::CreateBool(false);
         return true;
     }
 

--- a/src/cef/cef_app.cpp
+++ b/src/cef/cef_app.cpp
@@ -153,6 +153,9 @@ void App::OnContextCreated(CefRefPtr<CefBrowser> browser,
     jmpNative->SetValue("setSettingValue", CefV8Value::CreateFunction("setSettingValue", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
     jmpNative->SetValue("themeColor", CefV8Value::CreateFunction("themeColor", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
     jmpNative->SetValue("setOsdVisible", CefV8Value::CreateFunction("setOsdVisible", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
+    jmpNative->SetValue("togglePiP", CefV8Value::CreateFunction("togglePiP", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
+    jmpNative->SetValue("isPiPSupported", CefV8Value::CreateFunction("isPiPSupported", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
+    jmpNative->SetValue("isPiPActive", CefV8Value::CreateFunction("isPiPActive", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
     window->SetValue("jmpNative", jmpNative, V8_PROPERTY_ATTRIBUTE_READONLY);
 
     // Inject the JavaScript shim that creates window.api, window.NativeShell, etc.
@@ -526,6 +529,29 @@ bool NativeV8Handler::Execute(const CefString& name,
             msg->GetArgumentList()->SetBool(0, arguments[0]->GetBoolValue());
             browser_->GetMainFrame()->SendProcessMessage(PID_BROWSER, msg);
         }
+        return true;
+    }
+
+    if (name == "togglePiP") {
+        CefRefPtr<CefProcessMessage> msg = CefProcessMessage::Create("playerTogglePiP");
+        browser_->GetMainFrame()->SendProcessMessage(PID_BROWSER, msg);
+        return true;
+    }
+
+    if (name == "isPiPSupported") {
+#ifdef __APPLE__
+        retval = CefV8Value::CreateBool(true);
+#else
+        retval = CefV8Value::CreateBool(false);
+#endif
+        return true;
+    }
+
+    if (name == "isPiPActive") {
+        // PiP active state is managed on the browser process side.
+        // For simplicity, return false here — the JS side uses togglePiP()
+        // and the PiP button toggles state. The web UI handles this.
+        retval = CefV8Value::CreateBool(false);
         return true;
     }
 

--- a/src/cef/cef_client.cpp
+++ b/src/cef/cef_client.cpp
@@ -412,6 +412,9 @@ bool Client::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
     } else if (name == "getClipboard") {
         handleGetClipboard(browser, args);
         return true;
+    } else if (name == "playerTogglePiP") {
+        on_player_msg_("togglePiP", "", 0, "");
+        return true;
     } else if (name == "appExit") {
         LOG_INFO(LOG_CEF, "App exit requested from web UI");
         SDL_Event qe{};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1040,6 +1040,7 @@ int main(int argc, char* argv[]) {
         pending_cmds.push_back({"media_rate", "", 0, rate});
     };
 
+#ifdef __APPLE__
     // PiP callbacks — route through the command queue
     if (pipHelper) {
         pipHelper->setPlayPauseCallback([&cmd_mutex, &pending_cmds, &wakeMainLoop](bool playing) {
@@ -1053,6 +1054,7 @@ int main(int argc, char* argv[]) {
             wakeMainLoop();
         });
     }
+#endif
 
     // Overlay browser state
     enum class OverlayState { SHOWING, WAITING, FADING, HIDDEN };
@@ -1626,18 +1628,24 @@ int main(int argc, char* argv[]) {
                 }
                 client->emitPlaying();
                 mediaSessionThread.setPlaybackState(PlaybackState::Playing);
+#ifdef __APPLE__
                 if (pipHelper) pipHelper->setPlaying(true);
+#endif
                 break;
             case MpvEvent::Type::Paused:
                 if (mpv->isPlaying()) {
                     if (ev.flag) {
                         client->emitPaused();
                         mediaSessionThread.setPlaybackState(PlaybackState::Paused);
+#ifdef __APPLE__
                         if (pipHelper) pipHelper->setPlaying(false);
+#endif
                     } else {
                         client->emitPlaying();
                         mediaSessionThread.setPlaybackState(PlaybackState::Playing);
+#ifdef __APPLE__
                         if (pipHelper) pipHelper->setPlaying(true);
+#endif
                     }
                 }
                 break;
@@ -2022,11 +2030,10 @@ int main(int argc, char* argv[]) {
                     has_video = false;
                     setVideoTitlebar(false);
                     video_ready = false;
-                    // Stop PiP when video stops
+#ifdef __APPLE__
                     if (pipHelper && pipHelper->isActive()) {
                         pipHelper->stop();
                     }
-#ifdef __APPLE__
                     videoRenderer.setVisible(false);
 #else
                     videoController.setActive(false);
@@ -2129,9 +2136,8 @@ int main(int argc, char* argv[]) {
                         LOG_INFO(LOG_MAIN, "PiP toggled, active=%d", pipHelper->isActive());
                     }
                 } else if (cmd.cmd == "pipClosed") {
-                    // PiP closed — video view was reparented back, re-add to main window
                     LOG_INFO(LOG_MAIN, "PiP closed, restoring video view");
-                    // The video view auto-restores since PIPViewController releases it
+                    videoRenderer.restoreVideoView();
 #endif
                 }
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,6 +38,7 @@ void setMacTrafficLightsVisible(bool visible);
 #ifdef __APPLE__
 #include <mach-o/dyld.h>
 #include "player/macos/media_session_macos.h"
+#include "player/macos/pip_helper.h"
 #include "PFMoveApplication.h"
 #elif defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
@@ -680,6 +681,15 @@ int main(int argc, char* argv[]) {
     bool video_needs_rerender = false;
     double current_playback_rate = 1.0;
 
+    // Picture-in-Picture helper
+    std::unique_ptr<MacOSPiPHelper> pipHelper;
+    if (MacOSPiPHelper::isSupported()) {
+        pipHelper = std::make_unique<MacOSPiPHelper>();
+        LOG_INFO(LOG_PLATFORM, "PiP: supported on this system");
+    } else {
+        LOG_INFO(LOG_PLATFORM, "PiP: not supported on this system");
+    }
+
     // HiDPI setup for CEF overlays
     float initial_scale = SDL_GetWindowDisplayScale(window);
     int physical_width = static_cast<int>(width * initial_scale);
@@ -1029,6 +1039,20 @@ int main(int argc, char* argv[]) {
         std::lock_guard<std::mutex> lock(cmd_mutex);
         pending_cmds.push_back({"media_rate", "", 0, rate});
     };
+
+    // PiP callbacks — route through the command queue
+    if (pipHelper) {
+        pipHelper->setPlayPauseCallback([&cmd_mutex, &pending_cmds, &wakeMainLoop](bool playing) {
+            std::lock_guard<std::mutex> lock(cmd_mutex);
+            pending_cmds.push_back({playing ? "play" : "pause", "", 0, 0.0});
+            wakeMainLoop();
+        });
+        pipHelper->setRestoreCallback([&cmd_mutex, &pending_cmds, &wakeMainLoop]() {
+            std::lock_guard<std::mutex> lock(cmd_mutex);
+            pending_cmds.push_back({"pipClosed", "", 0, 0.0});
+            wakeMainLoop();
+        });
+    }
 
     // Overlay browser state
     enum class OverlayState { SHOWING, WAITING, FADING, HIDDEN };
@@ -1602,15 +1626,18 @@ int main(int argc, char* argv[]) {
                 }
                 client->emitPlaying();
                 mediaSessionThread.setPlaybackState(PlaybackState::Playing);
+                if (pipHelper) pipHelper->setPlaying(true);
                 break;
             case MpvEvent::Type::Paused:
                 if (mpv->isPlaying()) {
                     if (ev.flag) {
                         client->emitPaused();
                         mediaSessionThread.setPlaybackState(PlaybackState::Paused);
+                        if (pipHelper) pipHelper->setPlaying(false);
                     } else {
                         client->emitPlaying();
                         mediaSessionThread.setPlaybackState(PlaybackState::Playing);
+                        if (pipHelper) pipHelper->setPlaying(true);
                     }
                 }
                 break;
@@ -1995,6 +2022,10 @@ int main(int argc, char* argv[]) {
                     has_video = false;
                     setVideoTitlebar(false);
                     video_ready = false;
+                    // Stop PiP when video stops
+                    if (pipHelper && pipHelper->isActive()) {
+                        pipHelper->stop();
+                    }
 #ifdef __APPLE__
                     videoRenderer.setVisible(false);
 #else
@@ -2090,6 +2121,17 @@ int main(int argc, char* argv[]) {
 #ifdef __APPLE__
                 } else if (cmd.cmd == "osd_visible" && transparent_titlebar) {
                     setMacTrafficLightsVisible(cmd.intArg != 0);
+                } else if (cmd.cmd == "togglePiP") {
+                    if (pipHelper && has_video) {
+                        // Pass the video view and current window size as aspect ratio
+                        pipHelper->toggle(videoRenderer.getVideoView(),
+                            current_width, current_height);
+                        LOG_INFO(LOG_MAIN, "PiP toggled, active=%d", pipHelper->isActive());
+                    }
+                } else if (cmd.cmd == "pipClosed") {
+                    // PiP closed — video view was reparented back, re-add to main window
+                    LOG_INFO(LOG_MAIN, "PiP closed, restoring video view");
+                    // The video view auto-restores since PIPViewController releases it
 #endif
                 }
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2130,7 +2130,6 @@ int main(int argc, char* argv[]) {
                     setMacTrafficLightsVisible(cmd.intArg != 0);
                 } else if (cmd.cmd == "togglePiP") {
                     if (pipHelper && has_video) {
-                        // Pass the video view and current window size as aspect ratio
                         pipHelper->toggle(videoRenderer.getVideoView(),
                             current_width, current_height);
                         LOG_INFO(LOG_MAIN, "PiP toggled, active=%d", pipHelper->isActive());

--- a/src/platform/macos_layer.h
+++ b/src/platform/macos_layer.h
@@ -59,10 +59,12 @@ public:
     void setColorspace() {}  // macOS EDR is automatic
     void setDestinationSize(int, int) {}  // no-op on macOS
 
-    // For mpv render context
+    // Get the video NSView for PiP (reparented into PiP window)
 #ifdef __OBJC__
+    void* getVideoView() { return (__bridge void*)video_view_; }
     void* getMetalLayer() { return (__bridge void*)metal_layer_; }
 #else
+    void* getVideoView() { return video_view_; }
     void* getMetalLayer() { return metal_layer_; }
 #endif
 
@@ -103,6 +105,7 @@ private:
     VkPhysicalDeviceHostQueryResetFeatures host_query_reset_features_{};
     const char* const* device_extensions_ = nullptr;
     int device_extension_count_ = 0;
+
 };
 
 #endif // __APPLE__

--- a/src/platform/macos_layer.h
+++ b/src/platform/macos_layer.h
@@ -59,12 +59,15 @@ public:
     void setColorspace() {}  // macOS EDR is automatic
     void setDestinationSize(int, int) {}  // no-op on macOS
 
-    // Get the video NSView for PiP (reparented into PiP window)
+    // PiP: get the video NSView (reparented into PiP window)
+    void* getVideoView();
+    // Restore video view to the main window after PiP closes
+    void restoreVideoView();
+
+    // For mpv render context
 #ifdef __OBJC__
-    void* getVideoView() { return (__bridge void*)video_view_; }
     void* getMetalLayer() { return (__bridge void*)metal_layer_; }
 #else
-    void* getVideoView() { return video_view_; }
     void* getMetalLayer() { return metal_layer_; }
 #endif
 
@@ -105,7 +108,6 @@ private:
     VkPhysicalDeviceHostQueryResetFeatures host_query_reset_features_{};
     const char* const* device_extensions_ = nullptr;
     int device_extension_count_ = 0;
-
 };
 
 #endif // __APPLE__

--- a/src/platform/macos_layer.mm
+++ b/src/platform/macos_layer.mm
@@ -1,7 +1,6 @@
 #ifdef __APPLE__
 
 #import "macos_layer.h"
-#include "logging.h"
 #import <Cocoa/Cocoa.h>
 #import <QuartzCore/QuartzCore.h>
 #import <Metal/Metal.h>
@@ -455,6 +454,21 @@ void MacOSVideoLayer::setPosition(int x, int y) {
         frame.origin.x = x;
         frame.origin.y = y;
         [video_view_ setFrame:frame];
+    }
+}
+
+void* MacOSVideoLayer::getVideoView() {
+    return (__bridge void*)video_view_;
+}
+
+void MacOSVideoLayer::restoreVideoView() {
+    if (!video_view_ || video_view_.superview) return;
+
+    SDL_PropertiesID props = SDL_GetWindowProperties(window_);
+    NSWindow* ns_window = (__bridge NSWindow*)SDL_GetPointerProperty(
+        props, SDL_PROP_WINDOW_COCOA_WINDOW_POINTER, nullptr);
+    if (ns_window) {
+        [ns_window.contentView addSubview:video_view_ positioned:NSWindowBelow relativeTo:nil];
     }
 }
 

--- a/src/platform/macos_layer.mm
+++ b/src/platform/macos_layer.mm
@@ -1,6 +1,7 @@
 #ifdef __APPLE__
 
 #import "macos_layer.h"
+#include "logging.h"
 #import <Cocoa/Cocoa.h>
 #import <QuartzCore/QuartzCore.h>
 #import <Metal/Metal.h>

--- a/src/platform/macos_layer.mm
+++ b/src/platform/macos_layer.mm
@@ -462,14 +462,45 @@ void* MacOSVideoLayer::getVideoView() {
 }
 
 void MacOSVideoLayer::restoreVideoView() {
-    if (!video_view_ || video_view_.superview) return;
+    if (!video_view_) return;
 
     SDL_PropertiesID props = SDL_GetWindowProperties(window_);
     NSWindow* ns_window = (__bridge NSWindow*)SDL_GetPointerProperty(
         props, SDL_PROP_WINDOW_COCOA_WINDOW_POINTER, nullptr);
-    if (ns_window) {
-        [ns_window.contentView addSubview:video_view_ positioned:NSWindowBelow relativeTo:nil];
+    if (!ns_window) return;
+
+    NSView* contentView = ns_window.contentView;
+
+    // Tear down swapchain and surface before reparenting
+    vkDeviceWaitIdle(device_);
+    destroySwapchain();
+
+    if (surface_ != VK_NULL_HANDLE) {
+        vkDestroySurfaceKHR(instance_, surface_, nullptr);
+        surface_ = VK_NULL_HANDLE;
     }
+
+    // Move view back to main window
+    video_view_.frame = contentView.bounds;
+    metal_layer_.frame = contentView.bounds;
+    metal_layer_.contentsScale = ns_window.backingScaleFactor;
+    [contentView addSubview:video_view_ positioned:NSWindowBelow relativeTo:nil];
+
+    // Recreate VkSurfaceKHR for the layer in its new window context
+    VkMetalSurfaceCreateInfoEXT surfaceCreateInfo = {};
+    surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT;
+    surfaceCreateInfo.pLayer = metal_layer_;
+
+    PFN_vkCreateMetalSurfaceEXT vkCreateMetalSurfaceEXT =
+        (PFN_vkCreateMetalSurfaceEXT)vkGetInstanceProcAddr(instance_, "vkCreateMetalSurfaceEXT");
+    if (vkCreateMetalSurfaceEXT) {
+        vkCreateMetalSurfaceEXT(instance_, &surfaceCreateInfo, nullptr, &surface_);
+    }
+
+    CGFloat scale = ns_window.backingScaleFactor;
+    width_ = (uint32_t)(contentView.bounds.size.width * scale);
+    height_ = (uint32_t)(contentView.bounds.size.height * scale);
+    needs_swapchain_recreate_ = true;
 }
 
 #endif // __APPLE__

--- a/src/player/macos/pip_helper.h
+++ b/src/player/macos/pip_helper.h
@@ -1,0 +1,43 @@
+#pragma once
+#ifdef __APPLE__
+
+// macOS native Picture-in-Picture using the private PIPViewController API.
+// Reparents the actual video view (CAMetalLayer) into a PiP window.
+// mpv continues rendering directly — no frame capture needed.
+
+#include <functional>
+
+class MacOSPiPHelper {
+public:
+    MacOSPiPHelper();
+    ~MacOSPiPHelper();
+
+    static bool isSupported();
+
+    // Start PiP by reparenting the given video NSView into a floating PiP window.
+    // videoView: the NSView* containing the CAMetalLayer (cast to void*)
+    // videoW/videoH: native video dimensions for aspect ratio
+    void start(void* videoView, int videoW, int videoH);
+    void stop();
+    void toggle(void* videoView, int videoW, int videoH);
+
+    bool isActive() const;
+
+    // Update aspect ratio when video dimensions change
+    void setAspectRatio(int videoW, int videoH);
+
+    // Update playback state so PiP buttons reflect correctly
+    void setPlaying(bool playing);
+
+    // Called when PiP play/pause button is pressed
+    void setPlayPauseCallback(std::function<void(bool playing)> cb);
+
+    // Called when PiP closes — restore the video view to the main window
+    void setRestoreCallback(std::function<void()> cb);
+
+private:
+    struct Impl;
+    Impl* impl_ = nullptr;
+};
+
+#endif // __APPLE__

--- a/src/player/macos/pip_helper.h
+++ b/src/player/macos/pip_helper.h
@@ -23,9 +23,6 @@ public:
 
     bool isActive() const;
 
-    // Update aspect ratio when video dimensions change
-    void setAspectRatio(int videoW, int videoH);
-
     // Update playback state so PiP buttons reflect correctly
     void setPlaying(bool playing);
 

--- a/src/player/macos/pip_helper.mm
+++ b/src/player/macos/pip_helper.mm
@@ -1,0 +1,195 @@
+#ifdef __APPLE__
+#include "pip_helper.h"
+#include "logging.h"
+
+#import <AppKit/AppKit.h>
+
+// ---------------------------------------------------------------------------
+// Private PIP.framework API (same approach as IINA)
+// ---------------------------------------------------------------------------
+@interface PIPViewController : NSViewController
+@property (nonatomic, copy, nullable) NSString *name;
+@property (nonatomic, weak, nullable) id delegate;
+@property (nonatomic, weak, nullable) NSWindow *replacementWindow;
+@property (nonatomic) NSRect replacementRect;
+@property (nonatomic) bool playing;
+@property (nonatomic) NSSize aspectRatio;
+- (void)presentViewControllerAsPictureInPicture:(NSViewController *)viewController;
+@end
+
+@protocol PIPViewControllerDelegateProtocol <NSObject>
+@optional
+- (BOOL)pipShouldClose:(PIPViewController *)pip;
+- (void)pipWillClose:(PIPViewController *)pip;
+- (void)pipDidClose:(PIPViewController *)pip;
+- (void)pipActionPlay:(PIPViewController *)pip;
+- (void)pipActionPause:(PIPViewController *)pip;
+- (void)pipActionStop:(PIPViewController *)pip;
+@end
+
+// ---------------------------------------------------------------------------
+// Delegate: receives PiP lifecycle events
+// ---------------------------------------------------------------------------
+@interface PiPDelegate : NSObject <PIPViewControllerDelegateProtocol>
+@property (nonatomic, copy) void (^playBlock)(void);
+@property (nonatomic, copy) void (^pauseBlock)(void);
+@property (nonatomic, copy) void (^restoreBlock)(void);
+@end
+
+@implementation PiPDelegate
+
+- (BOOL)pipShouldClose:(PIPViewController *)pip {
+    LOG_INFO(LOG_PLATFORM, "PiP: should close");
+    return YES;
+}
+
+- (void)pipWillClose:(PIPViewController *)pip {
+    LOG_INFO(LOG_PLATFORM, "PiP: will close");
+}
+
+- (void)pipDidClose:(PIPViewController *)pip {
+    LOG_INFO(LOG_PLATFORM, "PiP: did close");
+    if (self.restoreBlock) {
+        self.restoreBlock();
+    }
+}
+
+- (void)pipActionPlay:(PIPViewController *)pip {
+    LOG_INFO(LOG_PLATFORM, "PiP: play");
+    pip.playing = YES;
+    if (self.playBlock) {
+        self.playBlock();
+    }
+}
+
+- (void)pipActionPause:(PIPViewController *)pip {
+    LOG_INFO(LOG_PLATFORM, "PiP: pause");
+    pip.playing = NO;
+    if (self.pauseBlock) {
+        self.pauseBlock();
+    }
+}
+
+- (void)pipActionStop:(PIPViewController *)pip {
+    LOG_INFO(LOG_PLATFORM, "PiP: stop");
+    pip.playing = NO;
+    if (self.pauseBlock) {
+        self.pauseBlock();
+    }
+}
+
+@end
+
+// ---------------------------------------------------------------------------
+// Implementation struct
+// ---------------------------------------------------------------------------
+struct MacOSPiPHelper::Impl {
+    PIPViewController* pipController = nil;
+    NSViewController* videoVC = nil;
+    PiPDelegate* delegate = nil;
+    bool active = false;
+    std::function<void(bool)> playPauseCb;
+    std::function<void()> restoreCb;
+};
+
+// ---------------------------------------------------------------------------
+// Public interface
+// ---------------------------------------------------------------------------
+
+MacOSPiPHelper::MacOSPiPHelper() : impl_(new Impl()) {}
+
+MacOSPiPHelper::~MacOSPiPHelper() {
+    if (impl_) {
+        stop();
+        delete impl_;
+    }
+}
+
+bool MacOSPiPHelper::isSupported() {
+    // PIPViewController is available since macOS 10.12
+    return NSClassFromString(@"PIPViewController") != nil;
+}
+
+void MacOSPiPHelper::start(void* videoView, int videoW, int videoH) {
+    if (!isSupported() || !videoView) return;
+    if (impl_->active) return;
+
+    NSView* view = (__bridge NSView*)videoView;
+
+    // Create PiP controller
+    impl_->pipController = [[PIPViewController alloc] init];
+
+    // Create delegate
+    impl_->delegate = [[PiPDelegate alloc] init];
+    if (impl_->playPauseCb) {
+        auto cb = impl_->playPauseCb;
+        impl_->delegate.playBlock = ^{ cb(true); };
+        impl_->delegate.pauseBlock = ^{ cb(false); };
+    }
+    if (impl_->restoreCb) {
+        auto restoreCb = impl_->restoreCb;
+        impl_->delegate.restoreBlock = ^{ restoreCb(); };
+    }
+
+    impl_->pipController.delegate = impl_->delegate;
+    impl_->pipController.playing = YES;
+    impl_->pipController.aspectRatio = NSMakeSize(videoW, videoH);
+
+    // Set replacement window for the fly-back animation
+    impl_->pipController.replacementWindow = view.window;
+    impl_->pipController.replacementRect = view.window.contentView.frame;
+
+    // Wrap the video view in a view controller and present as PiP
+    impl_->videoVC = [[NSViewController alloc] init];
+    impl_->videoVC.view = view;
+    [impl_->pipController presentViewControllerAsPictureInPicture:impl_->videoVC];
+
+    impl_->active = true;
+    LOG_INFO(LOG_PLATFORM, "PiP: started (%dx%d)", videoW, videoH);
+}
+
+void MacOSPiPHelper::stop() {
+    if (!impl_->active) return;
+    if (impl_->pipController && impl_->videoVC) {
+        [impl_->pipController dismissViewController:impl_->videoVC];
+    }
+    impl_->pipController = nil;
+    impl_->videoVC = nil;
+    impl_->delegate = nil;
+    impl_->active = false;
+    LOG_INFO(LOG_PLATFORM, "PiP: stopped");
+}
+
+void MacOSPiPHelper::toggle(void* videoView, int videoW, int videoH) {
+    if (impl_->active) {
+        stop();
+    } else {
+        start(videoView, videoW, videoH);
+    }
+}
+
+bool MacOSPiPHelper::isActive() const {
+    return impl_->active;
+}
+
+void MacOSPiPHelper::setAspectRatio(int videoW, int videoH) {
+    if (impl_->pipController && videoW > 0 && videoH > 0) {
+        impl_->pipController.aspectRatio = NSMakeSize(videoW, videoH);
+    }
+}
+
+void MacOSPiPHelper::setPlaying(bool playing) {
+    if (impl_->pipController) {
+        impl_->pipController.playing = playing;
+    }
+}
+
+void MacOSPiPHelper::setPlayPauseCallback(std::function<void(bool playing)> cb) {
+    impl_->playPauseCb = std::move(cb);
+}
+
+void MacOSPiPHelper::setRestoreCallback(std::function<void()> cb) {
+    impl_->restoreCb = std::move(cb);
+}
+
+#endif // __APPLE__

--- a/src/player/macos/pip_helper.mm
+++ b/src/player/macos/pip_helper.mm
@@ -130,13 +130,12 @@ void MacOSPiPHelper::start(void* videoView, int videoW, int videoH) {
         auto restoreCb = impl_->restoreCb;
         auto implPtr = impl_;
         impl_->delegate.restoreBlock = ^{
-            // PiP was closed by the system (user clicked return/close button).
-            // Clean up our state — don't call dismiss since PiP already closed.
+            // Clean up our state after PiP closes (system or programmatic dismiss).
             implPtr->pipController = nil;
             implPtr->videoVC = nil;
             implPtr->delegate = nil;
             implPtr->active = false;
-            LOG_INFO(LOG_PLATFORM, "PiP: closed by system");
+            LOG_INFO(LOG_PLATFORM, "PiP: closed");
             restoreCb();
         };
     }

--- a/src/player/macos/pip_helper.mm
+++ b/src/player/macos/pip_helper.mm
@@ -128,7 +128,17 @@ void MacOSPiPHelper::start(void* videoView, int videoW, int videoH) {
     }
     if (impl_->restoreCb) {
         auto restoreCb = impl_->restoreCb;
-        impl_->delegate.restoreBlock = ^{ restoreCb(); };
+        auto implPtr = impl_;
+        impl_->delegate.restoreBlock = ^{
+            // PiP was closed by the system (user clicked return/close button).
+            // Clean up our state — don't call dismiss since PiP already closed.
+            implPtr->pipController = nil;
+            implPtr->videoVC = nil;
+            implPtr->delegate = nil;
+            implPtr->active = false;
+            LOG_INFO(LOG_PLATFORM, "PiP: closed by system");
+            restoreCb();
+        };
     }
 
     impl_->pipController.delegate = impl_->delegate;
@@ -150,14 +160,13 @@ void MacOSPiPHelper::start(void* videoView, int videoW, int videoH) {
 
 void MacOSPiPHelper::stop() {
     if (!impl_->active) return;
+    impl_->active = false;
     if (impl_->pipController && impl_->videoVC) {
         [impl_->pipController dismissViewController:impl_->videoVC];
     }
-    impl_->pipController = nil;
-    impl_->videoVC = nil;
-    impl_->delegate = nil;
-    impl_->active = false;
-    LOG_INFO(LOG_PLATFORM, "PiP: stopped");
+    // Don't nil the delegate — pipDidClose will fire asynchronously
+    // and the restoreBlock will handle cleanup + restore callback.
+    LOG_INFO(LOG_PLATFORM, "PiP: stop requested");
 }
 
 void MacOSPiPHelper::toggle(void* videoView, int videoW, int videoH) {

--- a/src/player/macos/pip_helper.mm
+++ b/src/player/macos/pip_helper.mm
@@ -88,6 +88,7 @@ struct MacOSPiPHelper::Impl {
     NSViewController* videoVC = nil;
     PiPDelegate* delegate = nil;
     bool active = false;
+    bool playing = true;  // tracks mpv state even before PiP opens
     std::function<void(bool)> playPauseCb;
     std::function<void()> restoreCb;
 };
@@ -100,7 +101,23 @@ MacOSPiPHelper::MacOSPiPHelper() : impl_(new Impl()) {}
 
 MacOSPiPHelper::~MacOSPiPHelper() {
     if (impl_) {
-        stop();
+        // Disconnect delegate first to prevent async callbacks after delete
+        if (impl_->delegate) {
+            impl_->delegate.playBlock = nil;
+            impl_->delegate.pauseBlock = nil;
+            impl_->delegate.restoreBlock = nil;
+        }
+        if (impl_->pipController) {
+            impl_->pipController.delegate = nil;
+        }
+        @try {
+            stop();
+        } @catch (NSException* e) {
+            LOG_WARN(LOG_PLATFORM, "PiP: exception during cleanup: %s", e.reason.UTF8String);
+        }
+        impl_->pipController = nil;
+        impl_->videoVC = nil;
+        impl_->delegate = nil;
         delete impl_;
     }
 }
@@ -141,7 +158,7 @@ void MacOSPiPHelper::start(void* videoView, int videoW, int videoH) {
     }
 
     impl_->pipController.delegate = impl_->delegate;
-    impl_->pipController.playing = YES;
+    impl_->pipController.playing = impl_->playing;
     impl_->pipController.aspectRatio = NSMakeSize(videoW, videoH);
 
     // Set replacement window for the fly-back animation
@@ -181,6 +198,7 @@ bool MacOSPiPHelper::isActive() const {
 }
 
 void MacOSPiPHelper::setPlaying(bool playing) {
+    impl_->playing = playing;
     if (impl_->pipController) {
         impl_->pipController.playing = playing;
     }

--- a/src/player/macos/pip_helper.mm
+++ b/src/player/macos/pip_helper.mm
@@ -172,12 +172,6 @@ bool MacOSPiPHelper::isActive() const {
     return impl_->active;
 }
 
-void MacOSPiPHelper::setAspectRatio(int videoW, int videoH) {
-    if (impl_->pipController && videoW > 0 && videoH > 0) {
-        impl_->pipController.aspectRatio = NSMakeSize(videoW, videoH);
-    }
-}
-
 void MacOSPiPHelper::setPlaying(bool playing) {
     if (impl_->pipController) {
         impl_->pipController.playing = playing;

--- a/src/player/video_renderer.h
+++ b/src/player/video_renderer.h
@@ -23,4 +23,7 @@ public:
 
     // HDR query
     virtual bool isHdr() const = 0;
+
+    // PiP: get the native video view (NSView* on macOS, nullptr otherwise)
+    virtual void* getVideoView() { return nullptr; }
 };

--- a/src/player/video_renderer.h
+++ b/src/player/video_renderer.h
@@ -24,6 +24,7 @@ public:
     // HDR query
     virtual bool isHdr() const = 0;
 
-    // PiP: get the native video view (NSView* on macOS, nullptr otherwise)
+    // PiP support (macOS only)
     virtual void* getVideoView() { return nullptr; }
+    virtual void restoreVideoView() {}
 };

--- a/src/player/vulkan_subsurface_renderer.cpp
+++ b/src/player/vulkan_subsurface_renderer.cpp
@@ -97,3 +97,9 @@ float VulkanSubsurfaceRenderer::getClearAlpha(bool video_ready) const {
 bool VulkanSubsurfaceRenderer::isHdr() const {
     return surface_->isHdr();
 }
+
+#ifdef __APPLE__
+void* VulkanSubsurfaceRenderer::getVideoView() {
+    return surface_->getVideoView();
+}
+#endif

--- a/src/player/vulkan_subsurface_renderer.cpp
+++ b/src/player/vulkan_subsurface_renderer.cpp
@@ -102,4 +102,8 @@ bool VulkanSubsurfaceRenderer::isHdr() const {
 void* VulkanSubsurfaceRenderer::getVideoView() {
     return surface_->getVideoView();
 }
+
+void VulkanSubsurfaceRenderer::restoreVideoView() {
+    surface_->restoreVideoView();
+}
 #endif

--- a/src/player/vulkan_subsurface_renderer.h
+++ b/src/player/vulkan_subsurface_renderer.h
@@ -23,6 +23,9 @@ public:
     void cleanup() override;
     float getClearAlpha(bool video_ready) const override;
     bool isHdr() const override;
+#ifdef __APPLE__
+    void* getVideoView() override;
+#endif
 private:
     MpvPlayer* player_;
     VideoSurface* surface_;

--- a/src/player/vulkan_subsurface_renderer.h
+++ b/src/player/vulkan_subsurface_renderer.h
@@ -25,6 +25,7 @@ public:
     bool isHdr() const override;
 #ifdef __APPLE__
     void* getVideoView() override;
+    void restoreVideoView() override;
 #endif
 private:
     MpvPlayer* player_;

--- a/src/web/mpv-video-player.js
+++ b/src/web/mpv-video-player.js
@@ -339,20 +339,8 @@
         getSupportedPlaybackRates() { return this._core.getSupportedPlaybackRates(); }
 
         canSetAudioStreamIndex() { return true; }
-        setPictureInPictureEnabled(enabled) {
-            if (window.jmpNative && window.jmpNative.togglePiP) {
-                const isActive = window.jmpNative.isPiPActive ? window.jmpNative.isPiPActive() : false;
-                if (enabled !== isActive) {
-                    window.jmpNative.togglePiP();
-                }
-            }
-        }
-        isPictureInPictureEnabled() {
-            if (window.jmpNative && window.jmpNative.isPiPActive) {
-                return window.jmpNative.isPiPActive();
-            }
-            return false;
-        }
+        setPictureInPictureEnabled() {}
+        isPictureInPictureEnabled() { return false; }
         isAirPlayEnabled() { return false; }
         setAirPlayEnabled() {}
         setBrightness() {}

--- a/src/web/mpv-video-player.js
+++ b/src/web/mpv-video-player.js
@@ -303,7 +303,13 @@
         getDeviceProfile(item, options) {
             return this.appHost.getDeviceProfile ? this.appHost.getDeviceProfile(item, options) : Promise.resolve({});
         }
-        static getSupportedFeatures() { return ['PlaybackRate', 'SetAspectRatio']; }
+        static getSupportedFeatures() {
+            const features = ['PlaybackRate', 'SetAspectRatio'];
+            if (window.jmpNative && window.jmpNative.isPiPSupported && window.jmpNative.isPiPSupported()) {
+                features.push('PictureInPicture');
+            }
+            return features;
+        }
         supports(feature) { return mpvVideoPlayer.getSupportedFeatures().includes(feature); }
         isFullscreen() { return window._isFullscreen === true; }
         toggleFullscreen() {
@@ -333,8 +339,20 @@
         getSupportedPlaybackRates() { return this._core.getSupportedPlaybackRates(); }
 
         canSetAudioStreamIndex() { return true; }
-        setPictureInPictureEnabled() {}
-        isPictureInPictureEnabled() { return false; }
+        setPictureInPictureEnabled(enabled) {
+            if (window.jmpNative && window.jmpNative.togglePiP) {
+                const isActive = window.jmpNative.isPiPActive ? window.jmpNative.isPiPActive() : false;
+                if (enabled !== isActive) {
+                    window.jmpNative.togglePiP();
+                }
+            }
+        }
+        isPictureInPictureEnabled() {
+            if (window.jmpNative && window.jmpNative.isPiPActive) {
+                return window.jmpNative.isPiPActive();
+            }
+            return false;
+        }
         isAirPlayEnabled() { return false; }
         setAirPlayEnabled() {}
         setBrightness() {}
@@ -360,7 +378,11 @@
         }
         isMuted() { return this._core.isMuted(); }
 
-        togglePictureInPicture() {}
+        togglePictureInPicture() {
+            if (window.jmpNative && window.jmpNative.togglePiP) {
+                window.jmpNative.togglePiP();
+            }
+        }
         toggleAirPlay() {}
         getStats() { return Promise.resolve({ categories: [] }); }
         getSupportedAspectRatios() { return []; }


### PR DESCRIPTION
## Summary

Add native macOS Picture-in-Picture support using Apple's private `PIP.framework` (`PIPViewController` API).

When playing video, the PiP button appears in Jellyfin's player controls. Clicking it reparents the actual video `NSView` (with its `CAMetalLayer`) into a native floating PiP window. mpv continues rendering directly into the same layer — no frame capture or copying needed.

### Features
- Native macOS PiP window with standard system controls (play/pause, close, return to app)
- Play/pause sync between PiP controls and mpv playback
- Correct restore on all close paths: PiP close button, in-app toggle button, and navigating away from playback
- Vulkan surface + swapchain recreation after view reparenting (required because moving a `CAMetalLayer` between windows invalidates MoltenVK's surface state)

### Implementation approach
- Uses the private `PIPViewController` API (same approach as [IINA](https://github.com/iina/iina)) — wraps the video view in an `NSViewController` and calls `presentViewControllerAsPictureInPicture:`
- The `PIPViewControllerDelegateProtocol` handles lifecycle events (close, play, pause)
- All PiP close paths route through the delegate's `pipDidClose` callback asynchronously, ensuring the dismiss animation completes before the video view is restored
- JS integration follows the same interface as jellyfin-web's `htmlVideoPlayer` (`togglePictureInPicture`, `PictureInPicture` feature flag)

### Files changed

| File | Change |
|------|--------|
| `src/player/macos/pip_helper.h/.mm` | New — PiP helper using PIPViewController |
| `CMakeLists.txt` | Link PIP.framework, add pip_helper.mm with ARC |
| `src/cef/cef_app.cpp` | JS bridge: `togglePiP`, `isPiPSupported` |
| `src/cef/cef_client.cpp` | IPC routing for `playerTogglePiP` |
| `src/main.cpp` | PiP lifecycle, play/pause sync, restore handling |
| `src/platform/macos_layer.h/.mm` | `getVideoView()`, `restoreVideoView()` with surface recreation |
| `src/player/video_renderer.h` | Virtual PiP methods |
| `src/player/vulkan_subsurface_renderer.h/.cpp` | macOS PiP overrides |
| `src/web/mpv-video-player.js` | PiP feature flag and toggle |

### Disclaimer

This implementation was written (sloppered) collaboratively with **Claude** (Anthropic's AI assistant, Claude Opus 4.6). The PiP approach was inspired by researching [IINA's source code](https://github.com/iina/iina) — specifically their use of the private `PIPViewController` API and view reparenting pattern. The Vulkan surface recreation strategy for handling `CAMetalLayer` window transitions was developed through iterative debugging with Claude.

### Test plan
- [x] Build on macOS (`cmake --build build`)
- [x] Play a video, verify PiP button appears in player controls
- [x] Click PiP — native floating window opens with video playing
- [x] Play/pause from PiP window controls syncs with mpv
- [x] Close PiP via PiP window button — video returns to main window
- [x] Close PiP via in-app toggle button — video returns to main window
- [x] Navigate back to menu while PiP active — PiP closes, next video plays correctly
- [x] Multiple PiP open/close cycles work without crashes or black frames
- [ ] Verify non-Apple platforms still compile (PiP code is `#ifdef __APPLE__` guarded)
