### PR TITLE
Linux: prefer X11 and fall back to Wayland when DISPLAY is unavailable

### DIFF
--- a/src/cef/cef_app.cpp
+++ b/src/cef/cef_app.cpp
@@ -7,6 +7,7 @@
 #include "include/cef_frame.h"
 #include <cmath>
 #include <cstring>
+#include <cstdlib>
 #include "logging.h"
 
 void App::OnBeforeCommandLineProcessing(const CefString& process_type,
@@ -44,8 +45,18 @@ void App::OnBeforeCommandLineProcessing(const CefString& process_type,
 #endif
 
 #if !defined(__APPLE__) && !defined(_WIN32)
-    // Force X11 mode on Linux - Wayland OSR has scaling issues
-    command_line->AppendSwitchWithValue("ozone-platform", "x11");
+    // Prefer X11 mode on Linux - Wayland OSR has scaling issues; fall back to Wayland if X11 is unavailable.
+    bool x11_available = false;
+    if (const char* display = std::getenv("DISPLAY")) {
+        x11_available = display[0] != '\0';
+    }
+    const char* ozone_platform = x11_available ? "x11" : "wayland";
+    command_line->AppendSwitchWithValue("ozone-platform", ozone_platform);
+    if (!x11_available) {
+        LOG_INFO(LOG_CEF, "DISPLAY unavailable; falling back to Wayland (ozone-platform=wayland)");
+    } else {
+        LOG_INFO(LOG_CEF, "Using X11 backend (ozone-platform=x11)");
+    }
 #endif
 
     if (disable_gpu_compositing_) {


### PR DESCRIPTION
## Description
This PR updates Linux CEF backend selection for `ozone-platform`.

## Why
Some environments do not have X11 available (`DISPLAY` is unset). In those cases, forcing X11 can cause startup failures. This change keeps X11 as the preferred backend while adding an automatic Wayland fallback.

## Behavior
- On Linux, if `DISPLAY` is available:
  - use `ozone-platform=x11`
- On Linux, if `DISPLAY` is unavailable:
  - use `ozone-platform=wayland` (fallback)
- Logs were added to make backend selection explicit:
  - `Using X11 backend (ozone-platform=x11)`
  - `DISPLAY unavailable; falling back to Wayland (ozone-platform=wayland)`

## Scope
- No new CLI flags.
- No behavior change on macOS or Windows.

## Testing
- Built and launched on Linux.
- Verified with `DISPLAY` set: selects X11.
- Verified without `DISPLAY`: falls back to Wayland.
- Verified logs reflect selected backend path.