### PR TITLE
Separate CEF from business logic; fix fullscreen on episode transitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,6 +458,8 @@ if(WIN32)
         src/cef/cef_app.cpp
         src/cef/cef_client.cpp
         src/cef/resource_handler.cpp
+        src/browser/web_browser.cpp
+        src/browser/overlay_browser.cpp
         src/input/dispatch.cpp
         src/input/hotkeys.cpp
         src/cjson/cJSON.c
@@ -473,6 +475,8 @@ else()
         src/cef/cef_app.cpp
         src/cef/cef_client.cpp
         src/cef/resource_handler.cpp
+        src/browser/web_browser.cpp
+        src/browser/overlay_browser.cpp
         src/input/dispatch.cpp
         src/input/hotkeys.cpp
         src/single_instance.cpp

--- a/src/browser/browsers.h
+++ b/src/browser/browsers.h
@@ -1,0 +1,7 @@
+#pragma once
+
+class WebBrowser;
+class OverlayBrowser;
+
+extern WebBrowser* g_web_browser;
+extern OverlayBrowser* g_overlay_browser;

--- a/src/browser/overlay_browser.cpp
+++ b/src/browser/overlay_browser.cpp
@@ -1,0 +1,143 @@
+#include "overlay_browser.h"
+#include "web_browser.h"
+#include "../common.h"
+#include "../settings.h"
+#include "../logging.h"
+#include "../titlebar_color.h"
+#include "../input/dispatch.h"
+#include "include/cef_urlrequest.h"
+
+constexpr float OVERLAY_FADE_DELAY_SEC    = 1.0f;
+constexpr float OVERLAY_FADE_DURATION_SEC = 0.25f;
+
+// =====================================================================
+// Connectivity check
+// =====================================================================
+
+class ConnectivityURLRequestClient : public CefURLRequestClient {
+public:
+    ConnectivityURLRequestClient(CefRefPtr<CefBrowser> browser, const std::string& originalUrl)
+        : browser_(browser), original_url_(originalUrl) {}
+
+    void OnRequestComplete(CefRefPtr<CefURLRequest> request) override {
+        auto status = request->GetRequestStatus();
+        auto response = request->GetResponse();
+        bool success = false;
+        std::string resolved_url = original_url_;
+
+        if (status == UR_SUCCESS && response && response->GetStatus() == 200) {
+            if (response_body_.find("\"Id\"") != std::string::npos) {
+                success = true;
+                resolved_url = response->GetURL().ToString();
+                size_t pos = resolved_url.find("/System/Info/Public");
+                if (pos != std::string::npos)
+                    resolved_url = resolved_url.substr(0, pos);
+            }
+        }
+
+        auto frame = browser_ ? browser_->GetMainFrame() : nullptr;
+        if (frame) {
+            CefRefPtr<CefProcessMessage> msg = CefProcessMessage::Create("serverConnectivityResult");
+            msg->GetArgumentList()->SetString(0, original_url_);
+            msg->GetArgumentList()->SetBool(1, success);
+            msg->GetArgumentList()->SetString(2, resolved_url);
+            frame->SendProcessMessage(PID_RENDERER, msg);
+        }
+    }
+
+    void OnUploadProgress(CefRefPtr<CefURLRequest>, int64_t, int64_t) override {}
+    void OnDownloadProgress(CefRefPtr<CefURLRequest>, int64_t, int64_t) override {}
+    void OnDownloadData(CefRefPtr<CefURLRequest>, const void* data, size_t len) override {
+        response_body_.append(static_cast<const char*>(data), len);
+    }
+    bool GetAuthCredentials(bool, const CefString&, int, const CefString&, const CefString&,
+                            CefRefPtr<CefAuthCallback>) override { return false; }
+
+private:
+    CefRefPtr<CefBrowser> browser_;
+    std::string original_url_;
+    std::string response_body_;
+    IMPLEMENT_REFCOUNTING(ConnectivityURLRequestClient);
+};
+
+// =====================================================================
+// Helpers
+// =====================================================================
+
+static void applySettingValue(const std::string& section, const std::string& key, const std::string& value) {
+    auto& s = Settings::instance();
+    if (key == "hwdec") s.setHwdec(value);
+    else if (key == "audioPassthrough") s.setAudioPassthrough(value);
+    else if (key == "audioExclusive") s.setAudioExclusive(value == "true");
+    else if (key == "audioChannels") s.setAudioChannels(value);
+    else if (key == "logLevel") s.setLogLevel(value);
+    else LOG_WARN(LOG_CEF, "Unknown setting key: %s.%s", section.c_str(), key.c_str());
+    s.saveAsync();
+}
+
+// =====================================================================
+// OverlayBrowser
+// =====================================================================
+
+OverlayBrowser::OverlayBrowser(RenderTarget target, WebBrowser& main_browser)
+    : client_(new CefLayer(target))
+    , main_browser_(main_browser)
+{
+    client_->setMessageHandler([this](const std::string& name,
+                                      CefRefPtr<CefListValue> args,
+                                      CefRefPtr<CefBrowser> browser) {
+        return handleMessage(name, args, browser);
+    });
+    client_->setCreatedCallback([](CefRefPtr<CefBrowser> browser) {
+        // Overlay wins input whenever it's created.
+        input::set_active_browser(browser);
+    });
+}
+
+bool OverlayBrowser::handleMessage(const std::string& name,
+                                   CefRefPtr<CefListValue> args,
+                                   CefRefPtr<CefBrowser> browser) {
+    if (name == "loadServer") {
+        std::string url = args->GetString(0).ToString();
+        LOG_INFO(LOG_CEF, "Overlay: loadServer %s", url.c_str());
+        Settings::instance().setServerUrl(url);
+        Settings::instance().saveAsync();
+        // Navigate main browser to the server
+        if (main_browser_.browser())
+            main_browser_.browser()->GetMainFrame()->LoadURL(url);
+        // Hand input back to the main browser
+        input::set_active_browser(main_browser_.browser());
+        // Close after fade
+        CefRefPtr<CefBrowser> overlay_browser = browser;
+        g_platform.fade_overlay(OVERLAY_FADE_DELAY_SEC, OVERLAY_FADE_DURATION_SEC,
+            []() {
+                g_mpv.SetBackgroundColor(kVideoBgColor.hex);
+                if (g_titlebar_color) g_titlebar_color->onOverlayDismissed();
+            },
+            [overlay_browser]() {
+                if (overlay_browser)
+                    overlay_browser->GetHost()->CloseBrowser(false);
+            });
+    } else if (name == "saveServerUrl") {
+        std::string url = args->GetString(0).ToString();
+        Settings::instance().setServerUrl(url);
+        Settings::instance().saveAsync();
+    } else if (name == "setSettingValue") {
+        std::string section = args->GetString(0).ToString();
+        std::string key = args->GetString(1).ToString();
+        std::string value = args->GetString(2).ToString();
+        applySettingValue(section, key, value);
+    } else if (name == "checkServerConnectivity") {
+        std::string url = args->GetString(0).ToString();
+        if (url.find("://") == std::string::npos) url = "http://" + url;
+        if (!url.empty() && url.back() == '/') url.pop_back();
+        std::string check_url = url + "/System/Info/Public";
+        CefRefPtr<CefRequest> request = CefRequest::Create();
+        request->SetURL(check_url);
+        request->SetMethod("GET");
+        CefURLRequest::Create(request, new ConnectivityURLRequestClient(browser, url), nullptr);
+    } else {
+        return false;
+    }
+    return true;
+}

--- a/src/browser/overlay_browser.h
+++ b/src/browser/overlay_browser.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "../cef/cef_client.h"
+#include <string>
+
+class WebBrowser;
+
+// Business logic wrapper for the server selection overlay browser.
+// Owns an CefLayer (pure CEF) and handles server selection,
+// connectivity checks, and overlay fade/dismiss.
+class OverlayBrowser {
+public:
+    OverlayBrowser(RenderTarget target, WebBrowser& main_browser);
+
+    CefRefPtr<CefBrowser> browser() { return client_->browser(); }
+    void execJs(const std::string& js) { client_->execJs(js); }
+    void resize(int w, int h, int pw, int ph) { client_->resize(w, h, pw, ph); }
+    bool isClosed() const { return client_->isClosed(); }
+    bool isLoaded() const { return client_->isLoaded(); }
+    void waitForClose() { client_->waitForClose(); }
+    void waitForLoad() { client_->waitForLoad(); }
+    CefRefPtr<CefLayer> client() { return client_; }
+
+private:
+    bool handleMessage(const std::string& name,
+                       CefRefPtr<CefListValue> args,
+                       CefRefPtr<CefBrowser> browser);
+
+    CefRefPtr<CefLayer> client_;
+    WebBrowser& main_browser_;
+};

