### PR TITLE
Fix external subtitles not being selected immediately, refactor external sub handling

### DIFF
--- a/src/browser/web_browser.cpp
+++ b/src/browser/web_browser.cpp
@@ -168,6 +168,14 @@ bool WebBrowser::handleMessage(const std::string& name,
         std::string url = args->GetString(0).ToString();
         LOG_INFO(LOG_CEF, "playerAddSubtitle: {}", url.c_str());
         g_mpv.SubAdd(url);
+    } else if (name == "playerAddSubtitlesAndSelect") {
+        int64_t sid = args->GetInt(0);
+        std::vector<std::string> urls;
+        for (size_t i = 1; i < args->GetSize(); i++) {
+            urls.push_back(args->GetString(i).ToString());
+        }
+        LOG_INFO(LOG_CEF, "playerAddSubtitlesAndSelect: sid=%d urls=%zu", (int)sid, urls.size());
+        g_mpv.AddSubtitlesAndSelect(urls, sid, g_sub_add_pending, g_sub_add_deferred_sid);
     } else if (name == "playerSetAudio") {
         g_mpv.SetAudioTrack(getIntArg(args, 0));
     } else if (name == "playerSetAudioDelay") {

--- a/src/common.h
+++ b/src/common.h
@@ -26,6 +26,10 @@ constexpr Color kBgColor{0x101010};
 // Playback background color (behind video).
 constexpr Color kVideoBgColor{0x000000};
 
+// reply_userdata base for tracked sub-add commands (see MpvHandle::AddSubtitlesAndSelect)
+static constexpr uint64_t SUB_ADD_REPLY_BASE = 0x12345678;
+
+
 #include "platform/platform.h"
 #include "mpv/handle.h"
 #include "player/media_session.h"
@@ -33,6 +37,8 @@ constexpr Color kVideoBgColor{0x000000};
 class WakeEvent;
 
 extern MpvHandle g_mpv;
+extern std::atomic<int> g_sub_add_pending;
+extern std::atomic<int64_t> g_sub_add_deferred_sid;
 extern Platform g_platform;
 // Cross-thread state: written from mpv event loop / CEF IPC thread,
 // read from input and rendering threads.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,6 +58,8 @@
 // =====================================================================
 
 MpvHandle g_mpv;
+std::atomic<int> g_sub_add_pending{0};
+std::atomic<int64_t> g_sub_add_deferred_sid{0};
 std::atomic<bool> g_shutting_down{false};
 WakeEvent g_shutdown_event;
 
@@ -181,6 +183,11 @@ static void mpv_digest_thread() {
                 g_platform.set_fullscreen(me.flag);
             }
             publish(me);
+        }
+
+        if (ev->event_id == MPV_EVENT_COMMAND_REPLY &&
+            ev->reply_userdata == SUB_ADD_REPLY_BASE) {
+            MpvHandle::OnSubAddReply(g_mpv, g_sub_add_pending, g_sub_add_deferred_sid);
         }
     }
 }

--- a/src/mpv/handle.h
+++ b/src/mpv/handle.h
@@ -98,7 +98,8 @@ public:
     void SetAudioTrack(int64_t id)       { SetPropertyIntAsync("aid", id); }
     void SetSubtitleTrack(int64_t id)    { SetPropertyIntAsync("sid", id); }
     void SetAudioDelay(double secs)      { SetPropertyDoubleAsync("audio-delay", secs); }
-    void SetStartPosition(double secs)   { SetPropertyDoubleAsync("start", secs); }    void SubAdd(const std::string& url)   { CommandAsync({"sub-add", url, "select"}); }
+    void SetStartPosition(double secs)   { SetPropertyDoubleAsync("start", secs); }    
+    void SubAdd(const std::string& url)  { CommandAsync({"sub-add", url, "select"}); }
     // mpv track selection: -1 = auto, 0 = disable, 1+ = specific track
     static constexpr int64_t kTrackAuto    = -1;
     static constexpr int64_t kTrackDisable =  0;

--- a/src/mpv/handle.h
+++ b/src/mpv/handle.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#include "common.h"
 #include <mpv/client.h>
 #include <string>
 #include <unordered_map>
 #include <vector>
 #include <cstring>
+#include <atomic>
 
 #include "logging.h"
 #include "platform/display_backend.h"
