### PR TITLE
reveal macos menu bar when moving mouse to top of screen

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -600,6 +600,12 @@ int main(int argc, char* argv[]) {
 
     SDL_SetAppMetadata("Jellyfin Desktop", nullptr, "org.jellyfin.JellyfinDesktop");
 
+#ifdef __APPLE__
+    // Allow the macOS menu bar to be revealed by moving the mouse to the top
+    // of the screen during fullscreen
+    SDL_SetHint(SDL_HINT_VIDEO_MAC_FULLSCREEN_MENU_VISIBILITY, "1");
+#endif
+
     // SDL initialization with OpenGL (for main surface CEF overlay)
     if (!SDL_Init(SDL_INIT_VIDEO)) {
         LOG_ERROR(LOG_MAIN, "SDL_Init failed: %s", SDL_GetError());


### PR DESCRIPTION
Currently when you enter fullscreen from Jellyfin client, the top menu bar is never visible even if moving the mouse to the top of the screen. 

This sets the `SDL_HINT_VIDEO_MAC_FULLSCREEN_MENU_VISIBILITY` hint, allowing us to reveal the top menu bar when mousing to the top of the screen:

<img width="1512" height="146" alt="Screenshot 2026-04-04 at 8 28 29 PM" src="https://github.com/user-attachments/assets/1fe395dd-f428-44e9-a280-406aedf195d2" />