--- a/src/browser/web_browser.cpp
+++ b/src/browser/web_browser.cpp
@@ -1,0 +1,194 @@
+#include "web_browser.h"
+#include "browsers.h"
+#include <cmath>
+#include "../common.h"
+#include "../settings.h"
+#include "../logging.h"
+#include "../player/media_session.h"
+#include "../player/media_session_thread.h"
+#include "../titlebar_color.h"
+#include "../input/dispatch.h"
+#include "../cjson/cJSON.h"
+
+extern void update_idle_inhibit();
+
+// =====================================================================
+// Helpers
+// =====================================================================
+
+static MediaMetadata parseMetadataJson(const std::string& json) {
+    MediaMetadata meta;
+    cJSON* root = cJSON_Parse(json.c_str());
+    if (!root) return meta;
+
+    cJSON* item;
+    if ((item = cJSON_GetObjectItem(root, "Name")) && cJSON_IsString(item))
+        meta.title = item->valuestring;
+    if ((item = cJSON_GetObjectItem(root, "SeriesName")) && cJSON_IsString(item))
+        meta.artist = item->valuestring;
+    if (meta.artist.empty()) {
+        if ((item = cJSON_GetObjectItem(root, "Artists")) && cJSON_IsArray(item)) {
+            cJSON* first = cJSON_GetArrayItem(item, 0);
+            if (first && cJSON_IsString(first))
+                meta.artist = first->valuestring;
+        }
+    }
+    if ((item = cJSON_GetObjectItem(root, "SeasonName")) && cJSON_IsString(item))
+        meta.album = item->valuestring;
+    if (meta.album.empty()) {
+        if ((item = cJSON_GetObjectItem(root, "Album")) && cJSON_IsString(item))
+            meta.album = item->valuestring;
+    }
+    if ((item = cJSON_GetObjectItem(root, "IndexNumber")) && cJSON_IsNumber(item))
+        meta.track_number = item->valueint;
+    if ((item = cJSON_GetObjectItem(root, "RunTimeTicks")) && cJSON_IsNumber(item))
+        meta.duration_us = static_cast<int64_t>(item->valuedouble) / 10;
+    if ((item = cJSON_GetObjectItem(root, "Type")) && cJSON_IsString(item)) {
+        std::string type = item->valuestring;
+        if (type == "Audio") meta.media_type = MediaType::Audio;
+        else if (type == "Movie" || type == "Episode" || type == "Video" || type == "MusicVideo")
+            meta.media_type = MediaType::Video;
+    }
+    cJSON_Delete(root);
+    return meta;
+}
+
+static void applySettingValue(const std::string& section, const std::string& key, const std::string& value) {
+    auto& s = Settings::instance();
+    if (key == "hwdec") s.setHwdec(value);
+    else if (key == "audioPassthrough") s.setAudioPassthrough(value);
+    else if (key == "audioExclusive") s.setAudioExclusive(value == "true");
+    else if (key == "audioChannels") s.setAudioChannels(value);
+    else if (key == "logLevel") s.setLogLevel(value);
+    else LOG_WARN(LOG_CEF, "Unknown setting key: %s.%s", section.c_str(), key.c_str());
+    s.saveAsync();
+}
+
+// Helper to read an int from CefListValue that may have been sent as double.
+static int getIntArg(CefRefPtr<CefListValue> args, size_t idx) {
+    if (args->GetType(idx) == VTYPE_DOUBLE)
+        return static_cast<int>(std::lround(args->GetDouble(idx)));
+    return args->GetInt(idx);
+}
+
+// =====================================================================
+// WebBrowser
+// =====================================================================
+
+WebBrowser::WebBrowser(RenderTarget target)
+    : client_(new CefLayer(target))
+{
+    client_->setMessageHandler([this](const std::string& name,
+                                      CefRefPtr<CefListValue> args,
+                                      CefRefPtr<CefBrowser> browser) {
+        return handleMessage(name, args, browser);
+    });
+    client_->setCreatedCallback([](CefRefPtr<CefBrowser> browser) {
+        // Main browser takes input only if the overlay isn't currently active.
+        if (!g_overlay_browser)
+            input::set_active_browser(browser);
+    });
+}
+
+bool WebBrowser::handleMessage(const std::string& name,
+                               CefRefPtr<CefListValue> args,
+                               CefRefPtr<CefBrowser> browser) {
+    if (!g_mpv.IsValid()) return false;
+
+    if (name == "playerLoad") {
+        std::string url = args->GetString(0).ToString();
+        int startMs = args->GetSize() > 1 ? getIntArg(args, 1) : 0;
+        int audioIdx = getIntArg(args, 2);
+        int subIdx = getIntArg(args, 3);
+        LOG_INFO(LOG_CEF, "playerLoad: audio=%d sub=%d start=%dms url=%s",
+                 audioIdx, subIdx, startMs, url.c_str());
+        MpvHandle::LoadOptions opts;
+        opts.startSecs = startMs / 1000.0;
+        opts.audioTrack = audioIdx;
+        opts.subTrack = subIdx;
+        g_mpv.LoadFile(url, opts);
+    } else if (name == "playerStop") {
+        g_mpv.Stop();
+    } else if (name == "playerPause") {
+        g_mpv.Pause();
+    } else if (name == "playerPlay") {
+        g_mpv.Play();
+    } else if (name == "playerSeek") {
+        double pos = getIntArg(args, 0) / 1000.0;
+        g_mpv.SeekAbsolute(pos);
+    } else if (name == "playerSetVolume") {
+        g_mpv.SetVolume(getIntArg(args, 0));
+    } else if (name == "playerSetMuted") {
+        g_mpv.SetMuted(args->GetBool(0));
+    } else if (name == "playerSetSpeed") {
+        g_mpv.SetSpeed(getIntArg(args, 0) / 1000.0);
+    } else if (name == "playerSetSubtitle") {
+        LOG_INFO(LOG_CEF, "playerSetSubtitle: %d", getIntArg(args, 0));
+        g_mpv.SetSubtitleTrack(getIntArg(args, 0));
+    } else if (name == "playerAddSubtitle") {
+        std::string url = args->GetString(0).ToString();
+        LOG_INFO(LOG_CEF, "playerAddSubtitle: %s", url.c_str());
+        g_mpv.SubAdd(url);
+    } else if (name == "playerSetAudio") {
+        g_mpv.SetAudioTrack(getIntArg(args, 0));
+    } else if (name == "playerSetAudioDelay") {
+        g_mpv.SetAudioDelay(args->GetDouble(0));
+    } else if (name == "playerOsdActive") {
+        bool active = args->GetBool(0);
+        if (active) {
+            g_mpv.GetFullscreen(was_fullscreen_before_osd_);
+        } else {
+            if (!was_fullscreen_before_osd_)
+                g_platform.set_fullscreen(false);
+        }
+    } else if (name == "toggleFullscreen") {
+        g_platform.toggle_fullscreen();
+    } else if (name == "saveServerUrl") {
+        std::string url = args->GetString(0).ToString();
+        Settings::instance().setServerUrl(url);
+        Settings::instance().saveAsync();
+    } else if (name == "setSettingValue") {
+        std::string section = args->GetString(0).ToString();
+        std::string key = args->GetString(1).ToString();
+        std::string value = args->GetString(2).ToString();
+        applySettingValue(section, key, value);
+    } else if (name == "themeColor") {
+        std::string color = args->GetString(0).ToString();
+        if (g_titlebar_color) g_titlebar_color->onThemeColor(color);
+    } else if (name == "notifyMetadata") {
+        std::string json = args->GetString(0).ToString();
+        MediaMetadata meta = parseMetadataJson(json);
+        g_media_type = meta.media_type;
+        update_idle_inhibit();
+        if (g_media_session)
+            g_media_session->setMetadata(meta);
+    } else if (name == "notifyArtwork") {
+        std::string artworkUri = args->GetString(0).ToString();
+        if (g_media_session) g_media_session->setArtwork(artworkUri);
+    } else if (name == "notifyQueueChange") {
+        bool canNext = args->GetBool(0);
+        bool canPrev = args->GetBool(1);
+        if (g_media_session) {
+            g_media_session->setCanGoNext(canNext);
+            g_media_session->setCanGoPrevious(canPrev);
+        }
+    } else if (name == "notifyPlaybackState") {
+        std::string state = args->GetString(0).ToString();
+        if (g_media_session) {
+            if (state == "Playing") g_media_session->setPlaybackState(PlaybackState::Playing);
+            else if (state == "Paused") g_media_session->setPlaybackState(PlaybackState::Paused);
+            else g_media_session->setPlaybackState(PlaybackState::Stopped);
+        }
+    } else if (name == "notifySeek") {
+        int posMs = getIntArg(args, 0);
+        if (g_media_session)
+            g_media_session->emitSeeked(static_cast<int64_t>(posMs) * 1000);
+    } else if (name == "setCursorVisible") {
+        g_platform.set_cursor(args->GetBool(0) ? CT_POINTER : CT_NONE);
+    } else if (name == "appExit") {
+        initiate_shutdown();
+    } else {
+        return false;
+    }
+    return true;
+}

--- a/src/browser/web_browser.h
+++ b/src/browser/web_browser.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "../cef/cef_client.h"
+#include <string>
+
+// Business logic wrapper for the main jellyfin-web browser.
+// Owns a CefLayer (pure CEF) and handles all player, media session,
+// settings, and fullscreen policy IPC.
+class WebBrowser {
+public:
+    WebBrowser(RenderTarget target);
+
+    // Forwarded from the CEF client
+    CefRefPtr<CefBrowser> browser() { return client_->browser(); }
+    void execJs(const std::string& js) { client_->execJs(js); }
+    void resize(int w, int h, int pw, int ph) { client_->resize(w, h, pw, ph); }
+    bool isClosed() const { return client_->isClosed(); }
+    bool isLoaded() const { return client_->isLoaded(); }
+    void waitForClose() { client_->waitForClose(); }
+    void waitForLoad() { client_->waitForLoad(); }
+    CefRefPtr<CefLayer> client() { return client_; }
+
+private:
+    bool handleMessage(const std::string& name,
+                       CefRefPtr<CefListValue> args,
+                       CefRefPtr<CefBrowser> browser);
+
+    CefRefPtr<CefLayer> client_;
+    bool was_fullscreen_before_osd_ = false;
+};

--- a/src/cef/cef_app.cpp
+++ b/src/cef/cef_app.cpp
@@ -7,7 +7,7 @@
 #include "include/cef_command_line.h"
 #include "include/cef_frame.h"
 #include "include/cef_v8.h"
-#include <cmath>
+
 
 #ifdef __APPLE__
 #include <CoreFoundation/CoreFoundation.h>
