### PR TITLE
Strip build-host paths from system CEF wrapper

### DIFF
--- a/cmake/FindCEF.cmake
+++ b/cmake/FindCEF.cmake
@@ -255,7 +255,9 @@ add_subdirectory(libcef_dll)
 ")
         execute_process(
             COMMAND ${CMAKE_COMMAND} -B build -DCMAKE_BUILD_TYPE=Release
-                "-DCMAKE_C_FLAGS=-fPIC" "-DCMAKE_CXX_FLAGS=-fPIC" -DCMAKE_CXX_STANDARD=20
+                "-DCMAKE_C_FLAGS=-fPIC -ffile-prefix-map=${_WRAPPER_SRC_DIR}=cef_wrapper"
+                "-DCMAKE_CXX_FLAGS=-fPIC -ffile-prefix-map=${_WRAPPER_SRC_DIR}=cef_wrapper"
+                -DCMAKE_CXX_STANDARD=20
             WORKING_DIRECTORY "${_WRAPPER_SRC_DIR}"
             RESULT_VARIABLE _WRAPPER_CONFIG_RESULT
         )


### PR DESCRIPTION
## Summary
- Use `-ffile-prefix-map` when compiling the system CEF wrapper so `__FILE__` macros expand to `cef_wrapper/...` instead of absolute build-host paths
- Without this, error messages (e.g. API hash mismatch assertions) leak the build machine's filesystem paths, which is confusing when running on a different host

## Test plan
- [x] Built with system CEF, triggered a CEF assertion — path shows `cef_wrapper/libcef_dll/wrapper/libcef_dll_wrapper.cc` instead of the build-host absolute path