### PR TITLE
Custom mpv settings

### DIFF
--- a/src/browser/web_browser.cpp
+++ b/src/browser/web_browser.cpp
@@ -11,6 +11,7 @@
 #include "../titlebar_color.h"
 #include "../input/dispatch.h"
 #include "../cjson/cJSON.h"
+#include "../paths/paths.h"
 
 extern void update_idle_inhibit();
 
@@ -83,7 +84,7 @@ CefRefPtr<CefDictionaryValue> WebBrowser::injectionProfile() {
         "playerSetVolume", "playerSetMuted", "playerSetSpeed",
         "playerSetSubtitle", "playerAddSubtitle", "playerSetAudio",
         "playerSetAudioDelay", "playerSetAspectMode", "playerOsdActive",
-        "saveServerUrl",
+        "openConfigDir", "saveServerUrl",
         "notifyMetadata", "notifyPosition", "notifySeek",
         "notifyPlaybackState", "notifyArtwork", "notifyQueueChange",
         "notifyRateChange",
@@ -231,6 +232,9 @@ bool WebBrowser::handleMessage(const std::string& name,
         initiate_shutdown();
     } else if (name == "openAbout") {
         AboutBrowser::open();
+    } else if (name == "openConfigDir") {
+        LOG_INFO(LOG_CEF, "Openning mpv home directory");
+        paths::openMpvHome();
     } else {
         return false;
     }

--- a/src/paths/linux.cpp
+++ b/src/paths/linux.cpp
@@ -28,4 +28,9 @@ std::string getLogDir() {
     return dir;
 }
 
+void openMpvHome() {
+    std::string command = "xdg-open '" + getMpvHome() + "'";
+    system(command.c_str());
+}
+
 }  // namespace paths

--- a/src/paths/macos.cpp
+++ b/src/paths/macos.cpp
@@ -25,4 +25,9 @@ std::string getLogDir() {
     return dir;
 }
 
+void openMpvHome() {
+    std::string command = "open '" + getMpvHome() + "'";
+    system(command.c_str());
+}
+
 }  // namespace paths

--- a/src/paths/paths.h
+++ b/src/paths/paths.h
@@ -18,6 +18,7 @@ inline constexpr char kAppDirName[] = "jellyfin-desktop";
 inline constexpr char kLogFileName[] = "jellyfin-desktop.log";
 
 void ensureDir(const std::string& path);
+void openMpvHome();
 
 // Returns std::getenv(var) if set and non-empty, else fallback.
 std::string envOr(const char* var, std::string_view fallback);

--- a/src/paths/windows.cpp
+++ b/src/paths/windows.cpp
@@ -1,5 +1,11 @@
 #include "paths/paths.h"
 
+#include <algorithm>
+
+#include <windows.h>
+#include <shellapi.h>
+#pragma comment(lib, "Shell32.lib")
+
 
 namespace paths {
 
@@ -24,6 +30,12 @@ std::string getLogDir() {
     std::string dir = base + "/" + kAppDirName + "/Logs";
     ensureDir(dir);
     return dir;
+}
+
+void openMpvHome() {
+    auto path = getMpvHome();   
+    std::replace(path.begin(), path.end(), '/', '\\');
+    ShellExecuteA(NULL, "explore", path.c_str(), NULL, NULL, SW_SHOWNORMAL);
 }
 
 }  // namespace paths

--- a/src/web/client-settings.js
+++ b/src/web/client-settings.js
@@ -197,6 +197,30 @@
             }
         }
 
+        // Open mpv config button
+        if (jmpInfo.settings.main && jmpInfo.settings.main.userWebClient) {
+            const group = document.createElement('div');
+            group.className = 'verticalSection';
+            form.appendChild(group);
+
+            const sectionHeader = document.createElement('h2');
+            sectionHeader.className = 'sectionTitle';
+            sectionHeader.textContent = 'MPV config';
+            group.appendChild(sectionHeader);
+
+            const btn = document.createElement('button');
+            btn.className = 'raised button-cancel block emby-button';
+            btn.textContent = 'Open mpv config directory';
+            btn.type = 'button';
+            btn.addEventListener('click', () => {
+                if (window.jmpNative && window.jmpNative.openConfigDir) {
+                    console.log('[SETTINGS] called openConfigDir');
+                    window.jmpNative.openConfigDir();
+                }
+            });
+            group.appendChild(btn);
+        }
+
         // Reset server button
         if (jmpInfo.settings.main && jmpInfo.settings.main.userWebClient) {
             const group = document.createElement('div');


### PR DESCRIPTION
Added a way to pass custom options to MPV player.
The code was inspired by the implementation from [jellyfin-desktop-gt](https://github.com/jellyfin-archive/jellyfin-desktop-qt).

Client config:
<img width="886" height="493" alt="image" src="https://github.com/user-attachments/assets/8cd6eb01-fa05-402a-a271-461650d4d5b0" />


This PR solves issues: #90 #129
