### PR TITLE
Maybe fix Windows crash on startup when topmost DComp target is contested

### DIFF
--- a/dev/windows/sync-ssh.sh
+++ b/dev/windows/sync-ssh.sh
@@ -27,6 +27,7 @@ sync_to_remote() {
         --filter '- /third_party/mpv/build/**' \
         --filter '+ /third_party/mpv/**' \
         --filter '+ /third_party/letsmove/**' \
+        --filter '+ /third_party/quill/**' \
         --filter '+ /third_party/GL/**' \
         --filter '+ /third_party/KHR/**' \
         --filter '- /third_party/**' \

--- a/src/platform/windows.cpp
+++ b/src/platform/windows.cpp
@@ -122,7 +122,7 @@ static bool init_dcomp() {
         return false;
     }
 
-    hr = g_win.dcomp_device->CreateTargetForHwnd(g_win.mpv_hwnd, TRUE, &g_win.dcomp_target);
+    hr = g_win.dcomp_device->CreateTargetForHwnd(g_win.mpv_hwnd, FALSE, &g_win.dcomp_target);
     if (FAILED(hr)) {
         LOG_ERROR(LOG_PLATFORM, "CreateTargetForHwnd failed: 0x{:08x}", hr);
         return false;


### PR DESCRIPTION
## Summary

- `CreateTargetForHwnd(..., topmost=TRUE, ...)` fails with `DCOMPOSITION_ERROR_WINDOW_ALREADY_COMPOSED` (`0x88980800`) when another DComp device already owns a topmost target on mpv's HWND. Third-party overlays (RivaTuner Statistics Server / MSI Afterburner, GeForce Experience, Discord, screen recorders) routinely claim this — which is why reports cluster on Nvidia systems. The failure surfaces as an immediate window flash + exit.
- We don't need topmost: mpv renders Vulkan directly to the HWND via normal window paint, so any DComp target already composites above the video layer.
- Also adds `third_party/quill` to the Windows SSH sync filter so remote builds don't fail on missing vendored sources.

Fixes #153.

## Test plan

- [ ] Affected reporter confirms startup no longer crashes
- [ ] Main UI + overlay still render correctly over mpv video