@@ -106,37 +106,21 @@ void App::OnContextCreated(CefRefPtr<CefBrowser> browser,
     CefRefPtr<NativeV8Handler> handler = new NativeV8Handler(browser);
 
     CefRefPtr<CefV8Value> jmpNative = CefV8Value::CreateObject(nullptr, nullptr);
-    jmpNative->SetValue("playerLoad", CefV8Value::CreateFunction("playerLoad", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
-    jmpNative->SetValue("playerStop", CefV8Value::CreateFunction("playerStop", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
-    jmpNative->SetValue("playerPause", CefV8Value::CreateFunction("playerPause", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
-    jmpNative->SetValue("playerPlay", CefV8Value::CreateFunction("playerPlay", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
-    jmpNative->SetValue("playerSeek", CefV8Value::CreateFunction("playerSeek", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
-    jmpNative->SetValue("playerSetVolume", CefV8Value::CreateFunction("playerSetVolume", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
-    jmpNative->SetValue("playerSetMuted", CefV8Value::CreateFunction("playerSetMuted", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
-    jmpNative->SetValue("playerSetSpeed", CefV8Value::CreateFunction("playerSetSpeed", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
-    jmpNative->SetValue("playerSetSubtitle", CefV8Value::CreateFunction("playerSetSubtitle", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
-    jmpNative->SetValue("playerAddSubtitle", CefV8Value::CreateFunction("playerAddSubtitle", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
-    jmpNative->SetValue("playerSetAudio", CefV8Value::CreateFunction("playerSetAudio", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
-    jmpNative->SetValue("playerSetAudioDelay", CefV8Value::CreateFunction("playerSetAudioDelay", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
-    jmpNative->SetValue("saveServerUrl", CefV8Value::CreateFunction("saveServerUrl", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
-    jmpNative->SetValue("loadServer", CefV8Value::CreateFunction("loadServer", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
-    jmpNative->SetValue("checkServerConnectivity", CefV8Value::CreateFunction("checkServerConnectivity", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
-    jmpNative->SetValue("notifyMetadata", CefV8Value::CreateFunction("notifyMetadata", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
-    jmpNative->SetValue("notifyPosition", CefV8Value::CreateFunction("notifyPosition", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
-    jmpNative->SetValue("notifySeek", CefV8Value::CreateFunction("notifySeek", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
-    jmpNative->SetValue("notifyPlaybackState", CefV8Value::CreateFunction("notifyPlaybackState", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
-    jmpNative->SetValue("notifyArtwork", CefV8Value::CreateFunction("notifyArtwork", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
-    jmpNative->SetValue("notifyQueueChange", CefV8Value::CreateFunction("notifyQueueChange", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
-    jmpNative->SetValue("notifyRateChange", CefV8Value::CreateFunction("notifyRateChange", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
-    jmpNative->SetValue("appExit", CefV8Value::CreateFunction("appExit", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
-    jmpNative->SetValue("setSettingValue", CefV8Value::CreateFunction("setSettingValue", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
-    jmpNative->SetValue("themeColor", CefV8Value::CreateFunction("themeColor", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
-    jmpNative->SetValue("setOsdVisible", CefV8Value::CreateFunction("setOsdVisible", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
-    jmpNative->SetValue("setCursorVisible", CefV8Value::CreateFunction("setCursorVisible", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
-    jmpNative->SetValue("toggleFullscreen", CefV8Value::CreateFunction("toggleFullscreen", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
-    jmpNative->SetValue("menuItemSelected", CefV8Value::CreateFunction("menuItemSelected", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
-    jmpNative->SetValue("menuDismissed", CefV8Value::CreateFunction("menuDismissed", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
-    jmpNative->SetValue("overlayFadeComplete", CefV8Value::CreateFunction("overlayFadeComplete", handler), V8_PROPERTY_ATTRIBUTE_READONLY);
+    static const char* const kFunctions[] = {
+        "playerLoad", "playerStop", "playerPause", "playerPlay", "playerSeek",
+        "playerSetVolume", "playerSetMuted", "playerSetSpeed",
+        "playerSetSubtitle", "playerAddSubtitle", "playerSetAudio",
+        "playerSetAudioDelay", "playerOsdActive",
+        "saveServerUrl", "loadServer", "checkServerConnectivity",
+        "notifyMetadata", "notifyPosition", "notifySeek",
+        "notifyPlaybackState", "notifyArtwork", "notifyQueueChange",
+        "notifyRateChange",
+        "appExit", "setSettingValue", "themeColor",
+        "setOsdVisible", "setCursorVisible", "toggleFullscreen",
+        "menuItemSelected", "menuDismissed", "overlayFadeComplete",
+    };
+    for (const char* fn : kFunctions)
+        jmpNative->SetValue(fn, CefV8Value::CreateFunction(fn, handler), V8_PROPERTY_ATTRIBUTE_READONLY);
     window->SetValue("jmpNative", jmpNative, V8_PROPERTY_ATTRIBUTE_READONLY);
 
     // Inject JS shim
@@ -194,62 +178,24 @@ bool App::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
     return false;
 }
 
-// V8 handler -- sends IPC messages to browser process
-static int v8ToInt(const CefRefPtr<CefV8Value>& val, int fallback) {
-    if (val->IsInt()) return val->GetIntValue();
-    if (val->IsDouble()) return static_cast<int>(std::lround(val->GetDoubleValue()));
-    return fallback;
-}
-
+// V8 handler -- generic IPC relay to browser process.
+// Serializes V8 arguments by detected type; the receiving side handles
+// any coercion (e.g. JS numbers that should be ints).
 bool NativeV8Handler::Execute(const CefString& name,
                               CefRefPtr<CefV8Value>,
                               const CefV8ValueList& arguments,
                               CefRefPtr<CefV8Value>&,
                               CefString&) {
-    // Simple IPC relay: create message with same name and forward args
     CefRefPtr<CefProcessMessage> msg = CefProcessMessage::Create(name);
     CefRefPtr<CefListValue> args = msg->GetArgumentList();
 
-    if (name == "playerLoad") {
-        if (arguments.size() >= 1 && arguments[0]->IsString()) {
-            args->SetString(0, arguments[0]->GetStringValue());
-            args->SetInt(1, arguments.size() > 1 ? v8ToInt(arguments[1], 0) : 0);
-            args->SetInt(2, arguments.size() > 2 ? v8ToInt(arguments[2], -1) : -1);
-            args->SetInt(3, arguments.size() > 3 ? v8ToInt(arguments[3], -1) : -1);
-            args->SetString(4, arguments.size() > 4 && arguments[4]->IsString()
-                ? arguments[4]->GetStringValue() : "{}");
-        }
-    } else if (name == "playerSeek" || name == "playerSetVolume" || name == "playerSetSpeed" ||
-               name == "playerSetSubtitle" || name == "playerSetAudio" ||
-               name == "notifyPosition" || name == "notifySeek") {
-        if (arguments.size() >= 1) args->SetInt(0, v8ToInt(arguments[0], 0));
-    } else if (name == "playerSetMuted") {
-        if (arguments.size() >= 1 && arguments[0]->IsBool()) args->SetBool(0, arguments[0]->GetBoolValue());
-    } else if (name == "playerSetAudioDelay" || name == "notifyRateChange") {
-        if (arguments.size() >= 1 && arguments[0]->IsDouble()) args->SetDouble(0, arguments[0]->GetDoubleValue());
-    } else if (name == "saveServerUrl" || name == "loadServer" || name == "checkServerConnectivity" ||
-               name == "notifyMetadata" || name == "notifyPlaybackState" || name == "notifyArtwork" ||
-               name == "themeColor" || name == "playerAddSubtitle") {
-        if (arguments.size() >= 1 && arguments[0]->IsString()) args->SetString(0, arguments[0]->GetStringValue());
-    } else if (name == "notifyQueueChange") {
-        if (arguments.size() >= 2 && arguments[0]->IsBool() && arguments[1]->IsBool()) {
-            args->SetBool(0, arguments[0]->GetBoolValue());
-            args->SetBool(1, arguments[1]->GetBoolValue());
-        }
-    } else if (name == "setSettingValue") {
-        if (arguments.size() >= 3) {
-            args->SetString(0, arguments[0]->GetStringValue());
-            args->SetString(1, arguments[1]->GetStringValue());
-            args->SetString(2, arguments[2]->GetStringValue());
-        }
-    } else if (name == "setOsdVisible") {
-        if (arguments.size() >= 1 && arguments[0]->IsBool()) args->SetBool(0, arguments[0]->GetBoolValue());
-    } else if (name == "setCursorVisible") {
-        if (arguments.size() >= 1 && arguments[0]->IsBool()) args->SetBool(0, arguments[0]->GetBoolValue());
-    } else if (name == "menuItemSelected") {
-        if (arguments.size() >= 1) args->SetInt(0, v8ToInt(arguments[0], 0));
+    for (size_t i = 0; i < arguments.size(); i++) {
+        auto& v = arguments[i];
+        if      (v->IsBool())   args->SetBool(i, v->GetBoolValue());
+        else if (v->IsInt())    args->SetInt(i, v->GetIntValue());
+        else if (v->IsDouble()) args->SetDouble(i, v->GetDoubleValue());
+        else if (v->IsString()) args->SetString(i, v->GetStringValue());
     }
-    // playerStop, playerPause, playerPlay, appExit, menuDismissed: no args needed
 
     browser_->GetMainFrame()->SendProcessMessage(PID_BROWSER, msg);
     return true;

--- a/src/cef/cef_client.cpp
+++ b/src/cef/cef_client.cpp
@@ -1,226 +1,15 @@
 #include "cef_client.h"
-#include "../settings.h"
 #include "../logging.h"
-#include "../player/media_session.h"
-#include "../player/media_session_thread.h"
 #include "../cjson/cJSON.h"
-#include "../titlebar_color.h"
-#include "../input/dispatch.h"
-#include "include/cef_urlrequest.h"
+#include "../platform/platform.h"
 #include <cstdio>
-#ifndef _WIN32
-#include <unistd.h>
-#endif
 
-// Overlay fade timing — delay lets the main browser start loading behind
-// the overlay, then a snappy fade-out hides it.
-constexpr float OVERLAY_FADE_DELAY_SEC    = 1.0f;
-constexpr float OVERLAY_FADE_DURATION_SEC = 0.25f;
-
-extern void update_idle_inhibit();
+extern Platform g_platform;
+extern std::atomic<bool> g_shutting_down;
 
 // =====================================================================
-// Settings helper (shared between Client and OverlayClient)
+// Shared helpers (context menu, clipboard)
 // =====================================================================
-
-static MediaMetadata parseMetadataJson(const std::string& json) {
-    MediaMetadata meta;
-    cJSON* root = cJSON_Parse(json.c_str());
-    if (!root) return meta;
-
-    cJSON* item;
-    if ((item = cJSON_GetObjectItem(root, "Name")) && cJSON_IsString(item))
-        meta.title = item->valuestring;
-    // Episodes: SeriesName as artist; audio: first element of Artists array
-    if ((item = cJSON_GetObjectItem(root, "SeriesName")) && cJSON_IsString(item))
-        meta.artist = item->valuestring;
-    if (meta.artist.empty()) {
-        if ((item = cJSON_GetObjectItem(root, "Artists")) && cJSON_IsArray(item)) {
-            cJSON* first = cJSON_GetArrayItem(item, 0);
-            if (first && cJSON_IsString(first))
-                meta.artist = first->valuestring;
-        }
-    }
-    // Episodes: SeasonName as album; audio: Album
-    if ((item = cJSON_GetObjectItem(root, "SeasonName")) && cJSON_IsString(item))
-        meta.album = item->valuestring;
-    if (meta.album.empty()) {
-        if ((item = cJSON_GetObjectItem(root, "Album")) && cJSON_IsString(item))
-            meta.album = item->valuestring;
-    }
-    if ((item = cJSON_GetObjectItem(root, "IndexNumber")) && cJSON_IsNumber(item))
-        meta.track_number = item->valueint;
-    // RunTimeTicks is in 100ns units → microseconds
-    if ((item = cJSON_GetObjectItem(root, "RunTimeTicks")) && cJSON_IsNumber(item))
-        meta.duration_us = static_cast<int64_t>(item->valuedouble) / 10;
-    if ((item = cJSON_GetObjectItem(root, "Type")) && cJSON_IsString(item)) {
-        std::string type = item->valuestring;
-        if (type == "Audio") meta.media_type = MediaType::Audio;
-        else if (type == "Movie" || type == "Episode" || type == "Video" || type == "MusicVideo")
-            meta.media_type = MediaType::Video;
-    }
-    cJSON_Delete(root);
-    return meta;
-}
-
-static void applySettingValue(const std::string& section, const std::string& key, const std::string& value) {
-    auto& s = Settings::instance();
-    if (key == "hwdec") s.setHwdec(value);
-    else if (key == "audioPassthrough") s.setAudioPassthrough(value);
-    else if (key == "audioExclusive") s.setAudioExclusive(value == "true");
-    else if (key == "audioChannels") s.setAudioChannels(value);
-    else if (key == "logLevel") s.setLogLevel(value);
-    else LOG_WARN(LOG_CEF, "Unknown setting key: %s.%s", section.c_str(), key.c_str());
-    s.saveAsync();
-}
-
-// =====================================================================
-// Connectivity check for overlay browser
-// =====================================================================
-
-class ConnectivityURLRequestClient : public CefURLRequestClient {
-public:
-    ConnectivityURLRequestClient(CefRefPtr<CefBrowser> browser, const std::string& originalUrl)
-        : browser_(browser), original_url_(originalUrl) {}
-
-    void OnRequestComplete(CefRefPtr<CefURLRequest> request) override {
-        auto status = request->GetRequestStatus();
-        auto response = request->GetResponse();
-        bool success = false;
-        std::string resolved_url = original_url_;
-
-        if (status == UR_SUCCESS && response && response->GetStatus() == 200) {
-            if (response_body_.find("\"Id\"") != std::string::npos) {
-                success = true;
-                resolved_url = response->GetURL().ToString();
-                size_t pos = resolved_url.find("/System/Info/Public");
-                if (pos != std::string::npos)
-                    resolved_url = resolved_url.substr(0, pos);
-            }
-        }
-
-        auto frame = browser_ ? browser_->GetMainFrame() : nullptr;
-        if (frame) {
-            CefRefPtr<CefProcessMessage> msg = CefProcessMessage::Create("serverConnectivityResult");
-            msg->GetArgumentList()->SetString(0, original_url_);
-            msg->GetArgumentList()->SetBool(1, success);
-            msg->GetArgumentList()->SetString(2, resolved_url);
-            frame->SendProcessMessage(PID_RENDERER, msg);
-        }
-    }
-
-    void OnUploadProgress(CefRefPtr<CefURLRequest>, int64_t, int64_t) override {}
-    void OnDownloadProgress(CefRefPtr<CefURLRequest>, int64_t, int64_t) override {}
-    void OnDownloadData(CefRefPtr<CefURLRequest>, const void* data, size_t len) override {
-        response_body_.append(static_cast<const char*>(data), len);
-    }
-    bool GetAuthCredentials(bool, const CefString&, int, const CefString&, const CefString&,
-                            CefRefPtr<CefAuthCallback>) override { return false; }
-
-private:
-    CefRefPtr<CefBrowser> browser_;
-    std::string original_url_;
-    std::string response_body_;
-    IMPLEMENT_REFCOUNTING(ConnectivityURLRequestClient);
-};
-
-// =====================================================================
-// Client -- main browser
-// =====================================================================
-
-void Client::GetViewRect(CefRefPtr<CefBrowser>, CefRect& rect) {
-    rect.Set(0, 0, width_, height_);
-}
-
-bool Client::GetScreenInfo(CefRefPtr<CefBrowser>, CefScreenInfo& info) {
-    float scale = (physical_w_ > 0 && width_ > 0)
-        ? static_cast<float>(physical_w_) / width_
-        : 1.0f;
-    info.device_scale_factor = scale;
-    info.rect = CefRect(0, 0, width_, height_);
-    info.available_rect = info.rect;
-    return true;
-}
-
-void Client::resize(int w, int h, int physical_w, int physical_h) {
-    LOG_INFO(LOG_CEF, "[CLIENT] Client::resize logical=%dx%d physical=%dx%d browser=%p",
-             w, h, physical_w, physical_h, browser_.get());
-    width_ = w;
-    height_ = h;
-    physical_w_ = physical_w;
-    physical_h_ = physical_h;
-    if (browser_) {
-        browser_->GetHost()->NotifyScreenInfoChanged();
-        browser_->GetHost()->WasResized();
-        browser_->GetHost()->Invalidate(PET_VIEW);
-    }
-}
-
-void Client::OnPaint(CefRefPtr<CefBrowser>, PaintElementType type, const RectList& dirty,
-                     const void* buffer, int w, int h) {
-    if (type != PET_VIEW) return;
-    g_platform.present_software(dirty, buffer, w, h);
-}
-
-void Client::OnAcceleratedPaint(CefRefPtr<CefBrowser>, PaintElementType type,
-                                const RectList&, const CefAcceleratedPaintInfo& info) {
-    if (type != PET_VIEW) return;
-    g_platform.present(info);
-}
-
-void Client::OnAfterCreated(CefRefPtr<CefBrowser> browser) {
-    LOG_INFO(LOG_CEF, "[CLIENT] Client::OnAfterCreated browser=%p id=%d",
-             browser.get(), browser ? browser->GetIdentifier() : -1);
-    browser_ = browser;
-    if (g_shutting_down.load(std::memory_order_relaxed)) {
-        // CreateBrowser was in flight when initiate_shutdown() ran.
-        // Close immediately so CefShutdown doesn't find a live browser.
-        browser->GetHost()->CloseBrowser(true);
-        return;
-    }
-    browser->GetHost()->NotifyScreenInfoChanged();
-    browser->GetHost()->WasResized();
-    browser->GetHost()->Invalidate(PET_VIEW);
-    // Main browser takes input only if the overlay isn't currently active.
-    // The overlay's OnAfterCreated runs after ours (CreateBrowser order) and
-    // will override this if it's coming up.
-    if (!g_overlay_client || !g_overlay_client->browser())
-        input::set_active_browser(browser);
-}
-
-void Client::OnBeforeClose(CefRefPtr<CefBrowser>) {
-    browser_ = nullptr;
-    closed_ = true;
-    loaded_ = true;  // unblock waitForLoad if browser dies before loading
-    close_cv_.notify_all();
-    load_cv_.notify_all();
-}
-
-void Client::waitForClose() {
-    std::unique_lock<std::mutex> lock(close_mtx_);
-    close_cv_.wait(lock, [this] { return closed_.load(); });
-}
-
-void Client::OnLoadEnd(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame> frame, int code) {
-    LOG_INFO(LOG_CEF, "[CLIENT] Client::OnLoadEnd main=%d code=%d url=%s",
-             frame->IsMain() ? 1 : 0, code,
-             frame->GetURL().ToString().c_str());
-    if (frame->IsMain()) {
-        loaded_ = true;
-        load_cv_.notify_all();
-    }
-}
-
-void Client::waitForLoad() {
-    std::unique_lock<std::mutex> lock(load_mtx_);
-    load_cv_.wait(lock, [this] { return loaded_.load(); });
-}
-
-void Client::OnLoadError(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame>,
-                         ErrorCode errorCode, const CefString& errorText, const CefString& failedUrl) {
-    LOG_ERROR(LOG_CEF, "OnLoadError: %s error=%d %s",
-              failedUrl.ToString().c_str(), errorCode, errorText.ToString().c_str());
-}
 
 static std::string stripAccelerator(const std::string& label) {
     std::string out;
@@ -251,16 +40,12 @@ static cJSON* serializeMenuModel(CefRefPtr<CefMenuModel> model) {
     return arr;
 }
 
-// The "action modifier" for clipboard shortcuts: Cmd on macOS, Ctrl elsewhere.
 #ifdef __APPLE__
 constexpr uint32_t kActionModifier = EVENTFLAG_COMMAND_DOWN;
 #else
 constexpr uint32_t kActionModifier = EVENTFLAG_CONTROL_DOWN;
 #endif
 
-// Returns true if `e` is the "paste" keyboard shortcut and should be
-// intercepted. Matches only the press (RawKeyDown), with the platform
-// action modifier held and no Alt, so we don't hijack e.g. Ctrl+Alt+V.
 static bool is_paste_shortcut(const CefKeyEvent& e) {
     if (e.type != KEYEVENT_RAWKEYDOWN) return false;
     if ((e.modifiers & kActionModifier) == 0) return false;
@@ -268,9 +53,6 @@ static bool is_paste_shortcut(const CefKeyEvent& e) {
     return e.windows_key_code == 'V';
 }
 
-// Encode a UTF-8 string as a JavaScript string literal (including quotes).
-// JSON strings are valid JS strings, so cJSON handles all the escaping —
-// satisfies the "no hand-rolled JSON" rule.
 static std::string js_string_literal(const std::string& text) {
     cJSON* j = cJSON_CreateString(text.c_str());
     if (!j) return "\"\"";
@@ -281,11 +63,6 @@ static std::string js_string_literal(const std::string& text) {
     return result;
 }
 
-// Async paste via the platform clipboard + JS injection. Reads the
-// system clipboard (may complete on any thread) and posts the text into
-// the focused frame with document.execCommand('insertText', …), which
-// dispatches synthetic input events so controlled inputs (React etc.)
-// see the change.
 static void paste_via_platform_clipboard(CefRefPtr<CefBrowser> browser) {
     if (!browser) return;
     auto frame = browser->GetFocusedFrame();
@@ -299,10 +76,6 @@ static void paste_via_platform_clipboard(CefRefPtr<CefBrowser> browser) {
     });
 }
 
-// Route paste through our ext-data-control-v1 path when g_platform
-// advertises it (wlroots/KWin). On compositors without the hook
-// (Mutter/GNOME, etc.) CEF's own XWayland clipboard bridge works, so we
-// fall back to frame->Paste().
 static void do_paste(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame) {
     if (g_platform.clipboard_read_text_async)
         paste_via_platform_clipboard(browser);
@@ -310,9 +83,6 @@ static void do_paste(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame) {
         frame->Paste();
 }
 
-// Shared Ctrl+V intercept logic — both Client and OverlayClient route
-// paste through our path only when the platform hook is active. When it
-// isn't, we return false and let CEF handle Ctrl+V natively.
 static bool try_intercept_paste(CefRefPtr<CefBrowser> browser,
                                 const CefKeyEvent& e) {
     if (!g_platform.clipboard_read_text_async) return false;
@@ -321,202 +91,15 @@ static bool try_intercept_paste(CefRefPtr<CefBrowser> browser,
     return true;
 }
 
-bool Client::OnPreKeyEvent(CefRefPtr<CefBrowser> browser, const CefKeyEvent& e,
-                           CefEventHandle, bool* /*is_keyboard_shortcut*/) {
-    return try_intercept_paste(browser, e);
-}
-
-void Client::OnBeforeContextMenu(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame>,
-                                 CefRefPtr<CefContextMenuParams>,
-                                 CefRefPtr<CefMenuModel> model) {
-    model->Remove(MENU_ID_PRINT);
-    model->Remove(MENU_ID_VIEW_SOURCE);
-    if (model->GetIndexOf(MENU_ID_RELOAD) < 0)
-        model->AddItem(MENU_ID_RELOAD, "Reload");
-    // Strip trailing separators left behind
-    while (model->GetCount() > 0 &&
-           model->GetTypeAt(model->GetCount() - 1) == MENUITEMTYPE_SEPARATOR)
-        model->RemoveAt(model->GetCount() - 1);
-}
-
-bool Client::RunContextMenu(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame>,
-                            CefRefPtr<CefContextMenuParams> params,
-                            CefRefPtr<CefMenuModel> model,
-                            CefRefPtr<CefRunContextMenuCallback> callback) {
-    if (model->GetCount() == 0) {
-        callback->Cancel();
-        return true;
-    }
-    if (pending_menu_callback_)
-        pending_menu_callback_->Cancel();
-    pending_menu_callback_ = callback;
-
-    cJSON* call_args = cJSON_CreateArray();
-    cJSON_AddItemToArray(call_args, serializeMenuModel(model));
-    cJSON_AddItemToArray(call_args, cJSON_CreateNumber(params->GetXCoord()));
-    cJSON_AddItemToArray(call_args, cJSON_CreateNumber(params->GetYCoord()));
-    char* json = cJSON_PrintUnformatted(call_args);
-    browser->GetMainFrame()->ExecuteJavaScript(
-        "window._showContextMenu.apply(null," + std::string(json) + ")",
-        "", 0);
-    cJSON_free(json);
-    cJSON_Delete(call_args);
-    return true;
-}
-
-void Client::OnFullscreenModeChange(CefRefPtr<CefBrowser>, bool fullscreen) {
-    g_platform.set_fullscreen(fullscreen);
-}
-
-bool Client::OnCursorChange(CefRefPtr<CefBrowser>, CefCursorHandle,
-                            cef_cursor_type_t type, const CefCursorInfo&) {
-    g_platform.set_cursor(type);
-    return true;
-}
-
-void Client::execJs(const std::string& js) {
-    if (browser_ && browser_->GetMainFrame())
-        browser_->GetMainFrame()->ExecuteJavaScript(js, "", 0);
-}
-
-bool Client::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame>,
-                                      CefProcessId, CefRefPtr<CefProcessMessage> message) {
-    if (!g_mpv.IsValid()) return false;
-    auto name = message->GetName().ToString();
-    auto args = message->GetArgumentList();
-    // All mpv calls are async -- never block CEF's thread.
-    if (name == "playerLoad") {
-        std::string url = args->GetString(0).ToString();
-        int startMs = args->GetSize() > 1 ? args->GetInt(1) : 0;
-        int audioIdx = args->GetInt(2);
-        int subIdx = args->GetInt(3);
-        LOG_INFO(LOG_CEF, "playerLoad: audio=%d sub=%d start=%dms url=%s",
-                 audioIdx, subIdx, startMs, url.c_str());
-        MpvHandle::LoadOptions opts;
-        opts.startSecs = startMs / 1000.0;
-        opts.audioTrack = audioIdx;
-        opts.subTrack = subIdx;
-        g_mpv.LoadFile(url, opts);
-    } else if (name == "playerStop") {
-        g_mpv.Stop();
-        // Exit fullscreen when player stops — return to windowed library view
-        g_platform.set_fullscreen(false);
-    } else if (name == "playerPause") {
-        g_mpv.Pause();
-    } else if (name == "playerPlay") {
-        g_mpv.Play();
-    } else if (name == "playerSeek") {
-        double pos = args->GetInt(0) / 1000.0;
-        g_mpv.SeekAbsolute(pos);
-    } else if (name == "playerSetVolume") {
-        g_mpv.SetVolume(args->GetInt(0));
-    } else if (name == "playerSetMuted") {
-        g_mpv.SetMuted(args->GetBool(0));
-    } else if (name == "playerSetSpeed") {
-        g_mpv.SetSpeed(args->GetInt(0) / 1000.0);
-    } else if (name == "playerSetSubtitle") {
-        LOG_INFO(LOG_CEF, "playerSetSubtitle: %d", args->GetInt(0));
-        g_mpv.SetSubtitleTrack(args->GetInt(0));
-    } else if (name == "playerAddSubtitle") {
-        std::string url = args->GetString(0).ToString();
-        LOG_INFO(LOG_CEF, "playerAddSubtitle: %s", url.c_str());
-        g_mpv.SubAdd(url);
-    } else if (name == "playerSetAudio") {
-        g_mpv.SetAudioTrack(args->GetInt(0));
-    } else if (name == "playerSetAudioDelay") {
-        g_mpv.SetAudioDelay(args->GetDouble(0));
-    } else if (name == "toggleFullscreen") {
-        g_platform.toggle_fullscreen();
-    } else if (name == "saveServerUrl") {
-        std::string url = args->GetString(0).ToString();
-        Settings::instance().setServerUrl(url);
-        Settings::instance().saveAsync();
-    } else if (name == "setSettingValue") {
-        std::string section = args->GetString(0).ToString();
-        std::string key = args->GetString(1).ToString();
-        std::string value = args->GetString(2).ToString();
-        applySettingValue(section, key, value);
-    } else if (name == "themeColor") {
-        std::string color = args->GetString(0).ToString();
-        if (g_titlebar_color) g_titlebar_color->onThemeColor(color);
-    } else if (name == "notifyMetadata") {
-        std::string json = args->GetString(0).ToString();
-        MediaMetadata meta = parseMetadataJson(json);
-        g_media_type = meta.media_type;
-        update_idle_inhibit();
-        if (g_media_session)
-            g_media_session->setMetadata(meta);
-    } else if (name == "notifyArtwork") {
-        std::string artworkUri = args->GetString(0).ToString();
-        if (g_media_session) g_media_session->setArtwork(artworkUri);
-    } else if (name == "notifyQueueChange") {
-        bool canNext = args->GetBool(0);
-        bool canPrev = args->GetBool(1);
-        if (g_media_session) {
-            g_media_session->setCanGoNext(canNext);
-            g_media_session->setCanGoPrevious(canPrev);
-        }
-    } else if (name == "notifyPlaybackState") {
-        std::string state = args->GetString(0).ToString();
-        if (g_media_session) {
-            if (state == "Playing") g_media_session->setPlaybackState(PlaybackState::Playing);
-            else if (state == "Paused") g_media_session->setPlaybackState(PlaybackState::Paused);
-            else g_media_session->setPlaybackState(PlaybackState::Stopped);
-        }
-    } else if (name == "notifySeek") {
-        int posMs = args->GetInt(0);
-        if (g_media_session)
-            g_media_session->emitSeeked(static_cast<int64_t>(posMs) * 1000);
-    } else if (name == "setCursorVisible") {
-        g_platform.set_cursor(args->GetBool(0) ? CT_POINTER : CT_NONE);
-    } else if (name == "appExit") {
-        initiate_shutdown();
-    } else if (name == "menuItemSelected") {
-        int cmd = args->GetInt(0);
-        if (pending_menu_callback_) {
-            pending_menu_callback_->Cancel();
-            pending_menu_callback_ = nullptr;
-        }
-        // Execute commands directly — the callback path doesn't work
-        // because CEF's menu manager state (IsShowingContextMenu) is false.
-        if (browser_) {
-            auto frame = browser_->GetFocusedFrame();
-            if (!frame) frame = browser_->GetMainFrame();
-            switch (cmd) {
-            case MENU_ID_BACK: browser_->GoBack(); break;
-            case MENU_ID_FORWARD: browser_->GoForward(); break;
-            case MENU_ID_RELOAD: browser_->Reload(); break;
-            case MENU_ID_RELOAD_NOCACHE: browser_->ReloadIgnoreCache(); break;
-            case MENU_ID_STOPLOAD: browser_->StopLoad(); break;
-            case MENU_ID_UNDO: frame->Undo(); break;
-            case MENU_ID_REDO: frame->Redo(); break;
-            case MENU_ID_CUT: frame->Cut(); break;
-            case MENU_ID_COPY: frame->Copy(); break;
-            case MENU_ID_PASTE: do_paste(browser_, frame); break;
-            case MENU_ID_SELECT_ALL: frame->SelectAll(); break;
-            default: break;
-            }
-        }
-    } else if (name == "menuDismissed") {
-        if (pending_menu_callback_) {
-            pending_menu_callback_->Cancel();
-            pending_menu_callback_ = nullptr;
-        }
-    } else {
-        return false;
-    }
-    return true;
-}
-
 // =====================================================================
-// OverlayClient -- server selection/loading browser
+// CefLayer
 // =====================================================================
 
-void OverlayClient::GetViewRect(CefRefPtr<CefBrowser>, CefRect& rect) {
+void CefLayer::GetViewRect(CefRefPtr<CefBrowser>, CefRect& rect) {
     rect.Set(0, 0, width_, height_);
 }
 
-bool OverlayClient::GetScreenInfo(CefRefPtr<CefBrowser>, CefScreenInfo& info) {
+bool CefLayer::GetScreenInfo(CefRefPtr<CefBrowser>, CefScreenInfo& info) {
     float scale = (physical_w_ > 0 && width_ > 0)
         ? static_cast<float>(physical_w_) / width_
         : 1.0f;
@@ -526,7 +109,9 @@ bool OverlayClient::GetScreenInfo(CefRefPtr<CefBrowser>, CefScreenInfo& info) {
     return true;
 }
 
-void OverlayClient::resize(int w, int h, int physical_w, int physical_h) {
+void CefLayer::resize(int w, int h, int physical_w, int physical_h) {
+    LOG_INFO(LOG_CEF, "CefLayer::resize logical=%dx%d physical=%dx%d browser=%p",
+             w, h, physical_w, physical_h, browser_.get());
     width_ = w;
     height_ = h;
     physical_w_ = physical_w;
@@ -538,20 +123,20 @@ void OverlayClient::resize(int w, int h, int physical_w, int physical_h) {
     }
 }
 
-void OverlayClient::OnPaint(CefRefPtr<CefBrowser>, PaintElementType type, const RectList& dirty,
-                            const void* buffer, int w, int h) {
+void CefLayer::OnPaint(CefRefPtr<CefBrowser>, PaintElementType type, const RectList& dirty,
+                       const void* buffer, int w, int h) {
     if (type != PET_VIEW) return;
-    g_platform.overlay_present_software(dirty, buffer, w, h);
+    target_.present_software(dirty, buffer, w, h);
 }
 
-void OverlayClient::OnAcceleratedPaint(CefRefPtr<CefBrowser>, PaintElementType type,
-                                       const RectList&, const CefAcceleratedPaintInfo& info) {
+void CefLayer::OnAcceleratedPaint(CefRefPtr<CefBrowser>, PaintElementType type,
+                                  const RectList&, const CefAcceleratedPaintInfo& info) {
     if (type != PET_VIEW) return;
-    g_platform.overlay_present(info);
+    target_.present(info);
 }
 
-void OverlayClient::OnAfterCreated(CefRefPtr<CefBrowser> browser) {
-    LOG_INFO(LOG_CEF, "[OVERLAY] OverlayClient::OnAfterCreated browser=%p id=%d",
+void CefLayer::OnAfterCreated(CefRefPtr<CefBrowser> browser) {
+    LOG_INFO(LOG_CEF, "CefLayer::OnAfterCreated browser=%p id=%d",
              browser.get(), browser ? browser->GetIdentifier() : -1);
     browser_ = browser;
     if (g_shutting_down.load(std::memory_order_relaxed)) {
@@ -561,11 +146,10 @@ void OverlayClient::OnAfterCreated(CefRefPtr<CefBrowser> browser) {
     browser->GetHost()->NotifyScreenInfoChanged();
     browser->GetHost()->WasResized();
     browser->GetHost()->Invalidate(PET_VIEW);
-    // Overlay wins input whenever it's created.
-    input::set_active_browser(browser);
+    if (on_after_created_) on_after_created_(browser);
 }
 
-void OverlayClient::OnBeforeClose(CefRefPtr<CefBrowser>) {
+void CefLayer::OnBeforeClose(CefRefPtr<CefBrowser>) {
     browser_ = nullptr;
     closed_ = true;
     loaded_ = true;
@@ -573,13 +157,13 @@ void OverlayClient::OnBeforeClose(CefRefPtr<CefBrowser>) {
     load_cv_.notify_all();
 }
 
-void OverlayClient::waitForClose() {
+void CefLayer::waitForClose() {
     std::unique_lock<std::mutex> lock(close_mtx_);
     close_cv_.wait(lock, [this] { return closed_.load(); });
 }
 
-void OverlayClient::OnLoadEnd(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame> frame, int code) {
-    LOG_INFO(LOG_CEF, "[OVERLAY] OverlayClient::OnLoadEnd main=%d code=%d url=%s",
+void CefLayer::OnLoadEnd(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame> frame, int code) {
+    LOG_INFO(LOG_CEF, "CefLayer::OnLoadEnd main=%d code=%d url=%s",
              frame->IsMain() ? 1 : 0, code,
              frame->GetURL().ToString().c_str());
     if (frame->IsMain()) {
@@ -588,69 +172,39 @@ void OverlayClient::OnLoadEnd(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame> frame, 
     }
 }
 
-void OverlayClient::waitForLoad() {
+void CefLayer::waitForLoad() {
     std::unique_lock<std::mutex> lock(load_mtx_);
     load_cv_.wait(lock, [this] { return loaded_.load(); });
 }
 
-void OverlayClient::execJs(const std::string& js) {
+void CefLayer::OnLoadError(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame>,
+                           ErrorCode errorCode, const CefString& errorText, const CefString& failedUrl) {
+    LOG_ERROR(LOG_CEF, "OnLoadError: %s error=%d %s",
+              failedUrl.ToString().c_str(), errorCode, errorText.ToString().c_str());
+}
+
+void CefLayer::OnFullscreenModeChange(CefRefPtr<CefBrowser>, bool fullscreen) {
+    g_platform.set_fullscreen(fullscreen);
+}
+
+bool CefLayer::OnCursorChange(CefRefPtr<CefBrowser>, CefCursorHandle,
+                              cef_cursor_type_t type, const CefCursorInfo&) {
+    g_platform.set_cursor(type);
+    return true;
+}
+
+void CefLayer::execJs(const std::string& js) {
     if (browser_ && browser_->GetMainFrame())
         browser_->GetMainFrame()->ExecuteJavaScript(js, "", 0);
 }
 
-bool OverlayClient::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame>,
-                                             CefProcessId, CefRefPtr<CefProcessMessage> message) {
+bool CefLayer::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame>,
+                                        CefProcessId, CefRefPtr<CefProcessMessage> message) {
     auto name = message->GetName().ToString();
     auto args = message->GetArgumentList();
 
-    if (name == "loadServer") {
-        std::string url = args->GetString(0).ToString();
-        LOG_INFO(LOG_CEF, "Overlay: loadServer %s", url.c_str());
-        Settings::instance().setServerUrl(url);
-        Settings::instance().saveAsync();
-        // Navigate main browser to the server
-        if (g_client && g_client->browser())
-            g_client->browser()->GetMainFrame()->LoadURL(url);
-        // Hand input back to the main browser immediately so the user can
-        // start interacting with it while the overlay fades out.
-        input::set_active_browser(g_client ? g_client->browser() : nullptr);
-        // Close the browser after the fade so CEF keeps rendering frames
-        // throughout the animation.
-        CefRefPtr<CefBrowser> overlay_browser = browser;
-        g_platform.fade_overlay(OVERLAY_FADE_DELAY_SEC, OVERLAY_FADE_DURATION_SEC,
-            // on_fade_start: delay elapsed, fade animation is about to begin
-            []() {
-                g_mpv.SetBackgroundColor(kVideoBgColor.hex);
-                if (g_titlebar_color) g_titlebar_color->onOverlayDismissed();
-            },
-            // on_complete: fade finished, safe to tear down the browser
-            [overlay_browser]() {
-                if (overlay_browser)
-                    overlay_browser->GetHost()->CloseBrowser(false);
-            });
-        return true;
-    } else if (name == "saveServerUrl") {
-        std::string url = args->GetString(0).ToString();
-        Settings::instance().setServerUrl(url);
-        Settings::instance().saveAsync();
-        return true;
-    } else if (name == "setSettingValue") {
-        std::string section = args->GetString(0).ToString();
-        std::string key = args->GetString(1).ToString();
-        std::string value = args->GetString(2).ToString();
-        applySettingValue(section, key, value);
-        return true;
-    } else if (name == "checkServerConnectivity") {
-        std::string url = args->GetString(0).ToString();
-        if (url.find("://") == std::string::npos) url = "http://" + url;
-        if (!url.empty() && url.back() == '/') url.pop_back();
-        std::string check_url = url + "/System/Info/Public";
-        CefRefPtr<CefRequest> request = CefRequest::Create();
-        request->SetURL(check_url);
-        request->SetMethod("GET");
-        CefURLRequest::Create(request, new ConnectivityURLRequestClient(browser, url), nullptr);
-        return true;
-    } else if (name == "menuItemSelected") {
+    // Context menu commands are browser-level, handled here.
+    if (name == "menuItemSelected") {
         int cmd = args->GetInt(0);
         if (pending_menu_callback_) {
             pending_menu_callback_->Cancel();
@@ -683,17 +237,20 @@ bool OverlayClient::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser, CefR
         return true;
     }
 
+    // Everything else delegates to the business logic handler.
+    if (message_handler_)
+        return message_handler_(name, args, browser);
     return false;
 }
 
-bool OverlayClient::OnPreKeyEvent(CefRefPtr<CefBrowser> browser, const CefKeyEvent& e,
-                                  CefEventHandle, bool* /*is_keyboard_shortcut*/) {
+bool CefLayer::OnPreKeyEvent(CefRefPtr<CefBrowser> browser, const CefKeyEvent& e,
+                             CefEventHandle, bool*) {
     return try_intercept_paste(browser, e);
 }
 
-void OverlayClient::OnBeforeContextMenu(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame>,
-                                        CefRefPtr<CefContextMenuParams>,
-                                        CefRefPtr<CefMenuModel> model) {
+void CefLayer::OnBeforeContextMenu(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame>,
+                                   CefRefPtr<CefContextMenuParams>,
+                                   CefRefPtr<CefMenuModel> model) {
     model->Remove(MENU_ID_PRINT);
     model->Remove(MENU_ID_VIEW_SOURCE);
     if (model->GetIndexOf(MENU_ID_RELOAD) < 0)
@@ -703,16 +260,15 @@ void OverlayClient::OnBeforeContextMenu(CefRefPtr<CefBrowser>, CefRefPtr<CefFram
         model->RemoveAt(model->GetCount() - 1);
 }
 
-bool OverlayClient::RunContextMenu(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame>,
-                                   CefRefPtr<CefContextMenuParams> params,
-                                   CefRefPtr<CefMenuModel> model,
-                                   CefRefPtr<CefRunContextMenuCallback> callback) {
+bool CefLayer::RunContextMenu(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame>,
+                              CefRefPtr<CefContextMenuParams> params,
+                              CefRefPtr<CefMenuModel> model,
+                              CefRefPtr<CefRunContextMenuCallback> callback) {
     if (model->GetCount() == 0) {
         callback->Cancel();
         return true;
     }
-    if (pending_menu_callback_)
-        pending_menu_callback_->Cancel();
+    if (pending_menu_callback_) pending_menu_callback_->Cancel();
     pending_menu_callback_ = callback;
 
     cJSON* call_args = cJSON_CreateArray();

--- a/src/cef/cef_client.h
+++ b/src/cef/cef_client.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "../common.h"
 #include "include/cef_client.h"
 #include "include/cef_render_handler.h"
 #include "include/cef_life_span_handler.h"
@@ -9,15 +8,40 @@
 #include "include/cef_display_handler.h"
 #include "include/cef_keyboard_handler.h"
 #include <condition_variable>
+#include <functional>
 #include <mutex>
+#include <string>
 
-// Main browser client -- handles jellyfin-web and player commands.
-// OnAcceleratedPaint sends dmabuf to main Wayland subsurface via g_platform.present().
-class Client : public CefClient, public CefRenderHandler,
-               public CefLifeSpanHandler, public CefLoadHandler,
-               public CefContextMenuHandler, public CefDisplayHandler,
-               public CefKeyboardHandler {
+// Callback invoked for IPC messages from the renderer process.
+// Returns true if the message was handled.
+using MessageHandler = std::function<bool(const std::string& name,
+                                         CefRefPtr<CefListValue> args,
+                                         CefRefPtr<CefBrowser> browser)>;
+
+// Callback invoked after the browser is created (OnAfterCreated).
+using CreatedCallback = std::function<void(CefRefPtr<CefBrowser>)>;
+
+// Render target callbacks — decouple the client from the platform layer.
+struct RenderTarget {
+    void (*present)(const CefAcceleratedPaintInfo& info);
+    void (*present_software)(const CefRenderHandler::RectList& dirty,
+                             const void* buffer, int w, int h);
+};
+
+// Generic CEF browser client — pure rendering, lifecycle, context menu,
+// keyboard. Business logic is injected via setMessageHandler / setCreatedCallback.
+// Used for both the main browser and overlay browser; the only difference
+// is the RenderTarget passed at construction.
+class CefLayer : public CefClient, public CefRenderHandler,
+                 public CefLifeSpanHandler, public CefLoadHandler,
+                 public CefContextMenuHandler, public CefDisplayHandler,
+                 public CefKeyboardHandler {
 public:
+    explicit CefLayer(RenderTarget target) : target_(target) {}
+
+    void setMessageHandler(MessageHandler handler) { message_handler_ = std::move(handler); }
+    void setCreatedCallback(CreatedCallback cb) { on_after_created_ = std::move(cb); }
+
     CefRefPtr<CefRenderHandler> GetRenderHandler() override { return this; }
     CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() override { return this; }
     CefRefPtr<CefLoadHandler> GetLoadHandler() override { return this; }
@@ -25,9 +49,6 @@ public:
     CefRefPtr<CefDisplayHandler> GetDisplayHandler() override { return this; }
     CefRefPtr<CefKeyboardHandler> GetKeyboardHandler() override { return this; }
 
-    // CefKeyboardHandler — we only override Ctrl/Cmd+V on compositors
-    // where our platform clipboard is active (ext-data-control-v1). Other
-    // shortcuts (Copy, Cut, Select-All, etc.) fall through to CEF.
     bool OnPreKeyEvent(CefRefPtr<CefBrowser>, const CefKeyEvent&,
                        CefEventHandle, bool* is_keyboard_shortcut) override;
 
@@ -67,6 +88,7 @@ public:
     void execJs(const std::string& js);
 
 private:
+    RenderTarget target_;
     int width_ = 1280, height_ = 720;
     int physical_w_ = 1280, physical_h_ = 720;
     CefRefPtr<CefBrowser> browser_;
@@ -77,63 +99,7 @@ private:
     std::mutex load_mtx_;
     std::condition_variable load_cv_;
     CefRefPtr<CefRunContextMenuCallback> pending_menu_callback_;
-    IMPLEMENT_REFCOUNTING(Client);
-};
-
-// Overlay browser client -- handles server selection/loading UI.
-// OnAcceleratedPaint sends dmabuf to overlay Wayland subsurface via g_platform.overlay_present().
-class OverlayClient : public CefClient, public CefRenderHandler,
-                      public CefLifeSpanHandler, public CefLoadHandler,
-                      public CefContextMenuHandler,
-                      public CefKeyboardHandler {
-public:
-    CefRefPtr<CefRenderHandler> GetRenderHandler() override { return this; }
-    CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() override { return this; }
-    CefRefPtr<CefLoadHandler> GetLoadHandler() override { return this; }
-    CefRefPtr<CefContextMenuHandler> GetContextMenuHandler() override { return this; }
-    CefRefPtr<CefKeyboardHandler> GetKeyboardHandler() override { return this; }
-
-    bool OnPreKeyEvent(CefRefPtr<CefBrowser>, const CefKeyEvent&,
-                       CefEventHandle, bool* is_keyboard_shortcut) override;
-
-    void GetViewRect(CefRefPtr<CefBrowser>, CefRect& rect) override;
-    bool GetScreenInfo(CefRefPtr<CefBrowser>, CefScreenInfo& info) override;
-    void OnPaint(CefRefPtr<CefBrowser>, PaintElementType, const RectList&,
-                 const void*, int w, int h) override;
-    void OnAcceleratedPaint(CefRefPtr<CefBrowser>, PaintElementType type,
-                            const RectList&, const CefAcceleratedPaintInfo& info) override;
-    void OnAfterCreated(CefRefPtr<CefBrowser> browser) override;
-    void OnBeforeClose(CefRefPtr<CefBrowser>) override;
-    void OnLoadEnd(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame> frame, int) override;
-
-    bool OnProcessMessageReceived(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame>,
-                                  CefProcessId, CefRefPtr<CefProcessMessage> message) override;
-
-    void OnBeforeContextMenu(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame>,
-                             CefRefPtr<CefContextMenuParams>,
-                             CefRefPtr<CefMenuModel> model) override;
-    bool RunContextMenu(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame>,
-                        CefRefPtr<CefContextMenuParams>, CefRefPtr<CefMenuModel>,
-                        CefRefPtr<CefRunContextMenuCallback>) override;
-
-    void resize(int w, int h, int physical_w, int physical_h);
-    bool isClosed() const { return closed_; }
-    bool isLoaded() const { return loaded_; }
-    CefRefPtr<CefBrowser> browser() { return browser_; }
-    void waitForClose();
-    void waitForLoad();
-    void execJs(const std::string& js);
-
-private:
-    int width_ = 1280, height_ = 720;
-    int physical_w_ = 1280, physical_h_ = 720;
-    CefRefPtr<CefBrowser> browser_;
-    std::atomic<bool> closed_{false};
-    std::atomic<bool> loaded_{false};
-    std::mutex close_mtx_;
-    std::condition_variable close_cv_;
-    std::mutex load_mtx_;
-    std::condition_variable load_cv_;
-    CefRefPtr<CefRunContextMenuCallback> pending_menu_callback_;
-    IMPLEMENT_REFCOUNTING(OverlayClient);
+    MessageHandler message_handler_;
+    CreatedCallback on_after_created_;
+    IMPLEMENT_REFCOUNTING(CefLayer);
 };

--- a/src/common.h
+++ b/src/common.h
@@ -3,8 +3,6 @@
 #include <atomic>
 #include <cstdint>
 
-#include "include/cef_base.h"
-
 constexpr char hexdigit(uint32_t c, int i) {
     uint8_t n = (c >> (20 - i * 4)) & 0xF;
     return n < 10 ? '0' + n : 'a' + (n - 10);
@@ -32,12 +30,8 @@ constexpr Color kVideoBgColor{0x000000};
 #include "mpv/handle.h"
 #include "player/media_session.h"
 
-class Client;
-class OverlayClient;
 class WakeEvent;
 
-extern CefRefPtr<Client> g_client;
-extern CefRefPtr<OverlayClient> g_overlay_client;
 extern MpvHandle g_mpv;
 extern Platform g_platform;
 // Cross-thread state: written from mpv event loop / CEF IPC thread,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,9 @@
 #include "common.h"
 #include "cef/cef_app.h"
 #include "cef/cef_client.h"
+#include "browser/browsers.h"
+#include "browser/web_browser.h"
+#include "browser/overlay_browser.h"
 #include "mpv/event.h"
 #include "event_queue.h"
 #include "wake_event.h"
@@ -74,23 +77,18 @@ void update_idle_inhibit() {
     }
 }
 Platform g_platform{};
-CefRefPtr<Client> g_client;
-CefRefPtr<OverlayClient> g_overlay_client;
+WebBrowser* g_web_browser = nullptr;
+OverlayBrowser* g_overlay_browser = nullptr;
 
-// Close a browser if it exists. If browser() is still null, CreateBrowser
-// is in flight — OnAfterCreated will see g_shutting_down and close it.
-static void try_close(CefRefPtr<Client> c) {
-    if (c && c->browser()) c->browser()->GetHost()->CloseBrowser(true);
-}
-static void try_close(CefRefPtr<OverlayClient> c) {
-    if (c && c->browser()) c->browser()->GetHost()->CloseBrowser(true);
+static void try_close_browser(auto* b) {
+    if (b && b->browser()) b->browser()->GetHost()->CloseBrowser(true);
 }
 
 void initiate_shutdown() {
     bool expected = false;
     if (!g_shutting_down.compare_exchange_strong(expected, true)) return;
-    try_close(g_client);
-    try_close(g_overlay_client);
+    try_close_browser(g_web_browser);
+    try_close_browser(g_overlay_browser);
     g_shutdown_event.signal();
     // macOS main thread is parked in nextEventMatchingMask — post a sentinel
     // NSEvent so it returns and re-checks g_shutting_down.
@@ -178,7 +176,7 @@ static bool g_was_maximized_before_fullscreen = false;
 static void cef_consumer_thread() {
     LOG_INFO(LOG_MAIN, "[FLOW] cef_consumer_thread: waitForLoad() start");
     // Wait for main browser to load before processing events
-    g_client->waitForLoad();
+    g_web_browser->waitForLoad();
     LOG_INFO(LOG_MAIN, "[FLOW] cef_consumer_thread: waitForLoad() returned");
 
 #ifdef _WIN32
@@ -208,25 +206,25 @@ static void cef_consumer_thread() {
         g_cef_queue.drain_wake();
         MpvEvent ev;
         while (g_cef_queue.try_pop(ev)) {
-            if (!g_client) continue;
+            if (!g_web_browser) continue;
             switch (ev.type) {
             case MpvEventType::PAUSE:
                 g_playback_state = ev.flag ? PlaybackState::Paused : PlaybackState::Playing;
                 update_idle_inhibit();
-                g_client->execJs(ev.flag ? "window._nativeEmit('paused')" : "window._nativeEmit('playing')");
+                g_web_browser->execJs(ev.flag ? "window._nativeEmit('paused')" : "window._nativeEmit('playing')");
                 if (g_media_session)
                     g_media_session->setPlaybackState(ev.flag ? PlaybackState::Paused : PlaybackState::Playing);
                 break;
             case MpvEventType::TIME_POS: {
                 int ms = static_cast<int>(ev.dbl * 1000);
-                g_client->execJs("window._nativeUpdatePosition(" + std::to_string(ms) + ")");
+                g_web_browser->execJs("window._nativeUpdatePosition(" + std::to_string(ms) + ")");
                 if (g_media_session)
                     g_media_session->setPosition(static_cast<int64_t>(ev.dbl * 1000000));
                 break;
             }
             case MpvEventType::DURATION: {
                 int ms = static_cast<int>(ev.dbl * 1000);
-                g_client->execJs("window._nativeUpdateDuration(" + std::to_string(ms) + ")");
+                g_web_browser->execJs("window._nativeUpdateDuration(" + std::to_string(ms) + ")");
                 // Duration is set via metadata, not a separate call
                 break;
             }
@@ -239,52 +237,52 @@ static void cef_consumer_thread() {
                 } else {
                     g_was_maximized_before_fullscreen = false;
                 }
-                g_client->execJs("window._nativeFullscreenChanged(" + std::string(ev.flag ? "true" : "false") + ")");
+                g_web_browser->execJs("window._nativeFullscreenChanged(" + std::string(ev.flag ? "true" : "false") + ")");
                 break;
             case MpvEventType::SPEED:
-                g_client->execJs("window._nativeSetRate(" + std::to_string(ev.dbl) + ")");
+                g_web_browser->execJs("window._nativeSetRate(" + std::to_string(ev.dbl) + ")");
                 if (g_media_session)
                     g_media_session->setRate(ev.dbl);
                 break;
             case MpvEventType::SEEKING:
                 if (ev.flag) {
-                    g_client->execJs("window._nativeEmit('seeking')");
+                    g_web_browser->execJs("window._nativeEmit('seeking')");
                     if (g_media_session) g_media_session->emitSeeking();
                 }
                 break;
             case MpvEventType::FILE_LOADED:
                 g_playback_state = PlaybackState::Playing;
                 update_idle_inhibit();
-                g_client->execJs("window._nativeEmit('playing')");
+                g_web_browser->execJs("window._nativeEmit('playing')");
                 if (g_media_session)
                     g_media_session->setPlaybackState(PlaybackState::Playing);
                 break;
             case MpvEventType::END_FILE_EOF:
                 g_playback_state = PlaybackState::Stopped;
                 update_idle_inhibit();
-                g_client->execJs("window._nativeEmit('finished')");
+                g_web_browser->execJs("window._nativeEmit('finished')");
                 if (g_media_session)
                     g_media_session->setPlaybackState(PlaybackState::Stopped);
                 break;
             case MpvEventType::END_FILE_ERROR:
                 g_playback_state = PlaybackState::Stopped;
                 update_idle_inhibit();
-                g_client->execJs("window._nativeEmit('error','Playback error')");
+                g_web_browser->execJs("window._nativeEmit('error','Playback error')");
                 if (g_media_session)
                     g_media_session->setPlaybackState(PlaybackState::Stopped);
                 break;
             case MpvEventType::END_FILE_CANCEL:
                 g_playback_state = PlaybackState::Stopped;
                 update_idle_inhibit();
-                g_client->execJs("window._nativeEmit('canceled')");
+                g_web_browser->execJs("window._nativeEmit('canceled')");
                 if (g_media_session)
                     g_media_session->setPlaybackState(PlaybackState::Stopped);
                 break;
             case MpvEventType::OSD_DIMS:
-                if (g_client->browser())
-                    g_client->resize(ev.lw, ev.lh, ev.pw, ev.ph);
-                if (g_overlay_client && g_overlay_client->browser()) {
-                    g_overlay_client->resize(ev.lw, ev.lh, ev.pw, ev.ph);
+                if (g_web_browser->browser())
+                    g_web_browser->resize(ev.lw, ev.lh, ev.pw, ev.ph);
+                if (g_overlay_browser && g_overlay_browser->browser()) {
+                    g_overlay_browser->resize(ev.lw, ev.lh, ev.pw, ev.ph);
                     g_platform.overlay_resize(ev.lw, ev.lh, ev.pw, ev.ph);
                 }
                 break;
@@ -299,16 +297,16 @@ static void cef_consumer_thread() {
                 auto val = CefValue::Create();
                 val->SetList(list);
                 auto json = CefWriteJSON(val, JSON_WRITER_DEFAULT);
-                g_client->execJs("window._nativeUpdateBufferedRanges(" + json.ToString() + ")");
+                g_web_browser->execJs("window._nativeUpdateBufferedRanges(" + json.ToString() + ")");
                 break;
             }
             case MpvEventType::DISPLAY_FPS: {
                 int hz = g_display_hz.load(std::memory_order_relaxed);
                 LOG_INFO(LOG_MAIN, "Display refresh rate changed: %d Hz", hz);
-                if (g_client && g_client->browser())
-                    g_client->browser()->GetHost()->SetWindowlessFrameRate(hz);
-                if (g_overlay_client && g_overlay_client->browser())
-                    g_overlay_client->browser()->GetHost()->SetWindowlessFrameRate(hz);
+                if (g_web_browser && g_web_browser->browser())
+                    g_web_browser->browser()->GetHost()->SetWindowlessFrameRate(hz);
+                if (g_overlay_browser && g_overlay_browser->browser())
+                    g_overlay_browser->browser()->GetHost()->SetWindowlessFrameRate(hz);
                 break;
             }
             case MpvEventType::SHUTDOWN:
@@ -831,8 +829,9 @@ int main(int argc, char* argv[]) {
     bs.windowless_frame_rate = g_display_hz.load(std::memory_order_relaxed);
 
     // Main browser
-    g_client = new Client();
-    g_client->resize(lw, lh, (int)mw, (int)mh);
+    RenderTarget main_target{g_platform.present, g_platform.present_software};
+    g_web_browser = new WebBrowser(main_target);
+    g_web_browser->resize(lw, lh, (int)mw, (int)mh);
     g_platform.resize(lw, lh, (int)mw, (int)mh);
 
     std::string server_url = Settings::instance().serverUrl();
@@ -857,13 +856,14 @@ int main(int argc, char* argv[]) {
 
     LOG_INFO(LOG_MAIN, "[FLOW] CreateBrowser(main) url=%s lw=%d lh=%d pw=%lld ph=%lld",
              main_url.c_str(), lw, lh, (long long)mw, (long long)mh);
-    CefBrowserHost::CreateBrowser(wi, g_client, main_url, bs, nullptr, nullptr);
+    CefBrowserHost::CreateBrowser(wi, g_web_browser->client(), main_url, bs, nullptr, nullptr);
     LOG_INFO(LOG_MAIN, "[FLOW] CreateBrowser(main) call returned");
 
     // Overlay browser (server selection UI) -- only in full app mode
     if (!player_mode) {
-        g_overlay_client = new OverlayClient();
-        g_overlay_client->resize(lw, lh, (int)mw, (int)mh);
+        RenderTarget overlay_target{g_platform.overlay_present, g_platform.overlay_present_software};
+        g_overlay_browser = new OverlayBrowser(overlay_target, *g_web_browser);
+        g_overlay_browser->resize(lw, lh, (int)mw, (int)mh);
         g_platform.set_overlay_visible(true);
 
         CefWindowInfo owi;
@@ -878,14 +878,14 @@ int main(int argc, char* argv[]) {
         obs.background_color = 0;
         obs.windowless_frame_rate = g_display_hz.load(std::memory_order_relaxed);
         LOG_INFO(LOG_MAIN, "[FLOW] CreateBrowser(overlay)");
-        CefBrowserHost::CreateBrowser(owi, g_overlay_client, "app://resources/index.html", obs, nullptr, nullptr);
+        CefBrowserHost::CreateBrowser(owi, g_overlay_browser->client(), "app://resources/index.html", obs, nullptr, nullptr);
         LOG_INFO(LOG_MAIN, "[FLOW] CreateBrowser(overlay) call returned");
     }
 
 #ifdef __APPLE__
     // nothing — main thread pump happens below
 #else
-    g_client->waitForLoad();
+    g_web_browser->waitForLoad();
 #endif
     LOG_INFO(LOG_MAIN, "Main browser loaded");
 
@@ -924,8 +924,8 @@ int main(int argc, char* argv[]) {
     // report closed; dispatch blocks queued by OnScheduleMessagePumpWork
     // keep running CefDoMessageLoopWork as CEF posts new tasks. Event-
     // driven — CFRunLoopRunInMode wakes on any source firing.
-    while (!g_client->isClosed() ||
-           (g_overlay_client && !g_overlay_client->isClosed())) {
+    while (!g_web_browser->isClosed() ||
+           (g_overlay_browser && !g_overlay_browser->isClosed())) {
         CFRunLoopRunInMode(kCFRunLoopDefaultMode, 60.0, true);
     }
 
@@ -934,9 +934,9 @@ int main(int argc, char* argv[]) {
     // state that's about to be torn down by CefShutdown().
     App::ShutdownPump();
 #else
-    g_client->waitForClose();
-    if (g_overlay_client)
-        g_overlay_client->waitForClose();
+    g_web_browser->waitForClose();
+    if (g_overlay_browser)
+        g_overlay_browser->waitForClose();
 #endif
 
     // --- Cleanup ---
@@ -1002,8 +1002,8 @@ int main(int argc, char* argv[]) {
     }
 
     // CEF shutdown: all browsers must be closed first (guaranteed by waitForClose above)
-    g_client = nullptr;
-    g_overlay_client = nullptr;
+    delete g_web_browser; g_web_browser = nullptr;
+    delete g_overlay_browser; g_overlay_browser = nullptr;
     CefShutdown();
 
     // Platform cleanup (joins input thread, destroys subsurfaces)

--- a/src/platform/macos.mm
+++ b/src/platform/macos.mm
@@ -9,6 +9,9 @@
 
 #include "platform/platform.h"
 #include "common.h"
+#include "browser/browsers.h"
+#include "browser/overlay_browser.h"
+#include "browser/web_browser.h"
 #include "cef/cef_app.h"
 #include "cef/cef_client.h"
 #include "input/input_macos.h"
@@ -374,8 +377,6 @@ static void create_content_layer(NSView* contentView, CGRect frame, CGFloat scal
 // CADisplayLink → CEF BeginFrame
 // =====================================================================
 
-extern CefRefPtr<Client>        g_client;
-extern CefRefPtr<OverlayClient> g_overlay_client;
 // CADisplayLink target — fires on the main runloop at the display's
 // refresh rate, driving CEF's external BeginFrame production.
 @interface DisplayLinkTarget : NSObject
@@ -386,12 +387,12 @@ extern CefRefPtr<OverlayClient> g_overlay_client;
 - (void)tick:(CADisplayLink*)link {
     (void)link;
     if (g_shutting_down.load(std::memory_order_relaxed)) return;
-    if (g_client) {
-        CefRefPtr<CefBrowser> b = g_client->browser();
+    if (g_web_browser) {
+        CefRefPtr<CefBrowser> b = g_web_browser->browser();
         if (b) b->GetHost()->SendExternalBeginFrame();
     }
-    if (g_overlay_client) {
-        CefRefPtr<CefBrowser> b = g_overlay_client->browser();
+    if (g_overlay_browser) {
+        CefRefPtr<CefBrowser> b = g_overlay_browser->browser();
         if (b) b->GetHost()->SendExternalBeginFrame();
     }
 }
@@ -585,7 +586,7 @@ static void macos_present(const CefAcceleratedPaintInfo& info) {
     // frame is the reveal trigger. In normal mode this branch is a
     // no-op — macos_fade_overlay is responsible for unhiding the main
     // view when the overlay starts its fade-out.
-    if (!g_overlay_client && [g_main.view isHidden]) {
+    if (!g_overlay_browser && [g_main.view isHidden]) {
         [g_main.view setHidden:NO];
         reset_background_to_black();
     }
@@ -624,8 +625,8 @@ static void macos_set_overlay_visible(bool visible) {
     // don't show a caret and focus rings don't render. Matches the "active
     // tab" semantics: only one browser at a time holds focus. Mirrors the
     // Wayland path in wl_set_overlay_visible.
-    auto main = g_client ? g_client->browser() : nullptr;
-    auto ovl  = g_overlay_client ? g_overlay_client->browser() : nullptr;
+    auto main = g_web_browser ? g_web_browser->browser() : nullptr;
+    auto ovl  = g_overlay_browser ? g_overlay_browser->browser() : nullptr;
     if (visible) {
         if (main) main->GetHost()->SetFocus(false);
         if (ovl)  ovl->GetHost()->SetFocus(true);

--- a/src/platform/wayland.cpp
+++ b/src/platform/wayland.cpp
@@ -1,5 +1,8 @@
 #include "common.h"
 #include "cef/cef_client.h"
+#include "browser/browsers.h"
+#include "browser/web_browser.h"
+#include "browser/overlay_browser.h"
 #include "clipboard/wayland.h"
 #include "idle_inhibit_linux.h"
 #include "input/input_wayland.h"
@@ -374,8 +377,8 @@ static void wl_set_overlay_visible(bool visible) {
     // thinks the just-activated browser has no window focus, so text inputs
     // don't show a caret and focus rings don't render. Matches the "active
     // tab" semantics: only one browser at a time holds focus.
-    auto main = g_client ? g_client->browser() : nullptr;
-    auto ovl  = g_overlay_client ? g_overlay_client->browser() : nullptr;
+    auto main = g_web_browser ? g_web_browser->browser() : nullptr;
+    auto ovl  = g_overlay_browser ? g_overlay_browser->browser() : nullptr;
     if (visible) {
         if (main) main->GetHost()->SetFocus(false);
         if (ovl)  ovl->GetHost()->SetFocus(true);

--- a/src/platform/windows.cpp
+++ b/src/platform/windows.cpp
@@ -6,6 +6,9 @@
 #include "platform/platform.h"
 #include "common.h"
 #include "cef/cef_client.h"
+#include "browser/browsers.h"
+#include "browser/web_browser.h"
+#include "browser/overlay_browser.h"
 #include "input/input_windows.h"
 #include "logging.h"
 
@@ -313,8 +316,8 @@ static void win_set_overlay_visible(bool visible) {
     // thinks the just-activated browser has no window focus, so text inputs
     // don't show a caret and focus rings don't render. Matches the "active
     // tab" semantics: only one browser at a time holds focus.
-    auto main = g_client ? g_client->browser() : nullptr;
-    auto ovl  = g_overlay_client ? g_overlay_client->browser() : nullptr;
+    auto main = g_web_browser ? g_web_browser->browser() : nullptr;
+    auto ovl  = g_overlay_browser ? g_overlay_browser->browser() : nullptr;
     if (visible) {
         if (main) main->GetHost()->SetFocus(false);
         if (ovl)  ovl->GetHost()->SetFocus(true);

--- a/src/platform/x11.cpp
+++ b/src/platform/x11.cpp
@@ -1,5 +1,8 @@
 #include "common.h"
 #include "cef/cef_client.h"
+#include "browser/browsers.h"
+#include "browser/web_browser.h"
+#include "browser/overlay_browser.h"
 #include "idle_inhibit_linux.h"
 #include "input/input_x11.h"
 
@@ -342,8 +345,8 @@ static void x11_set_overlay_visible(bool visible) {
     }
 
     // Route keyboard focus to the active browser
-    auto main = g_client ? g_client->browser() : nullptr;
-    auto ovl  = g_overlay_client ? g_overlay_client->browser() : nullptr;
+    auto main = g_web_browser ? g_web_browser->browser() : nullptr;
+    auto ovl  = g_overlay_browser ? g_overlay_browser->browser() : nullptr;
     if (visible) {
         if (main) main->GetHost()->SetFocus(false);
         if (ovl)  ovl->GetHost()->SetFocus(true);

--- a/src/player/media_session.cpp
+++ b/src/player/media_session.cpp
@@ -1,6 +1,7 @@
 #include "player/media_session.h"
 #include "common.h"
-#include "cef/cef_client.h"
+#include "browser/browsers.h"
+#include "browser/web_browser.h"
 
 #ifdef __APPLE__
 #include "player/macos/media_session_macos.h"
@@ -36,14 +37,14 @@ void MediaSession::wireTransportCallbacks() {
     onStop = []() { g_mpv.Stop(); };
     onSetRate = [](double rate) { g_mpv.SetSpeed(rate); };
     onNext = []() {
-        if (g_client) g_client->execJs("if(window._nativeHostInput) window._nativeHostInput(['next']);");
+        if (g_web_browser) g_web_browser->execJs("if(window._nativeHostInput) window._nativeHostInput(['next']);");
     };
     onPrevious = []() {
-        if (g_client) g_client->execJs("if(window._nativeHostInput) window._nativeHostInput(['previous']);");
+        if (g_web_browser) g_web_browser->execJs("if(window._nativeHostInput) window._nativeHostInput(['previous']);");
     };
     onSeek = [](int64_t position_us) {
         int ms = static_cast<int>(position_us / 1000);
-        if (g_client) g_client->execJs("if(window._nativeSeek) window._nativeSeek(" + std::to_string(ms) + ");");
+        if (g_web_browser) g_web_browser->execJs("if(window._nativeSeek) window._nativeSeek(" + std::to_string(ms) + ");");
     };
 }
 

--- a/src/web/mpv-video-player.js
+++ b/src/web/mpv-video-player.js
@@ -250,6 +250,7 @@
 
         removeMediaDialog() {
             window.api.player.stop();
+            if (window.jmpNative) window.jmpNative.playerOsdActive(false);
             window.api.player.setVideoRectangle(-1, 0, 0, 0);
             document.body.classList.remove('hide-scroll');
             const dlg = this._videoDialog;
@@ -269,6 +270,7 @@
         createMediaElement(options) {
             let dlg = document.querySelector('.videoPlayerContainer');
             if (!dlg) {
+                if (window.jmpNative) window.jmpNative.playerOsdActive(true);
                 dlg = document.createElement('div');
                 dlg.classList.add('videoPlayerContainer');
                 dlg.style.cssText = 'position:fixed;top:0;bottom:0;left:0;right:0;display:flex;align-items:center;background:transparent;';


### PR DESCRIPTION
Extract all app-specific IPC handling out of the CEF layer into WebBrowser and OverlayBrowser wrapper classes that each own a generic CefLayer instance. The CEF client (CefLayer) is now purely rendering, lifecycle, context menu, and keyboard — no player, settings, or media session logic.

- Unify Client/OverlayClient into a single CefLayer class parameterized by RenderTarget. Business logic injected via MessageHandler callback.
- Make cef_app.cpp IPC relay fully generic: data-driven function registration, type-based argument serialization. Adding new IPC messages no longer requires touching CEF code.
- Remove all CEF types from common.h.
- Add playerOsdActive(bool) IPC from JS to track video player OSD lifecycle. Fullscreen is only auto-restored when the OSD closes AND the window was not already fullscreen before the OSD opened — episode transitions no longer exit fullscreen.