@@ -99,7 +101,40 @@ public:
     void SetSubtitleTrack(int64_t id)    { SetPropertyIntAsync("sid", id); }
     void SetAudioDelay(double secs)      { SetPropertyDoubleAsync("audio-delay", secs); }
     void SetStartPosition(double secs)   { SetPropertyDoubleAsync("start", secs); }    
-    void SubAdd(const std::string& url)  { CommandAsync({"sub-add", url, "select"}); }
+    void SubAdd(const std::string& url)  { CommandAsync({"sub-add", url, "auto"}); } // "auto" = don't select the subtitle after adding
+
+    // Tracked sub-add: adds external subtitles and defers subtitle track selection
+    // until all sub-add commands have finished. This avoid race conditions where MPV tries to select a subtitle before it's added,
+    // even though the methods were called in the correct order.
+    void AddSubtitlesAndSelect(const std::vector<std::string>& urls, int64_t target_sid,
+                               std::atomic<int>& pending, std::atomic<int64_t>& deferred_sid) {
+        if (urls.empty()) {
+            SetSubtitleTrack(target_sid);
+            return;
+        }
+        deferred_sid.store(target_sid, std::memory_order_relaxed);
+        pending.store(static_cast<int>(urls.size()), std::memory_order_release);
+        for (const auto& url : urls) {
+            std::vector<std::string> cmd = {"sub-add", url, "auto"}; // "auto" because we don't want to select the subtitle here
+            const char** c = BuildCommandArray(cmd);
+            if (c == nullptr) continue;
+            mpv_command_async(handle_, SUB_ADD_REPLY_BASE, c);
+            delete[] c;
+        }
+    }
+
+    // Called from the mpv digest thread when MPV_EVENT_COMMAND_REPLY arrives
+    // with reply_userdata == SUB_ADD_REPLY_BASE.
+    static void OnSubAddReply(MpvHandle& mpv,
+                              std::atomic<int>& pending, std::atomic<int64_t>& deferred_sid) {
+        if (pending.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+            int64_t sid = deferred_sid.exchange(0, std::memory_order_relaxed);
+            if (sid != 0) {
+                mpv.SetSubtitleTrack(sid);
+            }
+        }
+    }
+
     // mpv track selection: -1 = auto, 0 = disable, 1+ = specific track
     static constexpr int64_t kTrackAuto    = -1;
     static constexpr int64_t kTrackDisable =  0;

--- a/src/web/mpv-video-player.js
+++ b/src/web/mpv-video-player.js
@@ -18,6 +18,28 @@
         return mediaStreams.find(s => s.Index === index) || null;
     }
 
