### PR TITLE
fix(macOS): improve native wheel handling for mice [v2]

### DIFF
--- a/src/cef/cef_client.cpp
+++ b/src/cef/cef_client.cpp
@@ -6,6 +6,7 @@
 #include "include/cef_parser.h"
 #include <SDL3/SDL.h>
 #include "logging.h"
+#include <cmath>
 #include <mutex>
 #if !defined(__APPLE__) && !defined(_WIN32)
 #include <unistd.h>  // For dup()
@@ -718,6 +719,8 @@ void Client::sendMouseWheel(int x, int y, float deltaX, float deltaY, int modifi
     scroll_x_ = x;
     scroll_y_ = y;
     scroll_mods_ = modifiers;
+    scroll_precise_ = true;
+    scroll_animated_ = false;
     accum_scroll_x_ += deltaX * 10.0f;
     accum_scroll_y_ += deltaY * 10.0f;
     has_pending_scroll_ = true;
@@ -732,18 +735,76 @@ void Client::sendMouseWheel(int x, int y, float deltaX, float deltaY, int modifi
     int pixelX = static_cast<int>(deltaX * 53.0f);
     int pixelY = static_cast<int>(deltaY * 53.0f);
     b->GetHost()->SendMouseWheelEvent(event, pixelX, pixelY);
+    return;
+#endif
+
+    return;
+}
+
+void Client::sendNativeMouseWheel(int x, int y, float deltaX, float deltaY, bool precise, int modifiers) {
+#ifdef __APPLE__
+    if (!precise) {
+        constexpr float kPixelsPerCocoaTick = 40.0f;
+        scroll_x_ = x;
+        scroll_y_ = y;
+        scroll_mods_ = modifiers;
+        scroll_precise_ = false;
+        scroll_animated_ = true;
+        accum_scroll_x_ += deltaX * kPixelsPerCocoaTick;
+        accum_scroll_y_ += deltaY * kPixelsPerCocoaTick;
+        has_pending_scroll_ = true;
+        return;
+    }
+
+    accum_scroll_x_ += deltaX;
+    accum_scroll_y_ += deltaY;
+    const int pixelX = static_cast<int>(std::lround(accum_scroll_x_));
+    const int pixelY = static_cast<int>(std::lround(accum_scroll_y_));
+    accum_scroll_x_ -= pixelX;
+    accum_scroll_y_ -= pixelY;
+    auto b = browser();
+    if (!b) return;
+
+    if (pixelX == 0 && pixelY == 0) return;
+
+    CefMouseEvent event;
+    event.x = x;
+    event.y = y;
+    event.modifiers = modifiers;
+    if (precise)
+        event.modifiers |= EVENTFLAG_PRECISION_SCROLLING_DELTA;
+    b->GetHost()->SendMouseWheelEvent(event, pixelX, pixelY);
+#else
+    sendMouseWheel(x, y, deltaX, deltaY, modifiers);
 #endif
 }
 
 #ifdef __APPLE__
 void Client::flushScroll() {
     if (!has_pending_scroll_) return;
-    has_pending_scroll_ = false;
 
-    int pixelX = static_cast<int>(accum_scroll_x_);
-    int pixelY = static_cast<int>(accum_scroll_y_);
-    accum_scroll_x_ -= pixelX;
-    accum_scroll_y_ -= pixelY;
+    int pixelX = 0;
+    int pixelY = 0;
+    if (scroll_animated_) {
+        constexpr float kDrainFraction = 0.45f;
+        pixelX = static_cast<int>(std::lround(accum_scroll_x_ * kDrainFraction));
+        pixelY = static_cast<int>(std::lround(accum_scroll_y_ * kDrainFraction));
+        if (pixelX == 0 && std::fabs(accum_scroll_x_) >= 1.0f)
+            pixelX = accum_scroll_x_ > 0 ? 1 : -1;
+        if (pixelY == 0 && std::fabs(accum_scroll_y_) >= 1.0f)
+            pixelY = accum_scroll_y_ > 0 ? 1 : -1;
+        accum_scroll_x_ -= pixelX;
+        accum_scroll_y_ -= pixelY;
+        if (std::fabs(accum_scroll_x_) < 0.5f) accum_scroll_x_ = 0.0f;
+        if (std::fabs(accum_scroll_y_) < 0.5f) accum_scroll_y_ = 0.0f;
+        has_pending_scroll_ = (accum_scroll_x_ != 0.0f || accum_scroll_y_ != 0.0f);
+    } else {
+        has_pending_scroll_ = false;
+        pixelX = static_cast<int>(accum_scroll_x_);
+        pixelY = static_cast<int>(accum_scroll_y_);
+        accum_scroll_x_ -= pixelX;
+        accum_scroll_y_ -= pixelY;
+    }
     if (pixelX == 0 && pixelY == 0) return;
 
     auto b = browser();
@@ -752,7 +813,9 @@ void Client::flushScroll() {
     CefMouseEvent event;
     event.x = scroll_x_;
     event.y = scroll_y_;
-    event.modifiers = scroll_mods_ | EVENTFLAG_PRECISION_SCROLLING_DELTA;
+    event.modifiers = scroll_mods_;
+    if (scroll_precise_)
+        event.modifiers |= EVENTFLAG_PRECISION_SCROLLING_DELTA;
     b->GetHost()->SendMouseWheelEvent(event, pixelX, pixelY);
 }
 #endif
@@ -1202,6 +1265,8 @@ void OverlayClient::sendMouseWheel(int x, int y, float deltaX, float deltaY, int
     scroll_x_ = x;
     scroll_y_ = y;
     scroll_mods_ = modifiers;
+    scroll_precise_ = true;
+    scroll_animated_ = false;
     accum_scroll_x_ += deltaX * 10.0f;
     accum_scroll_y_ += deltaY * 10.0f;
     has_pending_scroll_ = true;
@@ -1215,18 +1280,76 @@ void OverlayClient::sendMouseWheel(int x, int y, float deltaX, float deltaY, int
     int pixelX = static_cast<int>(deltaX * 53.0f);
     int pixelY = static_cast<int>(deltaY * 53.0f);
     b->GetHost()->SendMouseWheelEvent(event, pixelX, pixelY);
+    return;
+#endif
+
+    return;
+}
+
+void OverlayClient::sendNativeMouseWheel(int x, int y, float deltaX, float deltaY, bool precise, int modifiers) {
+#ifdef __APPLE__
+    if (!precise) {
+        constexpr float kPixelsPerCocoaTick = 40.0f;
+        scroll_x_ = x;
+        scroll_y_ = y;
+        scroll_mods_ = modifiers;
+        scroll_precise_ = false;
+        scroll_animated_ = true;
+        accum_scroll_x_ += deltaX * kPixelsPerCocoaTick;
+        accum_scroll_y_ += deltaY * kPixelsPerCocoaTick;
+        has_pending_scroll_ = true;
+        return;
+    }
+
+    accum_scroll_x_ += deltaX;
+    accum_scroll_y_ += deltaY;
+    const int pixelX = static_cast<int>(std::lround(accum_scroll_x_));
+    const int pixelY = static_cast<int>(std::lround(accum_scroll_y_));
+    accum_scroll_x_ -= pixelX;
+    accum_scroll_y_ -= pixelY;
+    auto b = browser();
+    if (!b) return;
+
+    if (pixelX == 0 && pixelY == 0) return;
+
+    CefMouseEvent event;
+    event.x = x;
+    event.y = y;
+    event.modifiers = modifiers;
+    if (precise)
+        event.modifiers |= EVENTFLAG_PRECISION_SCROLLING_DELTA;
+    b->GetHost()->SendMouseWheelEvent(event, pixelX, pixelY);
+#else
+    sendMouseWheel(x, y, deltaX, deltaY, modifiers);
 #endif
 }
 
 #ifdef __APPLE__
 void OverlayClient::flushScroll() {
     if (!has_pending_scroll_) return;
-    has_pending_scroll_ = false;
 
-    int pixelX = static_cast<int>(accum_scroll_x_);
-    int pixelY = static_cast<int>(accum_scroll_y_);
-    accum_scroll_x_ -= pixelX;
-    accum_scroll_y_ -= pixelY;
+    int pixelX = 0;
+    int pixelY = 0;
+    if (scroll_animated_) {
+        constexpr float kDrainFraction = 0.45f;
+        pixelX = static_cast<int>(std::lround(accum_scroll_x_ * kDrainFraction));
+        pixelY = static_cast<int>(std::lround(accum_scroll_y_ * kDrainFraction));
+        if (pixelX == 0 && std::fabs(accum_scroll_x_) >= 1.0f)
+            pixelX = accum_scroll_x_ > 0 ? 1 : -1;
+        if (pixelY == 0 && std::fabs(accum_scroll_y_) >= 1.0f)
+            pixelY = accum_scroll_y_ > 0 ? 1 : -1;
+        accum_scroll_x_ -= pixelX;
+        accum_scroll_y_ -= pixelY;
+        if (std::fabs(accum_scroll_x_) < 0.5f) accum_scroll_x_ = 0.0f;
+        if (std::fabs(accum_scroll_y_) < 0.5f) accum_scroll_y_ = 0.0f;
+        has_pending_scroll_ = (accum_scroll_x_ != 0.0f || accum_scroll_y_ != 0.0f);
+    } else {
+        has_pending_scroll_ = false;
+        pixelX = static_cast<int>(accum_scroll_x_);
+        pixelY = static_cast<int>(accum_scroll_y_);
+        accum_scroll_x_ -= pixelX;
+        accum_scroll_y_ -= pixelY;
+    }
     if (pixelX == 0 && pixelY == 0) return;
 
     auto b = browser();
@@ -1235,7 +1358,9 @@ void OverlayClient::flushScroll() {
     CefMouseEvent event;
     event.x = scroll_x_;
     event.y = scroll_y_;
-    event.modifiers = scroll_mods_ | EVENTFLAG_PRECISION_SCROLLING_DELTA;
+    event.modifiers = scroll_mods_;
+    if (scroll_precise_)
+        event.modifiers |= EVENTFLAG_PRECISION_SCROLLING_DELTA;
     b->GetHost()->SendMouseWheelEvent(event, pixelX, pixelY);
 }
 #endif

--- a/src/cef/cef_client.h
+++ b/src/cef/cef_client.h
@@ -20,6 +20,7 @@ public:
     virtual void sendMouseMove(int x, int y, int modifiers) = 0;
     virtual void sendMouseClick(int x, int y, bool down, int button, int clickCount, int modifiers) = 0;
     virtual void sendMouseWheel(int x, int y, float deltaX, float deltaY, int modifiers) = 0;
+    virtual void sendNativeMouseWheel(int x, int y, float deltaX, float deltaY, bool precise, int modifiers) = 0;
     virtual void sendKeyEvent(int key, bool down, int modifiers) = 0;
     virtual void sendChar(int charCode, int modifiers) = 0;
     virtual void sendTouch(int id, float x, float y, float radiusX, float radiusY,
@@ -159,6 +160,7 @@ public:
     void sendMouseMove(int x, int y, int modifiers) override;
     void sendMouseClick(int x, int y, bool down, int button, int clickCount, int modifiers) override;
     void sendMouseWheel(int x, int y, float deltaX, float deltaY, int modifiers) override;
+    void sendNativeMouseWheel(int x, int y, float deltaX, float deltaY, bool precise, int modifiers) override;
     void sendKeyEvent(int key, bool down, int modifiers) override;
     void sendChar(int charCode, int modifiers) override;
     void sendTouch(int id, float x, float y, float radiusX, float radiusY,
@@ -230,6 +232,8 @@ private:
     float accum_scroll_y_ = 0.0f;
     int scroll_x_ = 0, scroll_y_ = 0;  // Last scroll position for coalesced event
     int scroll_mods_ = 0;
+    bool scroll_precise_ = true;
+    bool scroll_animated_ = false;
     bool has_pending_scroll_ = false;
 #endif
     mutable std::mutex browser_mutex_;  // Protects browser_ across threads
@@ -308,6 +312,7 @@ public:
     void sendMouseMove(int x, int y, int modifiers) override;
     void sendMouseClick(int x, int y, bool down, int button, int clickCount, int modifiers) override;
     void sendMouseWheel(int x, int y, float deltaX, float deltaY, int modifiers) override;
+    void sendNativeMouseWheel(int x, int y, float deltaX, float deltaY, bool precise, int modifiers) override;
     void sendKeyEvent(int key, bool down, int modifiers) override;
     void sendChar(int charCode, int modifiers) override;
     void sendTouch(int id, float x, float y, float radiusX, float radiusY,
@@ -342,6 +347,8 @@ private:
     float accum_scroll_y_ = 0.0f;
     int scroll_x_ = 0, scroll_y_ = 0;
     int scroll_mods_ = 0;
+    bool scroll_precise_ = true;
+    bool scroll_animated_ = false;
     bool has_pending_scroll_ = false;
 #endif
     mutable std::mutex browser_mutex_;  // Protects browser_ across threads

--- a/src/input/browser_layer.h
+++ b/src/input/browser_layer.h
@@ -5,6 +5,10 @@
 #include "../cef/cef_client.h"
 #include <SDL3/SDL.h>
 
+#ifdef __APPLE__
+bool macNativeScrollBridgeEnabled();
+#endif
+
 // Input layer that forwards events to a CEF browser client
 class BrowserLayer : public InputLayer, public WindowStateListener {
 public:
@@ -13,6 +17,12 @@ public:
     void setReceiver(InputReceiver* receiver) { receiver_ = receiver; }
     InputReceiver* receiver() const { return receiver_; }
     void setWindowSize(int w, int h) { window_width_ = w; window_height_ = h; }
+    void handleNativeScroll(int x, int y, float deltaX, float deltaY, bool precise) {
+        if (!receiver_) return;
+        mouse_x_ = x;
+        mouse_y_ = y;
+        receiver_->sendNativeMouseWheel(x, y, deltaX, deltaY, precise, getModifiers());
+    }
 
     bool handleInput(const SDL_Event& event) override {
         if (!receiver_) return false;
@@ -67,6 +77,11 @@ public:
             }
 
             case SDL_EVENT_MOUSE_WHEEL: {
+#ifdef __APPLE__
+                if (macNativeScrollBridgeEnabled()) {
+                    return true;
+                }
+#endif
                 int mods = getModifiers();
                 receiver_->sendMouseWheel(mouse_x_, mouse_y_, event.wheel.x, event.wheel.y, mods);
                 return true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,6 +35,8 @@ void activateMacWindow(SDL_Window* window);
 void setMacTitlebarColor(uint8_t r, uint8_t g, uint8_t b);
 // Show/hide traffic light buttons (close, minimize, zoom)
 void setMacTrafficLightsVisible(bool visible);
+// Route native Cocoa scroll-wheel events directly to the active browser layer.
+void setMacNativeScrollHandler(void (*handler)(int x, int y, float deltaX, float deltaY, bool precise));
 #endif
 
 #ifdef __APPLE__
@@ -80,6 +82,16 @@ void setMacTrafficLightsVisible(bool visible);
 #include "input/window_state.h"
 #include "ui/menu_overlay.h"
 #include "settings.h"
+
+#ifdef __APPLE__
+static BrowserLayer* g_active_browser_layer = nullptr;
+
+static void handleMacNativeScroll(int x, int y, float deltaX, float deltaY, bool precise) {
+    if (g_active_browser_layer) {
+        g_active_browser_layer->handleNativeScroll(x, y, deltaX, deltaY, precise);
+    }
+}
+#endif
 #include "single_instance.h"
 #include "window_geometry.h"
 #include "window_activation.h"
@@ -1484,6 +1496,10 @@ int main(int argc, char* argv[]) {
     BrowserLayer* active_browser = player_mode
         ? browsers.getInputLayer("main")
         : browsers.getInputLayer("overlay");
+#ifdef __APPLE__
+    g_active_browser_layer = active_browser;
+    setMacNativeScrollHandler(handleMacNativeScroll);
+#endif
 
     // Push/pop menu layer on open/close
     menu.setOnOpen([&]() { input_stack.push(&menu_layer); });
@@ -2216,6 +2232,9 @@ int main(int argc, char* argv[]) {
                 input_stack.remove(browsers.getInputLayer("overlay"));
                 input_stack.push(browsers.getInputLayer("main"));
                 active_browser = browsers.getInputLayer("main");
+#ifdef __APPLE__
+                g_active_browser_layer = active_browser;
+#endif
                 window_state.add(active_browser);
                 active_browser->onFocusGained();
                 overlay_fade_start = now;
@@ -2355,6 +2374,8 @@ int main(int argc, char* argv[]) {
 #endif
 #ifdef __APPLE__
     SDL_RemoveEventWatch(liveResizeCallback, &live_resize_ctx);
+    setMacNativeScrollHandler(nullptr);
+    g_active_browser_layer = nullptr;
 #elif defined(_WIN32)
     SDL_RemoveEventWatch(winLiveResizeCallback, &win_live_resize_ctx);
 #endif

--- a/src/platform/macos_app.mm
+++ b/src/platform/macos_app.mm
@@ -6,12 +6,15 @@
 #include "include/cef_application_mac.h"
 #include "settings.h"
 #include <SDL3/SDL.h>
+#include <cmath>
 
 // Store main window reference for dock click handling
 static NSWindow* g_mainWindow = nil;
 static NSView* g_titlebarDragView = nil;
 static bool g_trafficLightsVisible = true;
 static const CGFloat kTitlebarHeight = 28.0;
+using NativeScrollHandler = void(*)(int x, int y, float deltaX, float deltaY, bool precise);
+static NativeScrollHandler g_nativeScrollHandler = nullptr;
 
 // Apply current traffic light visibility state to window buttons and drag view.
 // Uses alphaValue instead of setHidden: because AppKit can reset hidden state
@@ -85,6 +88,27 @@ static void applyTrafficLightsVisibility() {
 
 - (void)sendEvent:(NSEvent*)event {
     CefScopedSendingEvent sendingEventScoper;
+    if (event.type == NSEventTypeScrollWheel && g_nativeScrollHandler) {
+        // Forward the original Cocoa scroll event deltas to the active browser
+        // before SDL translates them into wheel events.
+        NSWindow* window = event.window ?: g_mainWindow;
+        NSView* content = window.contentView;
+        if (content) {
+            NSPoint point = [content convertPoint:event.locationInWindow fromView:nil];
+            if (NSPointInRect(point, content.bounds)) {
+                int x = static_cast<int>(lround(point.x));
+                int y = static_cast<int>(lround(content.bounds.size.height - point.y));
+                const bool precise = event.hasPreciseScrollingDeltas;
+                const float deltaX = precise
+                    ? static_cast<float>(event.scrollingDeltaX)
+                    : static_cast<float>(event.deltaX);
+                const float deltaY = precise
+                    ? static_cast<float>(event.scrollingDeltaY)
+                    : static_cast<float>(event.deltaY);
+                g_nativeScrollHandler(x, y, deltaX, deltaY, precise);
+            }
+        }
+    }
     [super sendEvent:event];
 }
 
@@ -191,4 +215,12 @@ void setMacTrafficLightsVisible(bool visible) {
     if (!g_mainWindow || visible == g_trafficLightsVisible) return;
     g_trafficLightsVisible = visible;
     applyTrafficLightsVisibility();
+}
+
+void setMacNativeScrollHandler(NativeScrollHandler handler) {
+    g_nativeScrollHandler = handler;
+}
+
+bool macNativeScrollBridgeEnabled() {
+    return g_nativeScrollHandler != nullptr;
 }


### PR DESCRIPTION
Compared to v1, we no longer treat all macOS scroll input as “precise” pixel scroll because not all mice, especially third-party mice with traditional wheels, do not have pixel-perfect scroll events. V1 mistakenly treated all scroll events as pixel-precise, which broke scrolling on such mice and made it painfully slow.

For precise devices like Apple branded mice and trackpads, the behavior stays close to v1: native deltas are forwarded with `EVENTFLAG_PRECISION_SCROLLING_DELTA`. 

For non-precise wheel mice, we now use AppKit’s accelerated `event.deltaX/Y` instead of `scrollingDeltaX/Y`, this allows the CEF experience more "macOS native" mouse wheel handling, where the wheel scrolls faster, the sensitivity goes higher.

We also tried to replicate the smooth scrolling for mice without pixel-precise scroll by turning discrete wheel inputs into short pending scroll impulses. These impulses are then drained across multiple frames, which helps reduce jumpiness and creates a more Chrome-like smooth wheel feel. But chrome has much more work beyond this so we are not as smooth as real Chrome in this case, but it is much better than current brute-force way, and implementing overly complicated solution for scrolling is clearly out of scope of this project.

v1 changes, for reference
-----

For macOS, the old behavior is handling wheel events in the SDL layer and adding a 10x scale multiplier to match the scroll speed the OS would normally have. While this approach works, it results in a less smooth scrolling experience because we discard all intermediate states between scrolling events. Consequently, the scrolling “framerate” is significantly lower than it should be, as the scroll position between two events are huge enough to look like a jump visually.

To fix this, we need to capture native wheel events using macOS’s native method and forward them to CEF. This will allow CEF to handle the events in a manner similar to a typical Chromium-based browser.

Fixes https://github.com/jellyfin/jellyfin-desktop/issues/29
This would also address https://github.com/jellyfin/jellyfin-desktop/issues/30 for macOS, as now trackpad x axis scrolling is also correctly handled.