### PR TITLE
fix pathlib handling on posix systems

### DIFF
--- a/dev/download_cef.py
+++ b/dev/download_cef.py
@@ -172,7 +172,7 @@ def extract_tarball(tarball_path, extract_dir):
 
 def create_symlink(target_dir, link_path):
     """Create or update symlink (uses directory junction on Windows)."""
-    if link_path.is_symlink() or link_path.is_junction():
+    if link_path.is_symlink() or sys.platform == "win32" and link_path.is_junction():
         link_path.unlink()
     elif link_path.exists():
         shutil.rmtree(link_path)
@@ -304,7 +304,7 @@ def main():
     versioned_dir = args.output_dir / versioned_dir_name
 
     # Check if already at correct version
-    if cef_link.is_symlink() or cef_link.is_junction():
+    if cef_link.is_symlink() or sys.platform == "win32" and cef_link.is_junction():
         current_target = os.readlink(cef_link)
         if current_target == versioned_dir_name and versioned_dir.exists():
             log.info("Skipping, already set up")


### PR DESCRIPTION
`is_junction` is not available on PosixPath objects in python, causing a `AttributeError: 'PosixPath' object has no attribute 'is_junction'` when running `dev/download_cef.py` script on MacOS (and presumably linux as well).

Add a platform check before calling is_junction on the path objects in this dev script.