### PR TITLE
Implement native wheel event for macOS CEF

### DIFF
--- a/src/cef/cef_client.cpp
+++ b/src/cef/cef_client.cpp
@@ -6,6 +6,7 @@
 #include "include/cef_parser.h"
 #include <SDL3/SDL.h>
 #include "logging.h"
+#include <cmath>
 #include <mutex>
 #if !defined(__APPLE__) && !defined(_WIN32)
 #include <unistd.h>  // For dup()
@@ -713,8 +714,6 @@ void Client::sendChar(int charCode, int modifiers) {
 
 void Client::sendMouseWheel(int x, int y, float deltaX, float deltaY, int modifiers) {
 #ifdef __APPLE__
-    // macOS: accumulate scroll deltas — flushed once per frame via flushScroll()
-    // to coalesce multiple trackpad events into a single CEF wheel event.
     scroll_x_ = x;
     scroll_y_ = y;
     scroll_mods_ = modifiers;
@@ -732,6 +731,32 @@ void Client::sendMouseWheel(int x, int y, float deltaX, float deltaY, int modifi
     int pixelX = static_cast<int>(deltaX * 53.0f);
     int pixelY = static_cast<int>(deltaY * 53.0f);
     b->GetHost()->SendMouseWheelEvent(event, pixelX, pixelY);
+    return;
+#endif
+
+    return;
+}
+
+void Client::sendNativeMouseWheel(int x, int y, float deltaX, float deltaY, int modifiers) {
+#ifdef __APPLE__
+    accum_scroll_x_ += deltaX;
+    accum_scroll_y_ += deltaY;
+    const int pixelX = static_cast<int>(std::lround(accum_scroll_x_));
+    const int pixelY = static_cast<int>(std::lround(accum_scroll_y_));
+    accum_scroll_x_ -= pixelX;
+    accum_scroll_y_ -= pixelY;
+    auto b = browser();
+    if (!b) return;
+
+    if (pixelX == 0 && pixelY == 0) return;
+
+    CefMouseEvent event;
+    event.x = x;
+    event.y = y;
+    event.modifiers = modifiers | EVENTFLAG_PRECISION_SCROLLING_DELTA;
+    b->GetHost()->SendMouseWheelEvent(event, pixelX, pixelY);
+#else
+    sendMouseWheel(x, y, deltaX, deltaY, modifiers);
 #endif
 }
 
@@ -1215,6 +1240,32 @@ void OverlayClient::sendMouseWheel(int x, int y, float deltaX, float deltaY, int
     int pixelX = static_cast<int>(deltaX * 53.0f);
     int pixelY = static_cast<int>(deltaY * 53.0f);
     b->GetHost()->SendMouseWheelEvent(event, pixelX, pixelY);
+    return;
+#endif
+
+    return;
+}
+
+void OverlayClient::sendNativeMouseWheel(int x, int y, float deltaX, float deltaY, int modifiers) {
+#ifdef __APPLE__
+    accum_scroll_x_ += deltaX;
+    accum_scroll_y_ += deltaY;
+    const int pixelX = static_cast<int>(std::lround(accum_scroll_x_));
+    const int pixelY = static_cast<int>(std::lround(accum_scroll_y_));
+    accum_scroll_x_ -= pixelX;
+    accum_scroll_y_ -= pixelY;
+    auto b = browser();
+    if (!b) return;
+
+    if (pixelX == 0 && pixelY == 0) return;
+
+    CefMouseEvent event;
+    event.x = x;
+    event.y = y;
+    event.modifiers = modifiers | EVENTFLAG_PRECISION_SCROLLING_DELTA;
+    b->GetHost()->SendMouseWheelEvent(event, pixelX, pixelY);
+#else
+    sendMouseWheel(x, y, deltaX, deltaY, modifiers);
 #endif
 }
 

--- a/src/cef/cef_client.h
+++ b/src/cef/cef_client.h
@@ -20,6 +20,7 @@ public:
     virtual void sendMouseMove(int x, int y, int modifiers) = 0;
     virtual void sendMouseClick(int x, int y, bool down, int button, int clickCount, int modifiers) = 0;
     virtual void sendMouseWheel(int x, int y, float deltaX, float deltaY, int modifiers) = 0;
+    virtual void sendNativeMouseWheel(int x, int y, float deltaX, float deltaY, int modifiers) = 0;
     virtual void sendKeyEvent(int key, bool down, int modifiers) = 0;
     virtual void sendChar(int charCode, int modifiers) = 0;
     virtual void sendTouch(int id, float x, float y, float radiusX, float radiusY,
@@ -159,6 +160,7 @@ public:
     void sendMouseMove(int x, int y, int modifiers) override;
     void sendMouseClick(int x, int y, bool down, int button, int clickCount, int modifiers) override;
     void sendMouseWheel(int x, int y, float deltaX, float deltaY, int modifiers) override;
+    void sendNativeMouseWheel(int x, int y, float deltaX, float deltaY, int modifiers) override;
     void sendKeyEvent(int key, bool down, int modifiers) override;
     void sendChar(int charCode, int modifiers) override;
     void sendTouch(int id, float x, float y, float radiusX, float radiusY,
@@ -177,7 +179,6 @@ public:
     void loadUrl(const std::string& url);
 
 #ifdef __APPLE__
-    // Flush coalesced scroll events (call once per frame after event processing)
     void flushScroll();
 #endif
 
@@ -228,7 +229,7 @@ private:
 #ifdef __APPLE__
     float accum_scroll_x_ = 0.0f;  // Sub-pixel scroll accumulator
     float accum_scroll_y_ = 0.0f;
-    int scroll_x_ = 0, scroll_y_ = 0;  // Last scroll position for coalesced event
+    int scroll_x_ = 0, scroll_y_ = 0;
     int scroll_mods_ = 0;
     bool has_pending_scroll_ = false;
 #endif
@@ -308,6 +309,7 @@ public:
     void sendMouseMove(int x, int y, int modifiers) override;
     void sendMouseClick(int x, int y, bool down, int button, int clickCount, int modifiers) override;
     void sendMouseWheel(int x, int y, float deltaX, float deltaY, int modifiers) override;
+    void sendNativeMouseWheel(int x, int y, float deltaX, float deltaY, int modifiers) override;
     void sendKeyEvent(int key, bool down, int modifiers) override;
     void sendChar(int charCode, int modifiers) override;
     void sendTouch(int id, float x, float y, float radiusX, float radiusY,

--- a/src/input/browser_layer.h
+++ b/src/input/browser_layer.h
@@ -5,6 +5,10 @@
 #include "../cef/cef_client.h"
 #include <SDL3/SDL.h>
 
+#ifdef __APPLE__
+bool macNativeScrollBridgeEnabled();
+#endif
+
 // Input layer that forwards events to a CEF browser client
 class BrowserLayer : public InputLayer, public WindowStateListener {
 public:
@@ -13,6 +17,12 @@ public:
     void setReceiver(InputReceiver* receiver) { receiver_ = receiver; }
     InputReceiver* receiver() const { return receiver_; }
     void setWindowSize(int w, int h) { window_width_ = w; window_height_ = h; }
+    void handleNativeScroll(int x, int y, float deltaX, float deltaY) {
+        if (!receiver_) return;
+        mouse_x_ = x;
+        mouse_y_ = y;
+        receiver_->sendNativeMouseWheel(x, y, deltaX, deltaY, getModifiers());
+    }
 
     bool handleInput(const SDL_Event& event) override {
         if (!receiver_) return false;
@@ -67,6 +77,12 @@ public:
             }
 
             case SDL_EVENT_MOUSE_WHEEL: {
+#ifdef __APPLE__
+                if (macNativeScrollBridgeEnabled()) {
+                    // macOS scroll wheel input is handled directly from NSEvent.
+                    return true;
+                }
+#endif
                 int mods = getModifiers();
                 receiver_->sendMouseWheel(mouse_x_, mouse_y_, event.wheel.x, event.wheel.y, mods);
                 return true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,6 +33,8 @@ void activateMacWindow(SDL_Window* window);
 void setMacTitlebarColor(uint8_t r, uint8_t g, uint8_t b);
 // Show/hide traffic light buttons (close, minimize, zoom)
 void setMacTrafficLightsVisible(bool visible);
+// Route native Cocoa scroll-wheel events directly to the active browser layer.
+void setMacNativeScrollHandler(void (*handler)(int x, int y, float deltaX, float deltaY));
 #endif
 
 #ifdef __APPLE__
@@ -78,6 +80,16 @@ void setMacTrafficLightsVisible(bool visible);
 #include "input/window_state.h"
 #include "ui/menu_overlay.h"
 #include "settings.h"
+
+#ifdef __APPLE__
+static BrowserLayer* g_active_browser_layer = nullptr;
+
+static void handleMacNativeScroll(int x, int y, float deltaX, float deltaY) {
+    if (g_active_browser_layer) {
+        g_active_browser_layer->handleNativeScroll(x, y, deltaX, deltaY);
+    }
+}
+#endif
 #include "single_instance.h"
 #include "window_geometry.h"
 #include "window_activation.h"
@@ -1417,6 +1429,10 @@ int main(int argc, char* argv[]) {
 
     // Track which browser layer is active (for WindowStateNotifier)
     BrowserLayer* active_browser = browsers.getInputLayer("overlay");
+#ifdef __APPLE__
+    g_active_browser_layer = active_browser;
+    setMacNativeScrollHandler(handleMacNativeScroll);
+#endif
 
     // Push/pop menu layer on open/close
     menu.setOnOpen([&]() { input_stack.push(&menu_layer); });
@@ -1938,9 +1954,6 @@ int main(int argc, char* argv[]) {
         }
 
 #ifdef __APPLE__
-        // Flush coalesced scroll events before pumping CEF — sends one
-        // combined wheel event per frame instead of one per SDL event,
-        // eliminating stutter from uneven event distribution across frames.
         client->flushScroll();
         overlay_client->flushScroll();
 #endif
@@ -2148,6 +2161,9 @@ int main(int argc, char* argv[]) {
                 input_stack.remove(browsers.getInputLayer("overlay"));
                 input_stack.push(browsers.getInputLayer("main"));
                 active_browser = browsers.getInputLayer("main");
+#ifdef __APPLE__
+                g_active_browser_layer = active_browser;
+#endif
                 window_state.add(active_browser);
                 active_browser->onFocusGained();
                 overlay_fade_start = now;
@@ -2298,6 +2314,8 @@ int main(int argc, char* argv[]) {
     mpv->cleanup();
 
 #ifdef __APPLE__
+    setMacNativeScrollHandler(nullptr);
+    g_active_browser_layer = nullptr;
     // macOS: simpler cleanup - CefShutdown handles browser cleanup
     browsers.cleanupCompositors();
     videoRenderer.cleanup();

--- a/src/platform/macos_app.mm
+++ b/src/platform/macos_app.mm
@@ -6,12 +6,15 @@
 #include "include/cef_application_mac.h"
 #include "settings.h"
 #include <SDL3/SDL.h>
+#include <cmath>
 
 // Store main window reference for dock click handling
 static NSWindow* g_mainWindow = nil;
 static NSView* g_titlebarDragView = nil;
 static bool g_trafficLightsVisible = true;
 static const CGFloat kTitlebarHeight = 28.0;
+using NativeScrollHandler = void(*)(int x, int y, float deltaX, float deltaY);
+static NativeScrollHandler g_nativeScrollHandler = nullptr;
 
 // Apply current traffic light visibility state to window buttons and drag view.
 // Uses alphaValue instead of setHidden: because AppKit can reset hidden state
@@ -85,6 +88,22 @@ static void applyTrafficLightsVisibility() {
 
 - (void)sendEvent:(NSEvent*)event {
     CefScopedSendingEvent sendingEventScoper;
+    if (event.type == NSEventTypeScrollWheel && g_nativeScrollHandler) {
+        // Forward the original Cocoa scroll event deltas to the active browser
+        // before SDL translates them into wheel events.
+        NSWindow* window = event.window ?: g_mainWindow;
+        NSView* content = window.contentView;
+        if (content) {
+            NSPoint point = [content convertPoint:event.locationInWindow fromView:nil];
+            if (NSPointInRect(point, content.bounds)) {
+                int x = static_cast<int>(lround(point.x));
+                int y = static_cast<int>(lround(content.bounds.size.height - point.y));
+                g_nativeScrollHandler(x, y,
+                                      static_cast<float>(event.scrollingDeltaX),
+                                      static_cast<float>(event.scrollingDeltaY));
+            }
+        }
+    }
     [super sendEvent:event];
 }
 
@@ -191,4 +210,12 @@ void setMacTrafficLightsVisible(bool visible) {
     if (!g_mainWindow || visible == g_trafficLightsVisible) return;
     g_trafficLightsVisible = visible;
     applyTrafficLightsVisibility();
+}
+
+void setMacNativeScrollHandler(NativeScrollHandler handler) {
+    g_nativeScrollHandler = handler;
+}
+
+bool macNativeScrollBridgeEnabled() {
+    return g_nativeScrollHandler != nullptr;
 }


### PR DESCRIPTION
For macOS, the old behavior is handling wheel events in the SDL layer and adding a 10x scale multiplier to match the scroll speed the OS would normally have. While this approach works, it results in a less smooth scrolling experience because we discard all intermediate states between scrolling events. Consequently, the scrolling “framerate” is significantly lower than it should be, as the scroll position between two events are huge enough to look like a jump visually.

To fix this, we need to capture native wheel events using macOS’s native method and forward them to CEF. This will allow CEF to handle the events in a manner similar to a typical Chromium-based browser.

Fixes #29
This would also address #30 for macOS, as now trackpad x axis scrolling is also correctly handled.