### PR TITLE
Fix cursor auto-hide by syncing SDL cursor visibility with jellyfin-web mouseIdle

### DIFF
--- a/src/cef/cef_app.cpp
+++ b/src/cef/cef_app.cpp
@@ -152,6 +152,7 @@ void App::OnContextCreated(CefRefPtr<CefBrowser> browser,
     jmpNative->SetValue("appExit", CefV8Value::CreateFunction("appExit", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
     jmpNative->SetValue("setSettingValue", CefV8Value::CreateFunction("setSettingValue", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
     jmpNative->SetValue("themeColor", CefV8Value::CreateFunction("themeColor", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
+    jmpNative->SetValue("setCursorVisibility", CefV8Value::CreateFunction("setCursorVisibility", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
     jmpNative->SetValue("setOsdVisible", CefV8Value::CreateFunction("setOsdVisible", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
     window->SetValue("jmpNative", jmpNative, V8_PROPERTY_ATTRIBUTE_READONLY);
 
@@ -515,6 +516,15 @@ bool NativeV8Handler::Execute(const CefString& name,
             std::string color = arguments[0]->GetStringValue().ToString();
             CefRefPtr<CefProcessMessage> msg = CefProcessMessage::Create("themeColor");
             msg->GetArgumentList()->SetString(0, color);
+            browser_->GetMainFrame()->SendProcessMessage(PID_BROWSER, msg);
+        }
+        return true;
+    }
+
+    if (name == "setCursorVisibility") {
+        if (arguments.size() >= 1 && arguments[0]->IsBool()) {
+            CefRefPtr<CefProcessMessage> msg = CefProcessMessage::Create("cursorVisibility");
+            msg->GetArgumentList()->SetBool(0, arguments[0]->GetBoolValue());
             browser_->GetMainFrame()->SendProcessMessage(PID_BROWSER, msg);
         }
         return true;

--- a/src/cef/cef_client.cpp
+++ b/src/cef/cef_client.cpp
@@ -225,6 +225,7 @@ Client::Client(int width, int height, PaintCallback on_paint, PlayerMessageCallb
                AcceleratedPaintCallback on_accel_paint, MenuOverlay* menu,
                CursorChangeCallback on_cursor_change, FullscreenChangeCallback on_fullscreen_change,
                PhysicalSizeCallback physical_size_cb, ThemeColorCallback on_theme_color,
+               CursorVisibilityCallback on_cursor_visibility,
                OsdVisibleCallback on_osd_visible,
                PopupShowCallback on_popup_show, PopupSizeCallback on_popup_size,
                AcceleratedPaintCallback on_accel_popup_paint
@@ -250,6 +251,7 @@ Client::Client(int width, int height, PaintCallback on_paint, PlayerMessageCallb
       menu_(menu), on_cursor_change_(std::move(on_cursor_change)),
       on_fullscreen_change_(std::move(on_fullscreen_change)),
       on_theme_color_(std::move(on_theme_color)),
+      on_cursor_visibility_(std::move(on_cursor_visibility)),
       on_osd_visible_(std::move(on_osd_visible)),
       physical_size_cb_(std::move(physical_size_cb)) {}
 
@@ -293,6 +295,14 @@ bool Client::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
         std::string color = args->GetString(0).ToString();
         if (on_theme_color_) {
             on_theme_color_(color);
+        }
+        return true;
+    }
+
+    if (name == "cursorVisibility") {
+        bool visible = args->GetBool(0);
+        if (on_cursor_visibility_) {
+            on_cursor_visibility_(visible);
         }
         return true;
     }

--- a/src/cef/cef_client.h
+++ b/src/cef/cef_client.h
@@ -48,6 +48,9 @@ using FullscreenChangeCallback = std::function<void(bool fullscreen)>;
 // Theme color change callback (web content updated <meta name="theme-color">)
 using ThemeColorCallback = std::function<void(const std::string& color)>;
 
+// Cursor visibility change callback (web content toggled mouse idle state)
+using CursorVisibilityCallback = std::function<void(bool visible)>;
+
 // OSD visibility change callback (video player OSD shown/hidden)
 using OsdVisibleCallback = std::function<void(bool visible)>;
 
@@ -87,6 +90,7 @@ public:
            FullscreenChangeCallback on_fullscreen_change = nullptr,
            PhysicalSizeCallback physical_size_cb = nullptr,
            ThemeColorCallback on_theme_color = nullptr,
+           CursorVisibilityCallback on_cursor_visibility = nullptr,
            OsdVisibleCallback on_osd_visible = nullptr,
            PopupShowCallback on_popup_show = nullptr,
            PopupSizeCallback on_popup_size = nullptr,
@@ -220,6 +224,7 @@ private:
     CursorChangeCallback on_cursor_change_;
     FullscreenChangeCallback on_fullscreen_change_;
     ThemeColorCallback on_theme_color_;
+    CursorVisibilityCallback on_cursor_visibility_;
     OsdVisibleCallback on_osd_visible_;
     PhysicalSizeCallback physical_size_cb_;
     float scale_override_ = 0.0f;  // 0 = use physical/logical ratio

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1139,13 +1139,27 @@ int main(int argc, char* argv[]) {
 
     // Cursor state
     SDL_Cursor* current_cursor = nullptr;
-    // Blank cursor for hiding (1x1 transparent) - used when CEF reports CT_NONE
+    bool cursor_visible = true;
+    bool cursor_hidden_by_content = false;
+    // Blank cursor for explicit hiding (mouseIdle) or content-requested cursor:none
     SDL_Cursor* blank_cursor = nullptr;
     if (SDL_Surface* s = SDL_CreateSurface(1, 1, SDL_PIXELFORMAT_ARGB8888)) {
         SDL_memset(s->pixels, 0, s->pitch * s->h);
         blank_cursor = SDL_CreateColorCursor(s, 0, 0);
         SDL_DestroySurface(s);
     }
+    auto applyCursor = [&]() {
+        if ((cursor_hidden_by_content || !cursor_visible) && blank_cursor) {
+            SDL_SetCursor(blank_cursor);
+            return;
+        }
+        if (!current_cursor) {
+            current_cursor = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_DEFAULT);
+        }
+        if (current_cursor) {
+            SDL_SetCursor(current_cursor);
+        }
+    };
 
     // Physical pixel size callback for HiDPI support
     // Use SDL_GetWindowSizeInPixels - reliable after first frame
@@ -1312,21 +1326,15 @@ int main(int argc, char* argv[]) {
 #endif
         &menu,
         [&](cef_cursor_type_t type) {
-            if (type == CT_NONE && blank_cursor) {
-                // Web content set cursor: none (e.g. mouseIdle during video playback)
-                if (current_cursor) {
-                    SDL_DestroyCursor(current_cursor);
-                    current_cursor = nullptr;
-                }
-                SDL_SetCursor(blank_cursor);
-            } else if (type != CT_NONE) {
+            cursor_hidden_by_content = (type == CT_NONE);
+            if (type != CT_NONE) {
                 SDL_SystemCursor sdl_type = cefCursorToSDL(type);
                 if (current_cursor) {
                     SDL_DestroyCursor(current_cursor);
                 }
                 current_cursor = SDL_CreateSystemCursor(sdl_type);
-                SDL_SetCursor(current_cursor);
             }
+            applyCursor();
         },
         [&](bool fullscreen) {
             // Web content requested fullscreen change via JS Fullscreen API
@@ -1350,6 +1358,11 @@ int main(int argc, char* argv[]) {
         [&cmd_mutex, &pending_cmds, &wakeMainLoop](const std::string& color) {
             std::lock_guard<std::mutex> lock(cmd_mutex);
             pending_cmds.push_back({"theme_color", color, 0, 0.0});
+            wakeMainLoop();
+        },
+        [&cmd_mutex, &pending_cmds, &wakeMainLoop](bool visible) {
+            std::lock_guard<std::mutex> lock(cmd_mutex);
+            pending_cmds.push_back({"cursor_visible", "", visible ? 1 : 0, 0.0});
             wakeMainLoop();
         },
 #ifdef __APPLE__
@@ -2166,6 +2179,9 @@ int main(int argc, char* argv[]) {
                     } else {
                         pending_titlebar_color = cmd.url;
                     }
+                } else if (cmd.cmd == "cursor_visible") {
+                    cursor_visible = cmd.intArg != 0;
+                    applyCursor();
 #ifdef __APPLE__
                 } else if (cmd.cmd == "osd_visible" && transparent_titlebar) {
                     setMacTrafficLightsVisible(cmd.intArg != 0);

--- a/src/web/native-shim.js
+++ b/src/web/native-shim.js
@@ -239,6 +239,11 @@
             openExternalUrl(url) {
                 window.open(url, '_blank');
             },
+            setCursorVisibility(visible) {
+                if (window.jmpNative && window.jmpNative.setCursorVisibility) {
+                    window.jmpNative.setCursorVisibility(!!visible);
+                }
+            },
             exit() {
                 if (window.jmpNative) window.jmpNative.appExit();
             },
@@ -268,7 +273,9 @@
             executeActions() {}
         },
         window: {
-            setCursorVisibility(visible) {}
+            setCursorVisibility(visible) {
+                window.api.system.setCursorVisibility(visible);
+            }
         }
     };
 
@@ -411,11 +418,24 @@
     }
 
     document.addEventListener('DOMContentLoaded', () => {
-        // Inject CSS to hide cursor when jellyfin-web signals mouse idle.
-        // jellyfin-web adds 'mouseIdle' to body after inactivity during video playback.
-        // This CSS makes CEF report CT_NONE so the native side can hide the OS cursor.
+        // Let jellyfin-web own cursor auto-hide during playback.
+        // It toggles body.mouseIdle when the video OSD should hide/show.
+        const syncCursorVisibility = () => {
+            window.api.system.setCursorVisibility(!document.body.classList.contains('mouseIdle'));
+        };
+        const cursorObserver = new MutationObserver((mutations) => {
+            for (const mutation of mutations) {
+                if (mutation.attributeName === 'class') {
+                    syncCursorVisibility();
+                    break;
+                }
+            }
+        });
+        cursorObserver.observe(document.body, { attributes: true, attributeFilter: ['class'] });
+        syncCursorVisibility();
+
         const style = document.createElement('style');
-        let css = 'body.mouseIdle, body.mouseIdle * { cursor: none !important; }';
+        let css = '';
 
         // macOS: offset UI elements so traffic lights don't overlap content
         if (navigator.platform.startsWith('Mac') && jmpInfo.settings.advanced.transparentTitlebar) {


### PR DESCRIPTION
**This adapts the old Qt cursor fix from [jellyfin-desktop-qt commit 8009e81](https://github.com/jellyfin-archive/jellyfin-desktop-qt/commit/8009e817a604d924bed583785ab36b8ca571a0f5) to the current CEF/SDL client.**

**Fixes this issue: #18**

Instead of relying on `body.mouseIdle` forcing `cursor: none`, then waiting for CEF to emit `CT_NONE`, the web layer now forwards cursor visibility directly to the native side. The SDL layer keeps cursor visibility separate from cursor shape, so the previous cursor is restored immediately when activity resumes.

## Why

The current implementation can intermittently fail to hide the cursor during video playback because it depends on CEF cursor-change events being emitted when only the `mouseIdle` class changes.

## Changes

- add a native `setCursorVisibility` bridge
- observe `body.mouseIdle` directly in `native-shim.js`
- stop using injected `cursor: none` as the auto-hide trigger
- keep SDL cursor visibility separate from cursor shape restoration

## Testing

https://github.com/user-attachments/assets/f257654e-7fdf-46ed-9c65-0eb7716ab7f4