+    // Extract subs from streams and add them to a (stream index) -> (mpv sid) map.
+    // We will add all external subs to MPV after the player has started playing, so we need this map to know which mpv sid corresponds to each sub.
+    function createSubStreamMap(mediaStreams) {
+        const map = {};
+        let internalSubCount = 0;
+        // for every internal sub, add a mapping of its stream index to its mpv sid (which is the count of internal subs up to and including that sub)
+        for (i = 0; i < mediaStreams.length; i++) {
+            const s = mediaStreams[i];
+            if (s.Type === 'Subtitle' && !s.IsExternal) {
+                map[s.Index] = { mpvSid: ++internalSubCount, url: null };
+            }
+        }
+        // for every external sub with a valid url, add a mapping of its stream index to its mpv sid
+        mediaStreams.forEach(s => {
+            if (s.Type === 'Subtitle' && s.IsExternal && s.DeliveryUrl) {
+                // mpv sid for this sub will be the count of internal subs + 1-based index of this external sub among all subs
+                map[s.Index] = { mpvSid: ++internalSubCount, url: s.DeliveryUrl };
+            }
+        });
+        return map;
+    }
+
     class mpvVideoPlayer {
         constructor({ events, loading, appRouter, globalize, appHost, appSettings, confirm, dashboard }) {
             this.events = events;
@@ -58,6 +80,7 @@
             this._timeUpdated = false;
             this._currentPlayOptions = undefined;
             this._endedPending = false;
+            this._subStreamMap = {}; // holds mapping of Jellyfin subtitle stream index to mpv sid
 
             // Set up video-specific event handlers
             this._core.handlers.onPlaying = () => {
@@ -150,6 +173,10 @@
                 const defaultAudioIdx = options.mediaSource.DefaultAudioStreamIndex ?? -1;
                 const defaultSubIdx = options.mediaSource.DefaultSubtitleStreamIndex ?? -1;
 
+                this._subStreamMap = createSubStreamMap(streams);
+                console.log('[Media] [MPV] MediaStreams:', streams);
+                console.log('[Media] [MPV] subStreamMap:', this._subStreamMap);
+
                 // Convert audio index from Jellyfin global stream index to mpv 1-based audio track index
                 let audioParam = MpvPlayerCore.TRACK_DISABLE;
                 if (defaultAudioIdx >= 0) {
@@ -157,29 +184,18 @@
                     audioParam = relIdx != null ? relIdx : MpvPlayerCore.TRACK_AUTO;
                 }
 
-                // Convert subtitle index to relative
-                let subParam = MpvPlayerCore.TRACK_DISABLE;
-                let externalSubUrl = null;
-                if (defaultSubIdx >= 0) {
-                    const subStream = getStreamByIndex(streams, defaultSubIdx);
-                    if (subStream && subStream.DeliveryMethod === 'External' && subStream.DeliveryUrl) {
-                        externalSubUrl = subStream.DeliveryUrl;
-                    } else {
-                        const relIdx = getRelativeIndexByType(streams, defaultSubIdx, 'Subtitle');
-                        subParam = relIdx != null ? relIdx : MpvPlayerCore.TRACK_AUTO;
-                    }
-                }
-
+                let externalSubs = streams.filter(s => s.Type === 'Subtitle' && s.IsExternal && s.DeliveryUrl).map(s => s.DeliveryUrl);
                 window.api.player.setAspectMode(this.getAspectRatio());
                 window.api.player.load(val,
                     { startMilliseconds: ms, autoplay: true },
                     { type: 'video', metadata: options.item },
                     audioParam,
-                    subParam,
+                    MpvPlayerCore.TRACK_DISABLE, // we'll let the callback below select the subtitle track after adding the external subs
                     () => {
-                        if (externalSubUrl) {
-                            window.api.player.addSubtitleStream(externalSubUrl);
-                        }
+                        // add external subs and select the default subtitle atomically —
+                        // mpv defers the sid selection until all sub-add commands complete.
+                        const targetSid = this._subStreamMap[defaultSubIdx]?.mpvSid || MpvPlayerCore.TRACK_DISABLE;
+                        window.api.player.addSubtitlesAndSelect(externalSubs, targetSid);
                         resolve();
                     });
             });
@@ -190,14 +206,7 @@
                 window.api.player.setSubtitleStream(MpvPlayerCore.TRACK_DISABLE);
                 return;
             }
-            const streams = this._currentPlayOptions?.mediaSource?.MediaStreams || [];
-            const stream = getStreamByIndex(streams, index);
-            if (stream && stream.DeliveryMethod === 'External' && stream.DeliveryUrl) {
-                window.api.player.addSubtitleStream(stream.DeliveryUrl);
-                return;
-            }
-            const relIdx = getRelativeIndexByType(streams, index, 'Subtitle');
-            window.api.player.setSubtitleStream(relIdx != null ? relIdx : MpvPlayerCore.TRACK_DISABLE);
+            window.api.player.setSubtitleStream(this._subStreamMap[index]?.mpvSid || MpvPlayerCore.TRACK_DISABLE);
         }
 
         setSecondarySubtitleStreamIndex(index) {}

--- a/src/web/mpv-video-player.js
+++ b/src/web/mpv-video-player.js
@@ -176,11 +176,12 @@
                     { type: 'video', metadata: options.item },
                     audioParam,
                     subParam,
-                    resolve);
-
-                if (externalSubUrl) {
-                    window.api.player.addSubtitleStream(externalSubUrl);
-                }
+                    () => {
+                        if (externalSubUrl) {
+                            window.api.player.addSubtitleStream(externalSubUrl);
+                        }
+                        resolve();
+                    });
             });
         }
 

--- a/src/web/mpv-video-player.js
+++ b/src/web/mpv-video-player.js
@@ -173,10 +173,6 @@
                 const defaultAudioIdx = options.mediaSource.DefaultAudioStreamIndex ?? -1;
                 const defaultSubIdx = options.mediaSource.DefaultSubtitleStreamIndex ?? -1;
 
