### PR TITLE
feat: add standalone player mode (--player)

### DIFF
--- a/src/cef/resource_handler.cpp
+++ b/src/cef/resource_handler.cpp
@@ -16,6 +16,12 @@ CefRefPtr<CefResourceHandler> EmbeddedSchemeHandlerFactory::Create(
         url = url.substr(pos + 3);
     }
 
+    // Strip query string and fragment (e.g. "?foo=bar" or "#playlist-data")
+    pos = url.find_first_of("?#");
+    if (pos != std::string::npos) {
+        url = url.substr(0, pos);
+    }
+
     auto it = embedded_resources.find(url);
     if (it != embedded_resources.end()) {
         return new EmbeddedResourceHandler(it->second);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,9 @@
 #include <atomic>
 #include <memory>
 
+#include "cjson/cJSON.h"
 #include "include/cef_app.h"
+#include "include/cef_parser.h"
 #include "include/cef_version.h"
 #include "include/cef_version_info.h"
 #include "include/cef_browser.h"
@@ -320,6 +322,9 @@ int main(int argc, char* argv[]) {
     std::string audio_passthrough_str;
     bool audio_exclusive = false;
     std::string audio_channels_str;
+    bool player_mode = false;
+    std::vector<std::string> player_playlist;
+    std::string player_url;
     if (!is_cef_subprocess) {
         // Load persisted settings as defaults
         Settings::instance().load();
@@ -338,6 +343,7 @@ int main(int argc, char* argv[]) {
         for (int i = 1; i < argc; i++) {
             if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0) {
                 printf("Usage: jellyfin-desktop [options]\n"
+                       "       jellyfin-desktop --player [options] <file|url>...\n"
                        "\nOptions:\n"
                        "  -h, --help              Show this help message\n"
                        "  -v, --version           Show version information\n"
@@ -352,6 +358,7 @@ int main(int argc, char* argv[]) {
                        "  --audio-exclusive       Use exclusive audio output mode\n"
                        "  --audio-channels <layout>  Set audio channel layout (e.g. stereo, 5.1, 7.1)\n"
                        "  --remote-debug-port <port>  Enable Chrome remote debugging on port (1024-65535)\n"
+                       "  --player                Standalone player mode (play files/URLs directly)\n"
                        );
                 return 0;
             } else if (strcmp(argv[i], "-v") == 0 || strcmp(argv[i], "--version") == 0) {
@@ -390,9 +397,14 @@ int main(int argc, char* argv[]) {
                 remote_debugging_port = atoi(val);
             } else if (strncmp(argv[i], "--remote-debug-port=", 20) == 0) {
                 remote_debugging_port = atoi(argv[i] + 20);
+            } else if (strcmp(argv[i], "--player") == 0) {
+                player_mode = true;
             } else if (argv[i][0] == '-') {
                 fprintf(stderr, "Unknown option: %s\n", argv[i]);
                 return 1;
+            } else {
+                // Positional argument — treat as playlist item in player mode
+                player_playlist.push_back(argv[i]);
             }
         }
 
@@ -411,6 +423,31 @@ int main(int argc, char* argv[]) {
                 fprintf(stderr, "Failed to open log file: %s\n", log_file_path);
                 return 1;
             }
+        }
+        if (player_mode && player_playlist.empty()) {
+            fprintf(stderr, "Error: --player requires at least one file or URL\n");
+            return 1;
+        }
+        if (!player_playlist.empty() && !player_mode) {
+            fprintf(stderr, "Unknown arguments. See --help for usage.\n");
+            return 1;
+        }
+
+        if (player_mode) {
+            cJSON* arr = cJSON_CreateArray();
+            for (const auto& item : player_playlist) {
+                cJSON_AddItemToArray(arr, cJSON_CreateString(item.c_str()));
+            }
+            char* json = cJSON_PrintUnformatted(arr);
+            if (!json) {
+                cJSON_Delete(arr);
+                fprintf(stderr, "Error: failed to serialize playlist\n");
+                return 1;
+            }
+            CefString encoded = CefURIEncode(json, false);
+            player_url = "app://resources/player.html#" + encoded.ToString();
+            cJSON_free(json);
+            cJSON_Delete(arr);
         }
 
         initLogging(log_level);
@@ -551,7 +588,8 @@ int main(int argc, char* argv[]) {
 #endif
 
     // Single-instance check: signal existing instance to raise, then exit
-    if (trySignalExisting()) {
+    // Skip in player mode — allow multiple instances for testing
+    if (!player_mode && trySignalExisting()) {
         return 0;
     }
 
@@ -597,12 +635,14 @@ int main(int argc, char* argv[]) {
     std::mutex raise_mutex;
     std::string pending_activation_token;
     bool raise_requested = false;
-    startListener([&raise_mutex, &pending_activation_token, &raise_requested, &wakeMainLoop](const std::string& token) {
-        std::lock_guard<std::mutex> lock(raise_mutex);
-        pending_activation_token = token;
-        raise_requested = true;
-        wakeMainLoop();
-    });
+    if (!player_mode) {
+        startListener([&raise_mutex, &pending_activation_token, &raise_requested, &wakeMainLoop](const std::string& token) {
+            std::lock_guard<std::mutex> lock(raise_mutex);
+            pending_activation_token = token;
+            raise_requested = true;
+            wakeMainLoop();
+        });
+    }
 
     // Create window at saved geometry to avoid resize flash on startup
     const auto& saved_geom = Settings::instance().windowGeometry();
@@ -908,7 +948,7 @@ int main(int argc, char* argv[]) {
         cache_path = std::filesystem::path(home) / ".cache" / "jellyfin-desktop";
     }
 #endif
-    if (!cache_path.empty()) {
+    if (!cache_path.empty() && !player_mode) {
         std::filesystem::create_directories(cache_path);
         // Canonicalize after creating to resolve symlinks (CEF compares paths strictly)
         std::error_code ec;
@@ -924,9 +964,12 @@ int main(int argc, char* argv[]) {
 #ifdef __APPLE__
     // Pre-create Metal compositors BEFORE CefInitialize to avoid startup delay
     // Metal device/pipeline/texture creation takes time; do it while CEF init runs
-    auto overlay_compositor = std::make_unique<MetalCompositor>();
-    overlay_compositor->init(window, physical_width, physical_height);
-    LOG_DEBUG(LOG_COMPOSITOR, "Pre-created overlay Metal compositor");
+    std::unique_ptr<MetalCompositor> overlay_compositor;
+    if (!player_mode) {
+        overlay_compositor = std::make_unique<MetalCompositor>();
+        overlay_compositor->init(window, physical_width, physical_height);
+        LOG_DEBUG(LOG_COMPOSITOR, "Pre-created overlay Metal compositor");
+    }
 
     auto main_compositor = std::make_unique<MetalCompositor>();
     main_compositor->init(window, physical_width, physical_height);
@@ -1001,7 +1044,11 @@ int main(int argc, char* argv[]) {
 #elif defined(_WIN32)
     mediaSession.addBackend(createWindowsMediaBackend(&mediaSession, window));
 #else
-    mediaSession.addBackend(createMprisBackend(&mediaSession));
+    std::string mpris_suffix;
+    if (player_mode) {
+        mpris_suffix = ".player" + std::to_string(getpid());
+    }
+    mediaSession.addBackend(createMprisBackend(&mediaSession, mpris_suffix));
 #endif
     MediaSessionThread mediaSessionThread;
     mediaSessionThread.start(&mediaSession);
@@ -1043,10 +1090,10 @@ int main(int argc, char* argv[]) {
 
     // Overlay browser state
     enum class OverlayState { SHOWING, WAITING, FADING, HIDDEN };
-    OverlayState overlay_state = OverlayState::SHOWING;
+    OverlayState overlay_state = player_mode ? OverlayState::HIDDEN : OverlayState::SHOWING;
     std::chrono::steady_clock::time_point overlay_fade_start;
     float overlay_browser_alpha = 1.0f;
-    float clear_color = 16.0f / 255.0f;  // #101010 until fade begins
+    float clear_color = player_mode ? 0.0f : 16.0f / 255.0f;  // #101010 until fade begins (player mode: black immediately)
     std::string pending_server_url;
 
     // Titlebar color is locked to #101010 until the overlay fade begins,
@@ -1106,78 +1153,83 @@ int main(int argc, char* argv[]) {
         SDL_GetWindowSizeInPixels(window, &w, &h);
     };
 
-    // Create overlay browser entry
-    auto overlay_entry = std::make_unique<BrowserEntry>();
-    BrowserEntry* overlay_ptr = overlay_entry.get();  // save pointer before move
+    // Create overlay browser entry (not used in player mode)
+    CefRefPtr<OverlayClient> overlay_client;
+    BrowserEntry* overlay_ptr = nullptr;
+    std::unique_ptr<BrowserEntry> overlay_entry;
+    if (!player_mode) {
+        overlay_entry = std::make_unique<BrowserEntry>();
+        overlay_ptr = overlay_entry.get();  // save pointer before move
 #ifdef __APPLE__
-    // Use pre-created Metal compositor (avoids startup delay)
-    overlay_ptr->setCompositor(std::move(overlay_compositor));
+        // Use pre-created Metal compositor (avoids startup delay)
+        overlay_ptr->setCompositor(std::move(overlay_compositor));
 #else
-    if (!overlay_ptr->initCompositor(compositor_ctx, physical_width, physical_height)) {
-        LOG_ERROR(LOG_OVERLAY, "Overlay compositor init failed");
-        SDL_DestroyWindow(window);
-        SDL_Quit();
-        return 1;
-    }
+        if (!overlay_ptr->initCompositor(compositor_ctx, physical_width, physical_height)) {
+            LOG_ERROR(LOG_OVERLAY, "Overlay compositor init failed");
+            SDL_DestroyWindow(window);
+            SDL_Quit();
+            return 1;
+        }
 #endif
-    auto overlay_paint_cb = overlay_ptr->makePaintCallback();
+        auto overlay_paint_cb = overlay_ptr->makePaintCallback();
 
-    // Overlay browser client (for loading UI)
-    CefRefPtr<OverlayClient> overlay_client(new OverlayClient(width, height,
-        [overlay_paint_cb](const void* buffer, int w, int h) {
-            static bool first_overlay_paint = true;
-            if (first_overlay_paint) {
-                LOG_DEBUG(LOG_OVERLAY, "first paint callback: %dx%d", w, h);
-                first_overlay_paint = false;
-            }
-            overlay_paint_cb(buffer, w, h);
-        },
-        [&](const std::string& url) {
-            // loadServer callback - start loading main browser
-            LOG_INFO(LOG_OVERLAY, "loadServer callback: %s", url.c_str());
-            {
-                std::lock_guard<std::mutex> lock(cmd_mutex);
-                pending_server_url = url;
-            }
-            wakeMainLoop();
-        },
-        getPhysicalSize,
+        // Overlay browser client (for loading UI)
+        overlay_client = new OverlayClient(width, height,
+            [overlay_paint_cb](const void* buffer, int w, int h) {
+                static bool first_overlay_paint = true;
+                if (first_overlay_paint) {
+                    LOG_DEBUG(LOG_OVERLAY, "first paint callback: %dx%d", w, h);
+                    first_overlay_paint = false;
+                }
+                overlay_paint_cb(buffer, w, h);
+            },
+            [&](const std::string& url) {
+                // loadServer callback - start loading main browser
+                LOG_INFO(LOG_OVERLAY, "loadServer callback: %s", url.c_str());
+                {
+                    std::lock_guard<std::mutex> lock(cmd_mutex);
+                    pending_server_url = url;
+                }
+                wakeMainLoop();
+            },
+            getPhysicalSize,
 #if !defined(__APPLE__) && !defined(_WIN32)
-        // Accelerated paint callback for overlay
-        [overlay_ptr, wakeMainLoop](int fd, uint32_t stride, uint64_t modifier, int w, int h) {
-            overlay_ptr->compositor->queueDmabuf(fd, stride, modifier, w, h);
-            wakeMainLoop();
-        }
+            // Accelerated paint callback for overlay
+            [overlay_ptr, wakeMainLoop](int fd, uint32_t stride, uint64_t modifier, int w, int h) {
+                overlay_ptr->compositor->queueDmabuf(fd, stride, modifier, w, h);
+                wakeMainLoop();
+            }
 #else
-        nullptr
+            nullptr
 #endif
 #ifdef __APPLE__
-        // IOSurface callback for macOS accelerated paint - queue for import on main thread
-        , [overlay_ptr, wakeMainLoop](void* surface, int format, int w, int h) {
-            overlay_ptr->compositor->queueIOSurface(surface, format, w, h);
-            wakeMainLoop();
-        }
+            // IOSurface callback for macOS accelerated paint - queue for import on main thread
+            , [overlay_ptr, wakeMainLoop](void* surface, int format, int w, int h) {
+                overlay_ptr->compositor->queueIOSurface(surface, format, w, h);
+                wakeMainLoop();
+            }
 #endif
 #ifdef _WIN32
-        // Windows: DComp shared texture callback for overlay browser
-        , has_dcomp_browsers ?
-            WinSharedTexturePaintCallback([&overlayBrowserLayer](void* handle, int type, int w, int h) {
-                if (type == PET_VIEW) {
-                    overlayBrowserLayer.onPaintView(static_cast<HANDLE>(handle), w, h);
-                }
-                // Overlay browser has no popups (no dropdowns in settings UI)
-            }) : nullptr
+            // Windows: DComp shared texture callback for overlay browser
+            , has_dcomp_browsers ?
+                WinSharedTexturePaintCallback([&overlayBrowserLayer](void* handle, int type, int w, int h) {
+                    if (type == PET_VIEW) {
+                        overlayBrowserLayer.onPaintView(static_cast<HANDLE>(handle), w, h);
+                    }
+                    // Overlay browser has no popups (no dropdowns in settings UI)
+                }) : nullptr
 #endif
-    ));
-    overlay_ptr->client = overlay_client;
-    overlay_ptr->getBrowser = [overlay_client]() { return overlay_client->browser(); };
-    overlay_ptr->resizeBrowser = [overlay_client](int w, int h, int pw, int ph) { overlay_client->resize(w, h, pw, ph); };
-    overlay_ptr->getInputReceiver = [overlay_client]() -> InputReceiver* { return overlay_client.get(); };
-    overlay_ptr->isClosed = [overlay_client]() { return overlay_client->isClosed(); };
-    overlay_ptr->input_layer = std::make_unique<BrowserLayer>(overlay_client.get());
-    overlay_ptr->input_layer->setWindowSize(width, height);
-    overlay_ptr->wake_main_loop = wakeMainLoop;
-    // overlay_entry add is deferred until after main, so overlay composites on top
+        );
+        overlay_ptr->client = overlay_client;
+        overlay_ptr->getBrowser = [overlay_client]() { return overlay_client->browser(); };
+        overlay_ptr->resizeBrowser = [overlay_client](int w, int h, int pw, int ph) { overlay_client->resize(w, h, pw, ph); };
+        overlay_ptr->getInputReceiver = [overlay_client]() -> InputReceiver* { return overlay_client.get(); };
+        overlay_ptr->isClosed = [overlay_client]() { return overlay_client->isClosed(); };
+        overlay_ptr->input_layer = std::make_unique<BrowserLayer>(overlay_client.get());
+        overlay_ptr->input_layer->setWindowSize(width, height);
+        overlay_ptr->wake_main_loop = wakeMainLoop;
+        // overlay_entry add is deferred until after main, so overlay composites on top
+    }
 
     // Track who initiated fullscreen (only changes from NONE, returns to NONE on exit)
     enum class FullscreenSource { NONE, WM, CEF };
@@ -1348,8 +1400,10 @@ int main(int argc, char* argv[]) {
     main_ptr->input_layer->setWindowSize(width, height);
     main_ptr->wake_main_loop = wakeMainLoop;
     browsers.add("main", std::move(main_entry));
-    browsers.add("overlay", std::move(overlay_entry));  // overlay on top for fade
-    LOG_DEBUG(LOG_MAIN, "Browser entries added (main behind, overlay on top)");
+    if (!player_mode) {
+        browsers.add("overlay", std::move(overlay_entry));  // overlay on top for fade
+    }
+    LOG_DEBUG(LOG_MAIN, "Browser entries added%s", player_mode ? " (player mode, no overlay)" : " (main behind, overlay on top)");
 
     CefWindowInfo window_info;
     window_info.SetAsWindowless(0);
@@ -1377,46 +1431,59 @@ int main(int argc, char* argv[]) {
     }
 
     // Create overlay browser loading index.html
-    CefWindowInfo overlay_window_info;
-    overlay_window_info.SetAsWindowless(0);
+    if (!player_mode) {
+        CefWindowInfo overlay_window_info;
+        overlay_window_info.SetAsWindowless(0);
 #ifdef __APPLE__
-    overlay_window_info.shared_texture_enabled = true;  // macOS: use IOSurface zero-copy
+        overlay_window_info.shared_texture_enabled = true;  // macOS: use IOSurface zero-copy
 #elif defined(_WIN32)
-    overlay_window_info.shared_texture_enabled = has_dcomp_browsers;  // Windows: use DComp zero-copy
+        overlay_window_info.shared_texture_enabled = has_dcomp_browsers;  // Windows: use DComp zero-copy
 #else
-    overlay_window_info.shared_texture_enabled = use_dmabuf;  // Linux: dmabuf zero-copy
+        overlay_window_info.shared_texture_enabled = use_dmabuf;  // Linux: dmabuf zero-copy
 #endif
-    CefBrowserSettings overlay_browser_settings;
-    overlay_browser_settings.background_color = 0;
-    overlay_browser_settings.windowless_frame_rate = browser_settings.windowless_frame_rate;
+        CefBrowserSettings overlay_browser_settings;
+        overlay_browser_settings.background_color = 0;
+        overlay_browser_settings.windowless_frame_rate = browser_settings.windowless_frame_rate;
 
-    std::string overlay_html_path = "app://resources/index.html";
-    bool overlay_created = CefBrowserHost::CreateBrowser(overlay_window_info, overlay_client, overlay_html_path, overlay_browser_settings, nullptr, nullptr);
-    LOG_INFO(LOG_CEF, "Overlay CreateBrowser: %s", overlay_created ? "ok" : "FAILED");
+        std::string overlay_html_path = "app://resources/index.html";
+        bool overlay_created = CefBrowserHost::CreateBrowser(overlay_window_info, overlay_client, overlay_html_path, overlay_browser_settings, nullptr, nullptr);
+        LOG_INFO(LOG_CEF, "Overlay CreateBrowser: %s", overlay_created ? "ok" : "FAILED");
+    }
 
     // State tracking
     using Clock = std::chrono::steady_clock;
 
-    // Main browser: load saved server immediately, or wait for overlay IPC
-    std::string saved_url = Settings::instance().serverUrl();
-    if (saved_url.empty()) {
-        // No saved server - create with blank, wait for overlay loadServer IPC
-        LOG_INFO(LOG_MAIN, "Waiting for overlay to provide server URL");
-        CefBrowserHost::CreateBrowser(window_info, client, "about:blank", browser_settings, nullptr, nullptr);
+    // Main browser: load player URL, saved server, or wait for overlay IPC
+    if (player_mode) {
+        // Player mode: load bundled OSD directly
+        LOG_INFO(LOG_MAIN, "Player mode: loading %s", player_url.c_str());
+        CefBrowserHost::CreateBrowser(window_info, client, player_url, browser_settings, nullptr, nullptr);
     } else {
-        // Have saved server - start loading immediately, begin overlay fade
-        overlay_state = OverlayState::WAITING;
-        overlay_fade_start = Clock::now();
-        LOG_INFO(LOG_MAIN, "Loading saved server: %s", saved_url.c_str());
-        CefBrowserHost::CreateBrowser(window_info, client, saved_url, browser_settings, nullptr, nullptr);
+        // Normal mode: load saved server or wait for overlay
+        std::string saved_url = Settings::instance().serverUrl();
+        if (saved_url.empty()) {
+            LOG_INFO(LOG_MAIN, "Waiting for overlay to provide server URL");
+            CefBrowserHost::CreateBrowser(window_info, client, "about:blank", browser_settings, nullptr, nullptr);
+        } else {
+            overlay_state = OverlayState::WAITING;
+            overlay_fade_start = Clock::now();
+            LOG_INFO(LOG_MAIN, "Loading saved server: %s", saved_url.c_str());
+            CefBrowserHost::CreateBrowser(window_info, client, saved_url, browser_settings, nullptr, nullptr);
+        }
     }
     // Input routing stack - use BrowserStack for input layers
     MenuLayer menu_layer(&menu);
     InputStack input_stack;
-    input_stack.push(browsers.getInputLayer("overlay"));  // Start with overlay
+    if (player_mode) {
+        input_stack.push(browsers.getInputLayer("main"));
+    } else {
+        input_stack.push(browsers.getInputLayer("overlay"));
+    }
 
     // Track which browser layer is active (for WindowStateNotifier)
-    BrowserLayer* active_browser = browsers.getInputLayer("overlay");
+    BrowserLayer* active_browser = player_mode
+        ? browsers.getInputLayer("main")
+        : browsers.getInputLayer("overlay");
 
     // Push/pop menu layer on open/close
     menu.setOnOpen([&]() { input_stack.push(&menu_layer); });
@@ -1942,7 +2009,8 @@ int main(int argc, char* argv[]) {
         // combined wheel event per frame instead of one per SDL event,
         // eliminating stutter from uneven event distribution across frames.
         client->flushScroll();
-        overlay_client->flushScroll();
+        if (overlay_client)
+            overlay_client->flushScroll();
 #endif
 
 #ifndef _WIN32

--- a/src/player/mpris/media_session_mpris.cpp
+++ b/src/player/mpris/media_session_mpris.cpp
@@ -1,12 +1,13 @@
 #include "player/mpris/media_session_mpris.h"
 #include <cstring>
+#include <string>
 #include "logging.h"
 
 // D-Bus object path
 static const char* MPRIS_PATH = "/org/mpris/MediaPlayer2";
 static const char* MPRIS_ROOT_IFACE = "org.mpris.MediaPlayer2";
 static const char* MPRIS_PLAYER_IFACE = "org.mpris.MediaPlayer2.Player";
-static const char* SERVICE_NAME = "org.mpris.MediaPlayer2.JellyfinDesktop";
+static const char* BASE_SERVICE_NAME = "org.mpris.MediaPlayer2.JellyfinDesktop";
 
 // Root interface property getters
 static int prop_get_identity(sd_bus* bus, const char* path, const char* interface,
@@ -357,14 +358,16 @@ static const sd_bus_vtable player_vtable[] = {
     SD_BUS_VTABLE_END
 };
 
-MprisBackend::MprisBackend(MediaSession* session) : session_(session) {
+MprisBackend::MprisBackend(MediaSession* session, const std::string& service_suffix)
+    : session_(session)
+    , service_name_(std::string(BASE_SERVICE_NAME) + service_suffix) {
     int r = sd_bus_open_user(&bus_);
     if (r < 0) {
         LOG_ERROR(LOG_MEDIA, "MPRIS: Failed to connect to session bus: %s", strerror(-r));
         return;
     }
 
-    r = sd_bus_request_name(bus_, SERVICE_NAME, 0);
+    r = sd_bus_request_name(bus_, service_name_.c_str(), 0);
     if (r < 0) {
         LOG_ERROR(LOG_MEDIA, "MPRIS: Failed to acquire service name: %s", strerror(-r));
         sd_bus_unref(bus_);
@@ -372,7 +375,7 @@ MprisBackend::MprisBackend(MediaSession* session) : session_(session) {
         return;
     }
 
-    LOG_INFO(LOG_MEDIA, "MPRIS: Registered as %s", SERVICE_NAME);
+    LOG_INFO(LOG_MEDIA, "MPRIS: Registered as %s", service_name_.c_str());
 
     r = sd_bus_add_object_vtable(bus_, &slot_root_, MPRIS_PATH,
                                   MPRIS_ROOT_IFACE, root_vtable, this);
@@ -391,7 +394,7 @@ MprisBackend::~MprisBackend() {
     if (slot_player_) sd_bus_slot_unref(slot_player_);
     if (slot_root_) sd_bus_slot_unref(slot_root_);
     if (bus_) {
-        sd_bus_release_name(bus_, SERVICE_NAME);
+        sd_bus_release_name(bus_, service_name_.c_str());
         sd_bus_unref(bus_);
     }
 }
@@ -510,6 +513,6 @@ void MprisBackend::emitPropertiesChanged(const char* interface, const char* prop
     sd_bus_emit_properties_changed(bus_, MPRIS_PATH, interface, property, nullptr);
 }
 
-std::unique_ptr<MediaSessionBackend> createMprisBackend(MediaSession* session) {
-    return std::make_unique<MprisBackend>(session);
+std::unique_ptr<MediaSessionBackend> createMprisBackend(MediaSession* session, const std::string& service_suffix) {
+    return std::make_unique<MprisBackend>(session, service_suffix);
 }

--- a/src/player/mpris/media_session_mpris.h
+++ b/src/player/mpris/media_session_mpris.h
@@ -5,7 +5,7 @@
 
 class MprisBackend : public MediaSessionBackend {
 public:
-    explicit MprisBackend(MediaSession* session);
+    MprisBackend(MediaSession* session, const std::string& service_suffix = "");
     ~MprisBackend() override;
 
     void setMetadata(const MediaMetadata& meta) override;
@@ -37,6 +37,7 @@ private:
     void syncRate();  // Apply pending_rate_ or 0 based on seeking_/buffering_
 
     MediaSession* session_;
+    std::string service_name_;
     sd_bus* bus_ = nullptr;
     sd_bus_slot* slot_root_ = nullptr;
     sd_bus_slot* slot_player_ = nullptr;
@@ -53,4 +54,4 @@ private:
     bool can_go_previous_ = false;
 };
 
-std::unique_ptr<MediaSessionBackend> createMprisBackend(MediaSession* session);
+std::unique_ptr<MediaSessionBackend> createMprisBackend(MediaSession* session, const std::string& service_suffix = "");

--- a/src/web/player.css
+++ b/src/web/player.css
@@ -1,0 +1,187 @@
+/* Reset */
+* { margin: 0; padding: 0; box-sizing: border-box; }
+html, body { width: 100%; height: 100%; overflow: hidden; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+
+/* Idle screen — opaque black + centered logo */
+body {
+    background: #000;
+    color: #fff;
+}
+
+body.playing {
+    background: transparent;
+}
+
+#idle-screen {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    position: fixed;
+    top: 0;
+    left: 0;
+}
+
+#idle-screen .logo {
+    width: 200px;
+    opacity: 0.8;
+}
+
+body.playing #idle-screen {
+    display: none;
+}
+
+/* OSD container */
+#osd {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: linear-gradient(0deg, rgba(16, 16, 16, 0.75) 0%, rgba(16, 16, 16, 0) 100%);
+    padding: 7.5em 0 0 0;
+    color: #fff;
+    pointer-events: none;
+    user-select: none;
+    will-change: opacity;
+    transition: opacity 0.3s ease-out;
+}
+
+#osd.osd-hidden {
+    opacity: 0;
+}
+
+.osd-controls {
+    pointer-events: all;
+    padding: 0 0.8em;
+}
+
+/* Title */
+.osd-title {
+    padding: 0 0.5em;
+    margin-bottom: 0.5em;
+    font-size: 1.1em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* Progress row */
+.osd-progress-row {
+    display: flex;
+    align-items: center;
+    margin: 0.5em 0 0.25em;
+    gap: 0.8em;
+    padding: 0 0.5em;
+}
+
+.osd-time {
+    font-size: 0.85em;
+    font-variant-numeric: tabular-nums;
+    min-width: 3.5em;
+    text-align: center;
+}
+
+.osd-slider-container {
+    flex: 1;
+    display: flex;
+    align-items: center;
+}
+
+/* Slider shared styles */
+.osd-slider {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 100%;
+    height: 0.2em;
+    background: rgba(255, 255, 255, 0.3);
+    border-radius: 0.1em;
+    outline: none;
+    cursor: pointer;
+}
+
+.osd-slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 1.08em;
+    height: 1.08em;
+    border-radius: 50%;
+    background: #00a4dc;
+    cursor: pointer;
+    transition: transform 0.1s;
+}
+
+.osd-slider::-webkit-slider-thumb:hover {
+    transform: scale(1.3);
+}
+
+.osd-seek-slider {
+    background: linear-gradient(to right, #00a4dc var(--progress, 0%), rgba(255, 255, 255, 0.3) var(--progress, 0%));
+}
+
+.osd-volume-slider {
+    background: linear-gradient(to right, #00a4dc var(--progress, 100%), rgba(255, 255, 255, 0.3) var(--progress, 100%));
+}
+
+/* Button row */
+.osd-buttons {
+    display: flex;
+    align-items: center;
+    padding: 0.25em 0;
+    gap: 0.2em;
+}
+
+.osd-spacer {
+    flex: 1;
+}
+
+.osd-btn {
+    background: none;
+    border: none;
+    color: #fff;
+    cursor: pointer;
+    padding: 0.5em;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.15s;
+}
+
+.osd-btn:hover {
+    background: rgba(255, 255, 255, 0.1);
+}
+
+.osd-btn svg {
+    width: 1.8em;
+    height: 1.8em;
+    fill: currentColor;
+}
+
+.osd-btn-play svg {
+    width: 2.2em;
+    height: 2.2em;
+}
+
+/* Hide prev/next when single item */
+body.single-item .osd-btn-nav {
+    display: none;
+}
+
+/* Volume container */
+.osd-volume-container {
+    width: 7em;
+    display: flex;
+    align-items: center;
+    margin: 0 0.3em;
+}
+
+/* Responsive: hide volume slider on narrow screens */
+@media (max-width: 43em) {
+    .osd-volume-container { display: none; }
+}
+
+/* Responsive: hide rewind/forward on narrow screens */
+@media (max-width: 30em) {
+    #btn-rewind, #btn-forward { display: none; }
+}

--- a/src/web/player.html
+++ b/src/web/player.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Jellyfin Player</title>
+    <link rel="stylesheet" href="player.css">
+</head>
+<body>
+    <!-- Idle screen (between items / before playback) -->
+    <div id="idle-screen">
+        <img class="logo" src="logo.png">
+    </div>
+
+    <!-- OSD controls (shown during playback on mouse activity) -->
+    <div id="osd" class="osd-hidden">
+        <div class="osd-controls">
+            <!-- Title -->
+            <div class="osd-title" id="osd-title"></div>
+
+            <!-- Progress bar row -->
+            <div class="osd-progress-row">
+                <span class="osd-time" id="osd-current-time">0:00</span>
+                <div class="osd-slider-container">
+                    <input type="range" id="osd-seek" class="osd-slider osd-seek-slider"
+                           min="0" max="100" step="0.01" value="0">
+                </div>
+                <span class="osd-time" id="osd-duration">0:00</span>
+            </div>
+
+            <!-- Button row -->
+            <div class="osd-buttons">
+                <button id="btn-prev" class="osd-btn osd-btn-nav" title="Previous">
+                    <svg viewBox="0 0 24 24"><path d="M6 6h2v12H6zm3.5 6l8.5 6V6z"/></svg>
+                </button>
+                <button id="btn-rewind" class="osd-btn" title="Rewind 30s">
+                    <svg viewBox="0 0 24 24"><path d="M11.99 5V1l-5 5 5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6h-2c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"/><text x="12" y="16" text-anchor="middle" font-size="7" fill="currentColor">30</text></svg>
+                </button>
+                <button id="btn-play" class="osd-btn osd-btn-play" title="Play/Pause">
+                    <svg viewBox="0 0 24 24" id="icon-play"><path d="M8 5v14l11-7z"/></svg>
+                    <svg viewBox="0 0 24 24" id="icon-pause" style="display:none"><path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"/></svg>
+                </button>
+                <button id="btn-forward" class="osd-btn" title="Forward 30s">
+                    <svg viewBox="0 0 24 24"><path d="M12.01 5V1l5 5-5 5V7c-3.31 0-6 2.69-6 6s2.69 6 6 6 6-2.69 6-6h2c0 4.42-3.58 8-8 8s-8-3.58-8-8 3.58-8 8-8z"/><text x="12" y="16" text-anchor="middle" font-size="7" fill="currentColor">30</text></svg>
+                </button>
+                <button id="btn-next" class="osd-btn osd-btn-nav" title="Next">
+                    <svg viewBox="0 0 24 24"><path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z"/></svg>
+                </button>
+
+                <div class="osd-spacer"></div>
+
+                <button id="btn-mute" class="osd-btn" title="Mute">
+                    <svg viewBox="0 0 24 24" id="icon-vol-on"><path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"/></svg>
+                    <svg viewBox="0 0 24 24" id="icon-vol-off" style="display:none"><path d="M16.5 12c0-1.77-1.02-3.29-2.5-4.03v2.21l2.45 2.45c.03-.2.05-.41.05-.63zm2.5 0c0 .94-.2 1.82-.54 2.64l1.51 1.51C20.63 14.91 21 13.5 21 12c0-4.28-2.99-7.86-7-8.77v2.06c2.89.86 5 3.54 5 6.71zM4.27 3L3 4.27 7.73 9H3v6h4l5 5v-6.73l4.25 4.25c-.67.52-1.42.93-2.25 1.18v2.06c1.38-.31 2.63-.95 3.69-1.81L19.73 21 21 19.73l-9-9L4.27 3zM12 4L9.91 6.09 12 8.18V4z"/></svg>
+                </button>
+                <div class="osd-volume-container">
+                    <input type="range" id="osd-volume" class="osd-slider osd-volume-slider"
+                           min="0" max="100" step="1" value="100">
+                </div>
+                <button id="btn-fullscreen" class="osd-btn" title="Fullscreen">
+                    <svg viewBox="0 0 24 24" id="icon-fs-enter"><path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"/></svg>
+                    <svg viewBox="0 0 24 24" id="icon-fs-exit" style="display:none"><path d="M5 16h3v3h2v-5H5v2zm3-8H5v2h5V5H8v3zm6 11h2v-3h3v-2h-5v5zm2-11V5h-2v5h5V8h-3z"/></svg>
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <script src="native-shim.js"></script>
+    <script src="player.js"></script>
+</body>
+</html>

--- a/src/web/player.js
+++ b/src/web/player.js
@@ -1,0 +1,296 @@
+(function() {
+    'use strict';
+
+    // --- Playlist state ---
+    const playlist = JSON.parse(decodeURIComponent(location.hash.slice(1)));
+    let currentIndex = 0;
+    let isPlaying = false;
+    let isSeeking = false;
+    let duration = 0;
+    let position = 0;
+    let volume = 100;
+    let muted = false;
+    let hideTimer = null;
+
+    // --- DOM refs ---
+    const idleScreen = document.getElementById('idle-screen');
+    const osd = document.getElementById('osd');
+    const titleEl = document.getElementById('osd-title');
+    const currentTimeEl = document.getElementById('osd-current-time');
+    const durationEl = document.getElementById('osd-duration');
+    const seekSlider = document.getElementById('osd-seek');
+    const volumeSlider = document.getElementById('osd-volume');
+    const btnPlay = document.getElementById('btn-play');
+    const btnPrev = document.getElementById('btn-prev');
+    const btnNext = document.getElementById('btn-next');
+    const btnRewind = document.getElementById('btn-rewind');
+    const btnForward = document.getElementById('btn-forward');
+    const btnMute = document.getElementById('btn-mute');
+    const btnFullscreen = document.getElementById('btn-fullscreen');
+    const iconPlay = document.getElementById('icon-play');
+    const iconPause = document.getElementById('icon-pause');
+    const iconVolOn = document.getElementById('icon-vol-on');
+    const iconVolOff = document.getElementById('icon-vol-off');
+    const iconFsEnter = document.getElementById('icon-fs-enter');
+    const iconFsExit = document.getElementById('icon-fs-exit');
+
+    // --- Helpers ---
+    function formatTime(ms) {
+        const totalSec = Math.floor(ms / 1000);
+        const h = Math.floor(totalSec / 3600);
+        const m = Math.floor((totalSec % 3600) / 60);
+        const s = totalSec % 60;
+        if (h > 0) return h + ':' + String(m).padStart(2, '0') + ':' + String(s).padStart(2, '0');
+        return m + ':' + String(s).padStart(2, '0');
+    }
+
+    function filenameFromPath(path) {
+        // Extract filename from path or URL
+        const parts = path.replace(/\\/g, '/').split('/');
+        return decodeURIComponent(parts[parts.length - 1]) || path;
+    }
+
+    function updateSliderFill(slider, pct) {
+        slider.style.setProperty('--progress', pct + '%');
+    }
+
+    // --- Playlist control ---
+    function loadItem(index) {
+        if (index < 0 || index >= playlist.length) return;
+        currentIndex = index;
+        duration = 0;
+        position = 0;
+        isPlaying = false;
+        seekSlider.value = 0;
+        updateSliderFill(seekSlider, 0);
+        currentTimeEl.textContent = '0:00';
+        durationEl.textContent = '0:00';
+        titleEl.textContent = filenameFromPath(playlist[index]);
+        window.api.player.load(playlist[index]);
+    }
+
+    function goIdle() {
+        isPlaying = false;
+        document.body.classList.remove('playing');
+        hideOsd();
+        updatePlayPauseIcon();
+    }
+
+    // --- OSD show/hide ---
+    function showOsd() {
+        if (!isPlaying) return;
+        osd.classList.remove('osd-hidden');
+        resetHideTimer();
+    }
+
+    function hideOsd() {
+        osd.classList.add('osd-hidden');
+        clearTimeout(hideTimer);
+    }
+
+    function resetHideTimer() {
+        clearTimeout(hideTimer);
+        hideTimer = setTimeout(hideOsd, 3000);
+    }
+
+    // --- Icon updates ---
+    function updatePlayPauseIcon() {
+        iconPlay.style.display = isPlaying ? 'none' : '';
+        iconPause.style.display = isPlaying ? '' : 'none';
+    }
+
+    function updateMuteIcon() {
+        iconVolOn.style.display = muted ? 'none' : '';
+        iconVolOff.style.display = muted ? '' : 'none';
+    }
+
+    function updateFullscreenIcon() {
+        const fs = !!document.fullscreenElement;
+        iconFsEnter.style.display = fs ? 'none' : '';
+        iconFsExit.style.display = fs ? '' : 'none';
+    }
+
+    // --- Signal handlers ---
+    window.api.player.playing.connect(function() {
+        isPlaying = true;
+        document.body.classList.add('playing');
+        updatePlayPauseIcon();
+        showOsd();
+    });
+
+    window.api.player.paused.connect(function() {
+        isPlaying = false;
+        updatePlayPauseIcon();
+        showOsd();
+    });
+
+    window.api.player.finished.connect(function() {
+        if (currentIndex + 1 < playlist.length) {
+            loadItem(currentIndex + 1);
+        } else {
+            goIdle();
+        }
+    });
+
+    window.api.player.canceled.connect(function() {
+        goIdle();
+    });
+
+    window.api.player.error.connect(function(msg) {
+        console.error('[Player] Playback error:', msg);
+        goIdle();
+    });
+
+    window.api.player.positionUpdate.connect(function(ms) {
+        position = ms;
+        if (!isSeeking) {
+            currentTimeEl.textContent = formatTime(ms);
+            if (duration > 0) {
+                const pct = (ms / duration) * 100;
+                seekSlider.value = pct;
+                updateSliderFill(seekSlider, pct);
+            }
+        }
+    });
+
+    window.api.player.updateDuration.connect(function(ms) {
+        duration = ms;
+        durationEl.textContent = formatTime(ms);
+    });
+
+    // --- Button handlers ---
+    btnPlay.addEventListener('click', function() {
+        if (isPlaying) {
+            window.api.player.pause();
+        } else {
+            window.api.player.play();
+        }
+    });
+
+    btnPrev.addEventListener('click', function() {
+        if (currentIndex > 0) {
+            window.api.player.stop();
+            loadItem(currentIndex - 1);
+        }
+    });
+
+    btnNext.addEventListener('click', function() {
+        if (currentIndex + 1 < playlist.length) {
+            window.api.player.stop();
+            loadItem(currentIndex + 1);
+        }
+    });
+
+    btnRewind.addEventListener('click', function() {
+        window.api.player.seekTo(Math.max(0, position - 30000));
+    });
+
+    btnForward.addEventListener('click', function() {
+        window.api.player.seekTo(Math.min(duration, position + 30000));
+    });
+
+    btnMute.addEventListener('click', function() {
+        muted = !muted;
+        window.api.player.setMuted(muted);
+        updateMuteIcon();
+    });
+
+    btnFullscreen.addEventListener('click', function() {
+        if (document.fullscreenElement) {
+            document.exitFullscreen();
+        } else {
+            document.documentElement.requestFullscreen();
+        }
+    });
+
+    document.addEventListener('fullscreenchange', updateFullscreenIcon);
+
+    // --- Seek slider ---
+    seekSlider.addEventListener('input', function() {
+        isSeeking = true;
+        const pct = parseFloat(seekSlider.value);
+        updateSliderFill(seekSlider, pct);
+        currentTimeEl.textContent = formatTime((pct / 100) * duration);
+    });
+
+    seekSlider.addEventListener('change', function() {
+        const pct = parseFloat(seekSlider.value);
+        window.api.player.seekTo((pct / 100) * duration);
+        isSeeking = false;
+    });
+
+    // --- Volume slider ---
+    volumeSlider.addEventListener('input', function() {
+        volume = parseInt(volumeSlider.value, 10);
+        window.api.player.setVolume(volume);
+        updateSliderFill(volumeSlider, volume);
+        if (volume > 0 && muted) {
+            muted = false;
+            window.api.player.setMuted(false);
+            updateMuteIcon();
+        }
+    });
+    updateSliderFill(volumeSlider, volume);
+
+    // --- Mouse activity -> show OSD ---
+    document.addEventListener('mousemove', showOsd);
+    document.addEventListener('click', function(e) {
+        // Only show OSD if clicking outside the controls
+        if (!osd.contains(e.target)) {
+            showOsd();
+        }
+    });
+
+    // --- Keyboard shortcuts ---
+    document.addEventListener('keydown', function(e) {
+        switch (e.key) {
+            case ' ':
+            case 'k':
+                e.preventDefault();
+                btnPlay.click();
+                showOsd();
+                break;
+            case 'ArrowLeft':
+                e.preventDefault();
+                btnRewind.click();
+                showOsd();
+                break;
+            case 'ArrowRight':
+                e.preventDefault();
+                btnForward.click();
+                showOsd();
+                break;
+            case 'ArrowUp':
+                e.preventDefault();
+                volume = Math.min(100, volume + 5);
+                volumeSlider.value = volume;
+                window.api.player.setVolume(volume);
+                updateSliderFill(volumeSlider, volume);
+                showOsd();
+                break;
+            case 'ArrowDown':
+                e.preventDefault();
+                volume = Math.max(0, volume - 5);
+                volumeSlider.value = volume;
+                window.api.player.setVolume(volume);
+                updateSliderFill(volumeSlider, volume);
+                showOsd();
+                break;
+            case 'm':
+                btnMute.click();
+                showOsd();
+                break;
+            case 'f':
+                btnFullscreen.click();
+                break;
+        }
+    });
+
+    // --- Init ---
+    if (playlist.length <= 1) {
+        document.body.classList.add('single-item');
+    }
+
+    // Start playback of first item
+    loadItem(0);
+})();


### PR DESCRIPTION
## Summary

- Adds `--player <file|url>...` CLI flag for standalone media playback without a Jellyfin server
- CEF loads a bundled HTML/CSS/JS OSD (`src/web/player.{html,css,js}`) that reuses `native-shim.js` and the existing `window.api.player` IPC bridge
- Skips overlay browser, singleton lock, and CEF cache in player mode
- Instance-unique MPRIS D-Bus name (`.player<pid>`) to avoid conflicts
- Fixes embedded resource handler to strip query/fragment from URL lookup

Enables quick testing of the full video stack (CEF compositing, mpv rendering, HDR/SDR pipelines, OSD controls) without requiring a Jellyfin server connection.

## Test plan

- [ ] `jellyfin-desktop --help` shows `--player` usage
- [ ] `jellyfin-desktop --player` with no files shows error
- [ ] `jellyfin-desktop file.mkv` without `--player` shows help hint
- [ ] `jellyfin-desktop --player video.mkv` plays video with OSD
- [ ] OSD controls work: play/pause, seek, volume, fullscreen
- [ ] OSD auto-hides after 3s, shows on mouse movement
- [ ] Keyboard shortcuts: space/k, arrows, m, f
- [ ] Multiple files: prev/next buttons, auto-advance on track end
- [ ] Normal `jellyfin-desktop` still works while player instance is running
- [ ] MPRIS shows as separate instance in media controls