### PR TITLE
Remove GPU compositing toggle from settings UI

### DIFF
--- a/src/web/native-shim.js
+++ b/src/web/native-shim.js
@@ -75,7 +75,6 @@
             },
             advanced: {
                 transparentTitlebar: _savedSettings.transparentTitlebar !== false,
-                disableGpuCompositing: _savedSettings.disableGpuCompositing || false,
                 logLevel: _savedSettings.logLevel || ''
             }
         },
@@ -103,7 +102,6 @@
                 ]}
             ],
             advanced: [
-                { key: 'disableGpuCompositing', displayName: 'Disable GPU Compositing', help: 'Disable Chromium GPU compositing. May help with rendering issues on some systems.' },
                 { key: 'logLevel', displayName: 'Log Level', help: 'Set the application log verbosity level.', options: [
                     { value: '', title: 'Default (Info)' },
                     { value: 'verbose', title: 'Verbose' },


### PR DESCRIPTION
The disable GPU compositing option is no longer needed in the settings panel.

Resolves https://github.com/jellyfin/jellyfin-desktop/issues/105 as users now have to manually modify the config for a potentially breaking change.