### PR TITLE
feat(wayland): bypass EGL compositing with direct dmabuf subsurface for CEF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,6 +161,10 @@ else()
     set(XDG_ACTIVATION_CLIENT_H "${WAYLAND_GENERATED_DIR}/xdg-activation-v1-client.h")
     set(XDG_ACTIVATION_CODE_C "${WAYLAND_GENERATED_DIR}/xdg-activation-v1-code.c")
 
+    set(LINUX_DMABUF_PROTOCOL "${WAYLAND_PROTOCOLS_DIR}/unstable/linux-dmabuf/linux-dmabuf-unstable-v1.xml")
+    set(LINUX_DMABUF_CLIENT_H "${WAYLAND_GENERATED_DIR}/linux-dmabuf-unstable-v1-client.h")
+    set(LINUX_DMABUF_CODE_C "${WAYLAND_GENERATED_DIR}/linux-dmabuf-unstable-v1-code.c")
+
     # KDE server decoration palette — per-window titlebar colors on KWin.
     # Required by default; pass -DENABLE_KDE_PALETTE=OFF to disable.
     option(ENABLE_KDE_PALETTE "KDE/KWin per-window titlebar color support (requires plasma-wayland-protocols at build time)" ON)
@@ -209,6 +213,18 @@ else()
         DEPENDS ${XDG_ACTIVATION_PROTOCOL}
         COMMENT "Generating xdg-activation-v1 code"
     )