-                this._subStreamMap = createSubStreamMap(streams);
-                console.log('[Media] [MPV] MediaStreams:', streams);
-                console.log('[Media] [MPV] subStreamMap:', this._subStreamMap);
-
                 // Convert audio index from Jellyfin global stream index to mpv 1-based audio track index
                 let audioParam = MpvPlayerCore.TRACK_DISABLE;
                 if (defaultAudioIdx >= 0) {
@@ -184,7 +180,9 @@
                     audioParam = relIdx != null ? relIdx : MpvPlayerCore.TRACK_AUTO;
                 }
 
+                this._subStreamMap = createSubStreamMap(streams);
                 let externalSubs = streams.filter(s => s.Type === 'Subtitle' && s.IsExternal && s.DeliveryUrl).map(s => s.DeliveryUrl);
+
                 window.api.player.setAspectMode(this.getAspectRatio());
                 window.api.player.load(val,
                     { startMilliseconds: ms, autoplay: true },
@@ -192,7 +190,7 @@
                     audioParam,
                     MpvPlayerCore.TRACK_DISABLE, // we'll let the callback below select the subtitle track after adding the external subs
                     () => {
-                        // add external subs and select the default subtitle atomically —
+                        // add external subs and then select the default subtitle track
                         // mpv defers the sid selection until all sub-add commands complete.
                         const targetSid = this._subStreamMap[defaultSubIdx]?.mpvSid || MpvPlayerCore.TRACK_DISABLE;
                         window.api.player.addSubtitlesAndSelect(externalSubs, targetSid);

--- a/src/web/native-shim.js
+++ b/src/web/native-shim.js
@@ -233,6 +233,10 @@
                 console.log('[Media] player.addSubtitleStream:', url);
                 if (window.jmpNative) window.jmpNative.playerAddSubtitle(url);
             },
+            addSubtitlesAndSelect(urls, sid) {
+                console.log('[Media] player.addSubtitlesAndSelect: sid=' + sid + ' urls=' + urls.length);
+                if (window.jmpNative) window.jmpNative.playerAddSubtitlesAndSelect(sid, ...urls);
+            },
             setAudioStream(index) {
                 console.log('[Media] player.setAudioStream:', index);
                 if (window.jmpNative) window.jmpNative.playerSetAudio(index);


### PR DESCRIPTION
this kind of feels like a hack but fixes what I described here: https://github.com/jellyfin/jellyfin-desktop/pull/146#discussion_r3074747759. 

To be followed up with a proper solution: https://github.com/jellyfin/jellyfin-desktop/pull/146#issuecomment-4238444407

----

I decided to add the proper solution to this PR as well (second commit). How it works now:

1. At initialization, we create a map of stream index to mpv sid, which holds both internal and external subs.
2. We then load the player, without any subtitles enabled.
3. Once the player is actually playing, we add all external subtitles and select the default subtitle.

<details><summary>More info on the flow</summary>
<p>

Here's how the media streams look from the web side at initialization:

<img width="872" height="652" alt="image" src="https://github.com/user-attachments/assets/ff2d96a9-0cb9-4c13-8592-c6bc101f7557" />

Here's what MPV has:
```
23:33:11.039 [mpv] DEBUG: cplayer: ● Video  --vid=1  --vlang=en       (hevc 1920x1080 23.976 fps) [default original]
23:33:11.039 [mpv] DEBUG: cplayer: ● Audio  --aid=1  --alang=en       (eac3 6ch 48000 Hz) [default original]
23:33:11.039 [mpv] DEBUG: cplayer: ○ Subs   --sid=1  --slang=en       (subrip) [original]
23:33:11.039 [mpv] DEBUG: cplayer: ○ Subs   --sid=2  --slang=en       'SDH' (subrip) [hearing-impaired original]
23:33:11.039 [mpv] DEBUG: cplayer: ○ Subs   --sid=3  --slang=ar       (subrip)
23:33:11.040 [mpv] DEBUG: cplayer: ○ Subs   --sid=4  --slang=cs       (subrip)
23:33:11.040 [mpv] DEBUG: cplayer: ○ Subs   --sid=5  --slang=da       (subrip)
23:33:11.040 [mpv] DEBUG: cplayer: ○ Subs   --sid=6  --slang=de       (subrip)
23:33:11.040 [mpv] DEBUG: cplayer: ○ Subs   --sid=7  --slang=el       (subrip)
23:33:11.040 [mpv] DEBUG: cplayer: ○ Subs   --sid=8  --slang=es-419   'Latin American' (subrip)
23:33:11.040 [mpv] DEBUG: cplayer: ○ Subs   --sid=9  --slang=es-ES    (subrip)
23:33:11.040 [mpv] DEBUG: cplayer: ○ Subs   --sid=10 --slang=fi       (subrip)
23:33:11.040 [mpv] DEBUG: cplayer: ○ Subs   --sid=11 --slang=fil      (subrip)
23:33:11.040 [mpv] DEBUG: cplayer: ○ Subs   --sid=12 --slang=fr       (subrip)
23:33:11.040 [mpv] DEBUG: cplayer: ○ Subs   --sid=13 --slang=he       (subrip)
23:33:11.040 [mpv] DEBUG: cplayer: ○ Subs   --sid=14 --slang=hr       (subrip)
23:33:11.040 [mpv] DEBUG: cplayer: ○ Subs   --sid=15 --slang=hu       (subrip)
23:33:11.040 [mpv] DEBUG: cplayer: ○ Subs   --sid=16 --slang=id       (subrip)
23:33:11.040 [mpv] DEBUG: cplayer: ○ Subs   --sid=17 --slang=it       (subrip)
23:33:11.040 [mpv] DEBUG: cplayer: ○ Subs   --sid=18 --slang=ja       (subrip)
23:33:11.040 [mpv] DEBUG: cplayer: ○ Subs   --sid=19 --slang=ko       (subrip)
23:33:11.040 [mpv] DEBUG: cplayer: ○ Subs   --sid=20 --slang=ms       (subrip)
23:33:11.040 [mpv] DEBUG: cplayer: ○ Subs   --sid=21 --slang=nb       (subrip)
23:33:11.040 [mpv] DEBUG: cplayer: ○ Subs   --sid=22 --slang=nl       (subrip)
23:33:11.040 [mpv] DEBUG: cplayer: ○ Subs   --sid=23 --slang=pl       (subrip)
23:33:11.040 [mpv] DEBUG: cplayer: ○ Subs   --sid=24 --slang=pt-BR    'Brazilian' (subrip)
23:33:11.040 [mpv] DEBUG: cplayer: ○ Subs   --sid=25 --slang=pt-PT    (subrip)
23:33:11.040 [mpv] DEBUG: cplayer: ○ Subs   --sid=26 --slang=ro       (subrip)
23:33:11.040 [mpv] DEBUG: cplayer: ○ Subs   --sid=27 --slang=ru       (subrip)
23:33:11.040 [mpv] DEBUG: cplayer: ○ Subs   --sid=28 --slang=sv       (subrip)
23:33:11.040 [mpv] DEBUG: cplayer: ○ Subs   --sid=29 --slang=th       (subrip)
23:33:11.040 [mpv] DEBUG: cplayer: ○ Subs   --sid=30 --slang=tr       (subrip)
23:33:11.040 [mpv] DEBUG: cplayer: ○ Subs   --sid=31 --slang=uk       (subrip)
23:33:11.040 [mpv] DEBUG: cplayer: ○ Subs   --sid=32 --slang=vi       (subrip)
23:33:11.040 [mpv] DEBUG: cplayer: ○ Subs   --sid=33 --slang=zh-Hans  'Simplified' (subrip)
23:33:11.040 [mpv] DEBUG: cplayer: ○ Subs   --sid=34 --slang=zh-Hant  'Traditional' (subrip)
```

As you can see, it doesn't have the external sub (yet). 
So we create the map from stream ID to MPV SID:

<img width="638" height="612" alt="image" src="https://github.com/user-attachments/assets/cdb8a350-520a-4969-8b61-2e15721eb7b8" />

Which now has a (id=0 -> sid 35) pair added. sid 35 is the new sub we'll add to MPV using `sub-add`.

When we do this, this log appears in the client logs:
```
23:33:11.236 [mpv] DEBUG: cplayer:  ○ Subs   --sid=35                  'Stream.srt?ApiKey=XXX' (subrip) [external]
```
We can now select this sid on MPV's side.

</p>
</details> 

**AI disclaimer**: I used Opus 4.6 to help with implementing the AddSubtitlesAndSelect method. In the load functions' callback (`mpv-video-player.ts:197-202`), I needed a way to wait until the subs were added with sub-add before selecting the track because I was getting race conditions: the default sub was being selected before it was done adding it.

This description was not written with AI.