+    add_custom_command(
+        OUTPUT ${LINUX_DMABUF_CLIENT_H}
+        COMMAND ${WAYLAND_SCANNER} client-header ${LINUX_DMABUF_PROTOCOL} ${LINUX_DMABUF_CLIENT_H}
+        DEPENDS ${LINUX_DMABUF_PROTOCOL}
+        COMMENT "Generating linux-dmabuf-unstable-v1 client header"
+    )
+    add_custom_command(
+        OUTPUT ${LINUX_DMABUF_CODE_C}
+        COMMAND ${WAYLAND_SCANNER} private-code ${LINUX_DMABUF_PROTOCOL} ${LINUX_DMABUF_CODE_C}
+        DEPENDS ${LINUX_DMABUF_PROTOCOL}
+        COMMENT "Generating linux-dmabuf-unstable-v1 code"
+    )
     if(ENABLE_KDE_PALETTE)
         add_custom_command(
             OUTPUT ${DECO_PALETTE_CLIENT_H}
@@ -242,6 +258,9 @@ else()
         ${VIEWPORTER_CLIENT_H}
         ${XDG_ACTIVATION_CODE_C}
         ${XDG_ACTIVATION_CLIENT_H}
+        ${LINUX_DMABUF_CODE_C}
+        ${LINUX_DMABUF_CLIENT_H}
+        src/platform/wayland_browser_surface.cpp
     )
     if(ENABLE_KDE_PALETTE)
         list(APPEND PLATFORM_SOURCES

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,6 +55,7 @@ void setMacTrafficLightsVisible(bool visible);
 #include "player/mpris/media_session_mpris.h"
 #include <unistd.h>  // For close()
 #include "platform/event_loop_linux.h"
+#include "platform/wayland_browser_surface.h"
 #ifdef HAVE_KDE_DECORATION_PALETTE
 #include "platform/kde_decoration_palette.h"
 #endif
@@ -836,11 +837,28 @@ int main(int argc, char* argv[]) {
     bool video_needs_rerender = false;
     double current_playback_rate = 1.0;
 
+    // Wayland: create browser subsurface for direct dmabuf attach (bypasses EGL compositing)
+    const char* videoDriver = SDL_GetCurrentVideoDriver();
+    bool isWayland = videoDriver && strcmp(videoDriver, "wayland") == 0;
+    std::unique_ptr<WaylandBrowserSurface> browserSurface;
+    if (isWayland && use_dmabuf) {
+        browserSurface = std::make_unique<WaylandBrowserSurface>();
+        if (!browserSurface->init(window)) {
+            LOG_WARN(LOG_PLATFORM, "WaylandBrowserSurface init failed, falling back to EGL compositing");
+            browserSurface.reset();
+        }
+    }
+
     // Frame context (same for both Wayland and X11 - both use EGL)
     OpenGLFrameContext frameContext(&egl);
 
-    // Render an initial #101010 frame so the window doesn't flash the default background
-    frameContext.beginFrame(16.0f / 255.0f, 1.0f);
+    // Render an initial frame — transparent if using browser subsurface
+    // (parent must be see-through for subsurfaces), opaque otherwise.
+    if (browserSurface) {
+        frameContext.beginFrame(0.0f, 0.0f);
+    } else {
+        frameContext.beginFrame(16.0f / 255.0f, 1.0f);
+    }
     frameContext.endFrame();
 
     // Compositor context for BrowserEntry init
@@ -1251,8 +1269,12 @@ int main(int argc, char* argv[]) {
         },
 #if !defined(__APPLE__) && !defined(_WIN32)
         // Accelerated paint callback - queue dmabuf for import on main thread
-        [main_ptr, wakeMainLoop](int fd, uint32_t stride, uint64_t modifier, int w, int h) {
-            main_ptr->compositor->queueDmabuf(fd, stride, modifier, w, h);
+        [main_ptr, &browserSurface, wakeMainLoop](int fd, uint32_t stride, uint64_t modifier, int w, int h) {
+            if (browserSurface) {
+                browserSurface->queueDmabuf(fd, stride, modifier, w, h);
+            } else {
+                main_ptr->compositor->queueDmabuf(fd, stride, modifier, w, h);
+            }
             wakeMainLoop();
         },
 #else
@@ -1300,15 +1322,11 @@ int main(int argc, char* argv[]) {
             pending_cmds.push_back({"theme_color", color, 0, 0.0});
             wakeMainLoop();
         },
-#ifdef __APPLE__
         [&cmd_mutex, &pending_cmds, &wakeMainLoop](bool visible) {
             std::lock_guard<std::mutex> lock(cmd_mutex);
             pending_cmds.push_back({"osd_visible", "", visible ? 1 : 0, 0.0});
             wakeMainLoop();
         },
-#else
-        nullptr,
-#endif
         popup_show_cb,
         popup_size_cb,
         accel_popup_cb
@@ -1713,7 +1731,13 @@ int main(int argc, char* argv[]) {
         SDL_Event event;
         bool have_event;
         if (needs_render || has_video || has_pending || has_pending_cmds || !paint_size_matched) {
-            have_event = SDL_PollEvent(&event);
+            // With browser subsurface, no eglSwapBuffers throttles the loop.
+            // Always use a short wait to prevent busy-spinning.
+            if (browserSurface) {
+                have_event = SDL_WaitEventTimeout(&event, 2);
+            } else {
+                have_event = SDL_PollEvent(&event);
+            }
         } else {
 #ifdef _WIN32
             if (overlay_state == OverlayState::WAITING) {
@@ -1882,6 +1906,8 @@ int main(int argc, char* argv[]) {
                 egl.resize(physical_w, physical_h);
                 videoController.requestResize(physical_w, physical_h);
                 videoRenderer.setDestinationSize(current_width, current_height);
+                if (browserSurface)
+                    browserSurface->setDestinationSize(current_width, current_height);
                 last_resize_time = Clock::now();
 #endif
 #endif
@@ -2098,9 +2124,10 @@ int main(int argc, char* argv[]) {
                     } else {
                         pending_titlebar_color = cmd.url;
                     }
+                } else if (cmd.cmd == "osd_visible") {
 #ifdef __APPLE__
-                } else if (cmd.cmd == "osd_visible" && transparent_titlebar) {
-                    setMacTrafficLightsVisible(cmd.intArg != 0);
+                    if (transparent_titlebar)
+                        setMacTrafficLightsVisible(cmd.intArg != 0);
 #endif
                 }
             }
@@ -2239,24 +2266,37 @@ int main(int argc, char* argv[]) {
             frameContext.endFrame();
         }
 #else
-        // Linux: Get physical dimensions for viewport (HiDPI)
-        // Use SDL_GetWindowSizeInPixels instead of int(logical * scale) to avoid
-        // truncation rounding mismatch — the EGL surface uses ceil() internally,
-        // so truncating can leave a 1px unrendered strip at the right/bottom edge.
         int viewport_w, viewport_h;
         SDL_GetWindowSizeInPixels(window, &viewport_w, &viewport_h);
-        glViewport(0, 0, viewport_w, viewport_h);
 
-        frameContext.beginFrame(clear_color, videoController.getClearAlpha());
-        videoController.render(viewport_w, viewport_h);
+        if (browserSurface) {
+            // Wayland subsurface path: CEF dmabufs go directly to compositor.
+            browserSurface->commitQueued();
+            videoController.render(viewport_w, viewport_h);
 
-        // Composite video texture (for threaded OpenGL renderers like X11)
-        videoRenderer.composite(viewport_w, viewport_h);
+            // Swap a transparent EGL frame on resize so the compositor
+            // acknowledges the new parent surface size.
+            if (!paint_size_matched) {
+                glViewport(0, 0, viewport_w, viewport_h);
+                frameContext.beginFrame(0.0f, 0.0f);
+                frameContext.endFrame();
+                paint_size_matched = true;
+            }
+        } else {
+            // X11 / fallback: EGL compositing path
+            glViewport(0, 0, viewport_w, viewport_h);
 
-        // Flush and composite all browsers (back-to-front order)
-        browsers.renderAll(viewport_w, viewport_h);
+            frameContext.beginFrame(clear_color, videoController.getClearAlpha());
+            videoController.render(viewport_w, viewport_h);
 
-        frameContext.endFrame();
+            // Composite video texture (for threaded OpenGL renderers like X11)
+            videoRenderer.composite(viewport_w, viewport_h);
+
+            // Flush and composite all browsers (back-to-front order)
+            browsers.renderAll(viewport_w, viewport_h);
+
+            frameContext.endFrame();
+        }
 #endif
         // If CEF painted at stale size during resize, re-request repaint.
         // During rapid resize, WasResized()+Invalidate() from the resize handler
@@ -2338,6 +2378,7 @@ int main(int argc, char* argv[]) {
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
     browsers.cleanupCompositors();
+    browserSurface.reset();
     videoRenderer.cleanup();
     VideoStack::cleanupStatics();
     egl.cleanup();

--- a/src/platform/wayland_browser_surface.cpp
+++ b/src/platform/wayland_browser_surface.cpp
@@ -1,0 +1,223 @@
+#include "platform/wayland_browser_surface.h"
+#include <SDL3/SDL.h>
+#include "logging.h"
+#include <cstring>
+#include <unistd.h>
+#include <drm_fourcc.h>
+#include "wayland-protocols/viewporter-client.h"
+#include "wayland-protocols/linux-dmabuf-unstable-v1-client.h"
+
+static const wl_registry_listener s_registryListener = {
+    .global = WaylandBrowserSurface::registryGlobal,
+    .global_remove = WaylandBrowserSurface::registryGlobalRemove,
+};
+
+static const wl_buffer_listener s_bufferListener = {
+    .release = WaylandBrowserSurface::bufferRelease,
+};
+
+WaylandBrowserSurface::WaylandBrowserSurface() = default;
+WaylandBrowserSurface::~WaylandBrowserSurface() { cleanup(); }
+
+void WaylandBrowserSurface::registryGlobal(void* data, wl_registry* registry,
+                                            uint32_t name, const char* interface, uint32_t version) {
+    auto* self = static_cast<WaylandBrowserSurface*>(data);
+    if (strcmp(interface, wl_compositor_interface.name) == 0) {
+        self->wl_compositor_ = static_cast<wl_compositor*>(
+            wl_registry_bind(registry, name, &wl_compositor_interface, 4));
+    } else if (strcmp(interface, wl_subcompositor_interface.name) == 0) {
+        self->wl_subcompositor_ = static_cast<wl_subcompositor*>(
+            wl_registry_bind(registry, name, &wl_subcompositor_interface, 1));
+    } else if (strcmp(interface, wp_viewporter_interface.name) == 0) {
+        self->viewporter_ = static_cast<wp_viewporter*>(
+            wl_registry_bind(registry, name, &wp_viewporter_interface, 1));
+    } else if (strcmp(interface, zwp_linux_dmabuf_v1_interface.name) == 0) {
+        self->dmabuf_manager_ = static_cast<zwp_linux_dmabuf_v1*>(
+            wl_registry_bind(registry, name, &zwp_linux_dmabuf_v1_interface, std::min(version, 3u)));
+    }
+}
+
+bool WaylandBrowserSurface::init(SDL_Window* window) {
+    if (!initWayland(window)) return false;
+
+    if (!dmabuf_manager_) {
+        LOG_ERROR(LOG_PLATFORM, "WaylandBrowserSurface: zwp_linux_dmabuf_v1 not available");
+        return false;
+    }
+
+    LOG_INFO(LOG_PLATFORM, "WaylandBrowserSurface: initialized (direct dmabuf attach)");
+    return true;
+}
+
+bool WaylandBrowserSurface::initWayland(SDL_Window* window) {
+    SDL_PropertiesID props = SDL_GetWindowProperties(window);
+    if (!props) return false;
+
+    wl_display_ = static_cast<wl_display*>(
+        SDL_GetPointerProperty(props, SDL_PROP_WINDOW_WAYLAND_DISPLAY_POINTER, nullptr));
+    wl_surface* parent = static_cast<wl_surface*>(
+        SDL_GetPointerProperty(props, SDL_PROP_WINDOW_WAYLAND_SURFACE_POINTER, nullptr));
+    if (!wl_display_ || !parent) return false;
+
+    wl_registry* reg = wl_display_get_registry(wl_display_);
+    wl_registry_add_listener(reg, &s_registryListener, this);
+    wl_display_roundtrip(wl_display_);
+    wl_registry_destroy(reg);
+
+    if (!wl_compositor_ || !wl_subcompositor_) return false;
+    return createSubsurface(parent);
+}
+
+bool WaylandBrowserSurface::createSubsurface(wl_surface* parent) {
+    surface_ = wl_compositor_create_surface(wl_compositor_);
+    if (!surface_) return false;
+
+    subsurface_ = wl_subcompositor_get_subsurface(wl_subcompositor_, surface_, parent);
+    if (!subsurface_) return false;
+
+    // Place ABOVE parent (CEF overlay is on top of everything)
+    wl_subsurface_set_position(subsurface_, 0, 0);
+    wl_subsurface_place_above(subsurface_, parent);
+    wl_subsurface_set_desync(subsurface_);
+
+    // Pass-through input to parent
+    wl_region* empty = wl_compositor_create_region(wl_compositor_);
+    wl_surface_set_input_region(surface_, empty);
+    wl_region_destroy(empty);
+
+    if (viewporter_)
+        viewport_ = wp_viewporter_get_viewport(viewporter_, surface_);
+
+    wl_surface_commit(surface_);
+    wl_display_roundtrip(wl_display_);
+    return true;
+}
+
+void WaylandBrowserSurface::queueDmabuf(int fd, uint32_t stride, uint64_t modifier, int width, int height) {
+    std::lock_guard<std::mutex> lock(queue_mutex_);
+    // Close previously queued but uncommitted fd
+    if (pending_.load(std::memory_order_relaxed) && queued_.fd >= 0) {
+        close(queued_.fd);
+    }
+    queued_.fd = fd;
+    queued_.stride = stride;
+    queued_.modifier = modifier;
+    queued_.width = width;
+    queued_.height = height;
+    pending_.store(true, std::memory_order_release);
+}
+
+void WaylandBrowserSurface::bufferRelease(void* data, wl_buffer* buffer) {
+    auto* self = static_cast<WaylandBrowserSurface*>(data);
+    if (self->prev_buffer_ == buffer) {
+        wl_buffer_destroy(self->prev_buffer_);
+        self->prev_buffer_ = nullptr;
+        if (self->prev_fd_ >= 0) {
+            close(self->prev_fd_);
+            self->prev_fd_ = -1;
+        }
+    } else if (self->current_buffer_ == buffer) {
+        wl_buffer_destroy(self->current_buffer_);
+        self->current_buffer_ = nullptr;
+        if (self->current_fd_ >= 0) {
+            close(self->current_fd_);
+            self->current_fd_ = -1;
+        }
+    }
+}
+
+bool WaylandBrowserSurface::commitQueued() {
+    if (!pending_.load(std::memory_order_acquire)) return false;
+    if (!dmabuf_manager_ || !surface_) return false;
+
+    int fd;
+    uint32_t stride;
+    uint64_t modifier;
+    int w, h;
+    {
+        std::lock_guard<std::mutex> lock(queue_mutex_);
+        if (!pending_.load(std::memory_order_relaxed)) return false;
+        fd = queued_.fd;
+        stride = queued_.stride;
+        modifier = queued_.modifier;
+        w = queued_.width;
+        h = queued_.height;
+        pending_.store(false, std::memory_order_relaxed);
+        queued_.fd = -1;
+    }
+    if (fd < 0) return false;
+
+    // Create wl_buffer from dmabuf
+    struct zwp_linux_buffer_params_v1* params =
+        zwp_linux_dmabuf_v1_create_params(dmabuf_manager_);
+
+    zwp_linux_buffer_params_v1_add(params, fd, 0, 0, stride,
+                                    modifier >> 32, modifier & 0xFFFFFFFF);
+
+    wl_buffer* buffer = zwp_linux_buffer_params_v1_create_immed(
+        params, w, h, DRM_FORMAT_ARGB8888, 0);
+    zwp_linux_buffer_params_v1_destroy(params);
+
+    if (!buffer) {
+        LOG_ERROR(LOG_PLATFORM, "WaylandBrowserSurface: create_immed failed (%dx%d stride=%u mod=0x%lx)",
+                  w, h, stride, modifier);
+        close(fd);
+        return false;
+    }
+
+    // Track previous buffer for release
+    if (prev_buffer_) {
+        // Previous buffer not yet released by compositor — destroy it now.
+        // The compositor may have already released it via the listener,
+        // in which case prev_buffer_ is already nullptr.
+        wl_buffer_destroy(prev_buffer_);
+        if (prev_fd_ >= 0) close(prev_fd_);
+    }
+    prev_buffer_ = current_buffer_;
+    prev_fd_ = current_fd_;
+
+    current_buffer_ = buffer;
+    current_fd_ = fd;
+
+    // Listen for release so we can clean up
+    wl_buffer_add_listener(buffer, &s_bufferListener, this);
+
+    // Attach and commit
+    wl_surface_attach(surface_, buffer, 0, 0);
+    wl_surface_damage_buffer(surface_, 0, 0, w, h);
+    wl_surface_commit(surface_);
+
+    return true;
+}
+
+void WaylandBrowserSurface::setDestinationSize(int w, int h) {
+    if (viewport_ && w > 0 && h > 0)
+        wp_viewport_set_destination(viewport_, w, h);
+}
+
+void WaylandBrowserSurface::hide() {
+    if (!surface_) return;
+    wl_surface_attach(surface_, nullptr, 0, 0);
+    wl_surface_commit(surface_);
+    wl_display_flush(wl_display_);
+}
+
+void WaylandBrowserSurface::cleanup() {
+    if (current_buffer_) { wl_buffer_destroy(current_buffer_); current_buffer_ = nullptr; }
+    if (current_fd_ >= 0) { close(current_fd_); current_fd_ = -1; }
+    if (prev_buffer_) { wl_buffer_destroy(prev_buffer_); prev_buffer_ = nullptr; }
+    if (prev_fd_ >= 0) { close(prev_fd_); prev_fd_ = -1; }
+    // Close any pending queued fd
+    {
+        std::lock_guard<std::mutex> lock(queue_mutex_);
+        if (queued_.fd >= 0) { close(queued_.fd); queued_.fd = -1; }
+    }
+    if (viewport_) { wp_viewport_destroy(viewport_); viewport_ = nullptr; }
+    if (viewporter_) { wp_viewporter_destroy(viewporter_); viewporter_ = nullptr; }
+    if (subsurface_) { wl_subsurface_destroy(subsurface_); subsurface_ = nullptr; }
+    if (surface_) { wl_surface_destroy(surface_); surface_ = nullptr; }
+    if (dmabuf_manager_) { zwp_linux_dmabuf_v1_destroy(dmabuf_manager_); dmabuf_manager_ = nullptr; }
+    wl_compositor_ = nullptr;
+    wl_subcompositor_ = nullptr;
+    wl_display_ = nullptr;
+}

--- a/src/platform/wayland_browser_surface.h
+++ b/src/platform/wayland_browser_surface.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <wayland-client.h>
+#include <atomic>
+#include <mutex>
+
+struct SDL_Window;
+struct wp_viewporter;
+struct wp_viewport;
+struct zwp_linux_dmabuf_v1;
+
+// Wayland subsurface for CEF browser content.
+// Attaches CEF dmabufs directly as wl_buffers, bypassing EGL compositing.
+// The Wayland compositor handles layering with the mpv video subsurface.
+class WaylandBrowserSurface {
+public:
+    WaylandBrowserSurface();
+    ~WaylandBrowserSurface();
+
+    // Initialize: create subsurface above parent (SDL window surface)
+    bool init(SDL_Window* window);
+    void cleanup();
+
+    // Thread-safe: queue dmabuf from CEF's OnAcceleratedPaint callback
+    void queueDmabuf(int fd, uint32_t stride, uint64_t modifier, int width, int height);
+
+    // Main thread: create wl_buffer from queued dmabuf, attach+commit
+    bool commitQueued();
+
+    void setDestinationSize(int width, int height);
+    void hide();
+
+    bool isInitialized() const { return subsurface_ != nullptr; }
+    wl_surface* surface() const { return surface_; }
+
+    // Public for Wayland listener structs
+    static void registryGlobal(void* data, wl_registry* registry,
+                               uint32_t name, const char* interface, uint32_t version);
+    static void registryGlobalRemove(void*, wl_registry*, uint32_t) {}
+    static void bufferRelease(void* data, wl_buffer* buffer);
+
+private:
+    bool initWayland(SDL_Window* window);
+    bool createSubsurface(wl_surface* parent);
+
+    wl_display* wl_display_ = nullptr;
+    wl_compositor* wl_compositor_ = nullptr;
+    wl_subcompositor* wl_subcompositor_ = nullptr;
+    wl_surface* surface_ = nullptr;
+    wl_subsurface* subsurface_ = nullptr;
+    wp_viewporter* viewporter_ = nullptr;
+    wp_viewport* viewport_ = nullptr;
+    zwp_linux_dmabuf_v1* dmabuf_manager_ = nullptr;
+
+    // Queued dmabuf from CEF thread
+    struct DmabufFrame {
+        int fd = -1;
+        uint32_t stride = 0;
+        uint64_t modifier = 0;
+        int width = 0;
+        int height = 0;
+    };
+    DmabufFrame queued_;
+    std::mutex queue_mutex_;
+    std::atomic<bool> pending_{false};
+
+    // Active buffer tracking for release
+    wl_buffer* current_buffer_ = nullptr;
+    int current_fd_ = -1;
+    wl_buffer* prev_buffer_ = nullptr;
+    int prev_fd_ = -1;
+};

--- a/src/web/native-shim.js
+++ b/src/web/native-shim.js
@@ -431,20 +431,21 @@
             // Dialog headers (e.g. client settings modal)
             css += '\n.formDialogHeader { padding-top: var(--mac-titlebar-height) !important; }';
 
-            // Hide/show traffic lights with the video OSD.
-            // jellyfin-web uses an internal Events.trigger() system (obj._callbacks),
-            // not DOM events. Register directly on that callback structure.
-            document._callbacks = document._callbacks || {};
-            document._callbacks['SHOW_VIDEO_OSD'] = document._callbacks['SHOW_VIDEO_OSD'] || [];
-            document._callbacks['SHOW_VIDEO_OSD'].push((_e, visible) => {
-                if (window.jmpNative && window.jmpNative.setOsdVisible) {
-                    window.jmpNative.setOsdVisible(!!visible);
-                }
-            });
         }
 
         style.textContent = css;
         document.head.appendChild(style);
+
+        // Notify native side when video OSD visibility changes.
+        // jellyfin-web uses an internal Events.trigger() system (obj._callbacks),
+        // not DOM events. Register directly on that callback structure.
+        document._callbacks = document._callbacks || {};
+        document._callbacks['SHOW_VIDEO_OSD'] = document._callbacks['SHOW_VIDEO_OSD'] || [];
+        document._callbacks['SHOW_VIDEO_OSD'].push((_e, visible) => {
+            if (window.jmpNative && window.jmpNative.setOsdVisible) {
+                window.jmpNative.setOsdVisible(!!visible);
+            }
+        });
 
         // Sync titlebar color with theme-color meta tag
         const meta = document.querySelector('meta[name="theme-color"]');


### PR DESCRIPTION
### Summary
- On Wayland, attach CEF dmabufs directly to a wl_subsurface via zwp_linux_dmabuf_v1 instead of importing into EGL and compositing as GL textures
- The Wayland compositor handles surface layering natively, eliminating the glDraw + eglSwapBuffers overhead entirely
- Enable OSD visibility callback on all platforms (was macOS-only)
- X11 keeps the existing EGL compositing path unchanged

### Motivation
The current rendering path imports CEF dmabufs into EGL as GL textures and composites them at display refresh rate. On integrated GPUs at high resolutions (e.g. 3440x1440 @ 120Hz), this saturates the GPU on idle pages.

```
Before: CEF paint → dmabuf → EGL import → GL texture → glDraw → eglSwapBuffers
After:  CEF paint → dmabuf → wl_buffer → wl_surface_attach → compositor (free)
```

Z-order: mpv subsurface (below) → SDL parent surface (transparent) → CEF subsurface (above)

### Test plan

- No high CPU usage
- GPU usage on idle page (should be ~0% instead of ~80%)
- OSD appearing/disappearing during video playback
- CEF framerate matches display refresh rate
- Window resizing and maximize/unmaximize
- X11 fallback still works
- Video playback in fullscreen

Fix: #68 