### PR TITLE
macOS: Tag CEF IOSurfaces as sRGB; refactor mpv options

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -522,57 +522,10 @@ int main(int argc, char* argv[]) {
     setenv("MPV_HOME", mpv_home.c_str(), 1);
 #endif
 
-    g_mpv = MpvHandle::Create();
+    g_mpv = MpvHandle::Create(g_platform.display);
     if (!g_mpv.IsValid()) { LOG_ERROR(LOG_MAIN, "mpv_create failed"); return 1; }
 
-#ifdef __APPLE__
-    setenv("MPVBUNDLE", "true", 1);
-#endif
-
-    g_mpv.SetOptionString("hwdec", hwdec_str);
-    g_mpv.SetOptionString("osd-level", "0");
-    g_mpv.SetOptionString("osc", "no");
-    g_mpv.SetOptionString("display-tags", "");  // suppress "Title: ...", "Artist: ..." tag dump
-    g_mpv.SetOptionString("input-default-bindings", "no");
-    g_mpv.SetOptionString("input-vo-keyboard", "no");
-    g_mpv.SetOptionString("input-vo-cursor", "no");
-    g_mpv.SetOptionString("input-cursor", "no");
-    // X11's WM_DELETE_WINDOW routes through mpv's input system as
-    // CLOSE_WIN — input-keyboard=no drops it, breaking the close button.
-#if defined(_WIN32) || defined(__APPLE__)
-    g_mpv.SetOptionString("input-keyboard", "no");
-#else
-    if (use_wayland)
-        g_mpv.SetOptionString("input-keyboard", "no");
-#endif
-    g_mpv.SetOptionString("stop-screensaver", "no");
-    g_mpv.SetOptionString("keepaspect-window", "no");
-    g_mpv.SetOptionString("auto-window-resize", "no");
-    g_mpv.SetOptionString("border", "yes");
-    g_mpv.SetOptionString("title", "Jellyfin Desktop");
-    g_mpv.SetOptionString("wayland-app-id", "org.jellyfin.JellyfinDesktop");
-#ifdef _WIN32
-    // Tell mpv to load window icon from our exe resources (read at class
-    // registration time, before any window is created — no icon flash)
-    SetEnvironmentVariableW(L"MPV_WINDOW_ICON", L"IDI_ICON1");
-#endif
-#ifdef __APPLE__
-    // macOS VO (mac_common.swift:37) uses DispatchQueue.main.sync for window
-    // creation. mp_initialize (main.c:435) calls handle_force_window when
-    // force_vo==2 ("immediate"), which deadlocks because main is blocked in
-    // mpv_initialize and can't service GCD.
-    //
-    // force-window=yes (force_vo=1) SKIPS the init-time call. idle=yes makes
-    // core_thread enter idle_loop (playloop.c:1349), which calls
-    // handle_force_window(mpctx, true) from the core thread. By that point,
-    // main has returned from mpv_initialize and is pumping GCD in the VO
-    // wait loop — DispatchQueue.main.sync succeeds.
-    g_mpv.SetOptionString("force-window", "yes");
-    g_mpv.SetOptionString("idle", "yes");
-#else
-    g_mpv.SetOptionString("force-window", "yes");
-    g_mpv.SetOptionString("idle", "yes");
-#endif
+    g_mpv.SetHwdec(hwdec_str);
     g_mpv.SetOptionString("background-color", kBgColor.hex);
 
     // Restore saved window geometry. mpv's macOS VO honors the --geometry
@@ -613,12 +566,12 @@ int main(int argc, char* argv[]) {
             }
             audio_passthrough_str = filtered;
         }
-        g_mpv.SetOptionString("audio-spdif", audio_passthrough_str);
+        g_mpv.SetAudioSpdif(audio_passthrough_str);
     }
     if (audio_exclusive)
-        g_mpv.SetOptionString("audio-exclusive", "yes");
+        g_mpv.SetAudioExclusive(true);
     if (!audio_channels_str.empty())
-        g_mpv.SetOptionString("audio-channels", audio_channels_str);
+        g_mpv.SetAudioChannels(audio_channels_str);
 
     // Register property observations before mpv_initialize. On macOS,
     // core_thread races to DispatchQueue.main.sync immediately after init

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,6 +16,7 @@
 #include "browser/web_browser.h"
 #include "browser/overlay_browser.h"
 #include "mpv/event.h"
+#include "mpv/options.h"
 #include "event_queue.h"
 #include "wake_event.h"
 #include "paths/paths.h"
@@ -338,7 +339,7 @@ int main(int argc, char* argv[]) {
     if (int rc = CefRuntime::Start(argc, argv); rc >= 0) return rc;
 
     // --- Parse CLI ---
-    std::string hwdec_str = "auto-safe";
+    std::string hwdec_str = kHwdecDefault;
     std::string audio_passthrough_str;
     bool audio_exclusive = false;
     std::string audio_channels_str;
@@ -369,7 +370,7 @@ int main(int argc, char* argv[]) {
                    "  -v, --version             Show version\n"
                    "  --log-level <level>       trace|debug|info|warn|error\n"
                    "  --log-file <path>         Write logs to file ('' to disable)\n"
-                   "  --hwdec <mode>            Hardware decoding mode (default: auto-safe)\n"
+                   "  --hwdec <mode>            Hardware decoding mode (default: auto)\n"
                    "  --audio-passthrough <codecs>  e.g. ac3,dts-hd,eac3,truehd\n"
                    "  --audio-exclusive         Exclusive audio output\n"
                    "  --audio-channels <layout> e.g. stereo, 5.1, 7.1\n"
@@ -426,6 +427,8 @@ int main(int argc, char* argv[]) {
             player_playlist.push_back(argv[i]);
         }
     }
+
+    if (!isValidHwdec(hwdec_str)) hwdec_str = kHwdecDefault;
 
     // --log-file overrides default; empty argument disables file logging entirely.
     // Default to a platform log file on macOS/Windows (GUI apps have no

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -325,15 +325,13 @@ int main(int argc, char* argv[]) {
     // They must hit CefExecuteProcess immediately and exit — before CLI parsing,
     // settings, single instance, or anything else touches shared state.
 #ifdef _WIN32
-    g_platform = make_windows_platform();
-    g_platform.early_init();
+    g_platform = make_platform(DisplayBackend::Windows);
 #elif defined(__APPLE__)
-    g_platform = make_macos_platform();
-    g_platform.early_init();
+    g_platform = make_platform(DisplayBackend::macOS);
 #else
     // Linux: runtime detection, overridable with --platform.
-    // Deferred to after CLI parsing. Both platforms' early_init are no-ops,
-    // and CEF subprocesses exit at CefExecuteProcess before any platform use.
+    // Deferred to after CLI parsing — CEF subprocesses exit at
+    // CefExecuteProcess before any platform use.
 #endif
 
     if (int rc = CefRuntime::Start(argc, argv); rc >= 0) return rc;
@@ -464,29 +462,30 @@ int main(int argc, char* argv[]) {
 
     // --- Linux platform selection ---
 #if !defined(_WIN32) && !defined(__APPLE__)
-    bool use_wayland;
-    if (platform_override == "wayland")
-        use_wayland = true;
-    else if (platform_override == "x11")
-        use_wayland = false;
-    else if (!platform_override.empty()) {
-        fprintf(stderr, "Unknown platform: %s (expected wayland or x11)\n",
-                platform_override.c_str());
-        return 1;
-    } else {
-        use_wayland = getenv("WAYLAND_DISPLAY") || !getenv("DISPLAY");
-    }
-#ifdef HAVE_X11
-    g_platform = use_wayland ? make_wayland_platform() : make_x11_platform();
-#else
-    if (!use_wayland) {
-        fprintf(stderr, "X11 detected but X11 support not compiled in\n");
-        return 1;
-    }
-    g_platform = make_wayland_platform();
+    {
+        DisplayBackend backend;
+        if (platform_override == "wayland")
+            backend = DisplayBackend::Wayland;
+        else if (platform_override == "x11")
+            backend = DisplayBackend::X11;
+        else if (!platform_override.empty()) {
+            fprintf(stderr, "Unknown platform: %s (expected wayland or x11)\n",
+                    platform_override.c_str());
+            return 1;
+        } else {
+            backend = (getenv("WAYLAND_DISPLAY") || !getenv("DISPLAY"))
+                    ? DisplayBackend::Wayland : DisplayBackend::X11;
+        }
+#ifndef HAVE_X11
+        if (backend == DisplayBackend::X11) {
+            fprintf(stderr, "X11 detected but X11 support not compiled in\n");
+            return 1;
+        }
 #endif
-    g_platform.early_init();
-    LOG_INFO(LOG_MAIN, "Display backend: {}", use_wayland ? "wayland" : "x11");
+        g_platform = make_platform(backend);
+    }
+    LOG_INFO(LOG_MAIN, "Display backend: {}",
+             g_platform.display == DisplayBackend::Wayland ? "wayland" : "x11");
 #endif
 
     // --- Signal handlers ---
@@ -644,7 +643,7 @@ int main(int argc, char* argv[]) {
     // Resolve effective ozone platform so CEF clients can check it.
 #if !defined(_WIN32) && !defined(__APPLE__)
     if (ozone_platform.empty())
-        ozone_platform = use_wayland ? "wayland" : "x11";
+        ozone_platform = g_platform.display == DisplayBackend::Wayland ? "wayland" : "x11";
 #endif
     g_platform.cef_ozone_platform = ozone_platform;
     if (!g_platform.init(g_mpv.Get())) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -529,10 +529,7 @@ int main(int argc, char* argv[]) {
     setenv("MPVBUNDLE", "true", 1);
 #endif
 
-    g_mpv.SetOptionString("vo", "gpu-next");
-    g_mpv.SetOptionString("gpu-api", "vulkan");
     g_mpv.SetOptionString("hwdec", hwdec_str);
-    g_mpv.SetOptionString("target-colorspace-hint", "yes");
     g_mpv.SetOptionString("osd-level", "0");
     g_mpv.SetOptionString("osc", "no");
     g_mpv.SetOptionString("display-tags", "");  // suppress "Title: ...", "Artist: ..." tag dump

--- a/src/mpv/handle.h
+++ b/src/mpv/handle.h
@@ -5,6 +5,8 @@
 #include <vector>
 #include <cstring>
 
+#include "platform/display_backend.h"
+
 /**
  * Typed wrapper for mpv_handle. Encapsulates the mpv instance so it doesn't
  * need to be passed around. All methods are typesafe and handle format
@@ -21,8 +23,11 @@ public:
     // Creation and initialization
     // =====================================================================
 
-    static MpvHandle Create() {
-        return MpvHandle(mpv_create());
+    static MpvHandle Create(DisplayBackend display) {
+        MpvHandle mpv(mpv_create());
+        if (mpv.IsValid())
+            mpv.SetDefaults(display);
+        return mpv;
     }
 
     int Initialize() {
@@ -52,6 +57,12 @@ public:
         int flag = value ? 1 : 0;
         mpv_set_option(handle_, name.c_str(), MPV_FORMAT_FLAG, &flag);
     }
+
+    // Typed option setters (must be called before Initialize)
+    void SetHwdec(const std::string& mode)          { SetOptionString("hwdec", mode); }
+    void SetAudioSpdif(const std::string& codecs)    { SetOptionString("audio-spdif", codecs); }
+    void SetAudioExclusive(bool v)                   { SetOptionFlag("audio-exclusive", v); }
+    void SetAudioChannels(const std::string& layout)  { SetOptionString("audio-channels", layout); }
 
     // =====================================================================
     // Property access (synchronous - safe in main thread)
@@ -165,6 +176,54 @@ public:
     }
 
 private:
+    // =====================================================================
+    // Default options (called by Create)
+    // =====================================================================
+
+    void SetDefaults(DisplayBackend display) {
+#ifdef __APPLE__
+        setenv("MPVBUNDLE", "true", 1);
+#endif
+
+        // Disable OSD/OSC — CEF overlay handles all UI
+        SetOptionString("osd-level", "0");
+        SetOptionString("osc", "no");
+        SetOptionString("display-tags", "");
+
+        // Disable all mpv input — we own input and route through CEF
+        SetOptionString("input-default-bindings", "no");
+        SetOptionString("input-vo-keyboard", "no");
+        SetOptionString("input-vo-cursor", "no");
+        SetOptionString("input-cursor", "no");
+        // X11's WM_DELETE_WINDOW routes through mpv's input system as
+        // CLOSE_WIN — input-keyboard=no drops it, breaking the close button.
+#if defined(_WIN32) || defined(__APPLE__)
+        SetOptionString("input-keyboard", "no");
+#else
+        if (display == DisplayBackend::Wayland)
+            SetOptionString("input-keyboard", "no");
+#endif
+
+        // Window behavior
+        SetOptionString("stop-screensaver", "no");
+        SetOptionString("keepaspect-window", "no");
+        SetOptionString("auto-window-resize", "no");
+        SetOptionString("border", "yes");
+        SetOptionString("title", "Jellyfin Desktop");
+        SetOptionString("wayland-app-id", "org.jellyfin.JellyfinDesktop");
+#ifdef _WIN32
+        // Tell mpv to load window icon from our exe resources
+        SetEnvironmentVariableW(L"MPV_WINDOW_ICON", L"IDI_ICON1");
+#endif
+
+        // Keep window open when idle (no media loaded).
+        // force-window=yes (not "immediate") avoids a macOS deadlock:
+        // "immediate" calls handle_force_window during mpv_initialize, which
+        // triggers DispatchQueue.main.sync while main is blocked in init.
+        SetOptionString("force-window", "yes");
+        SetOptionString("idle", "yes");
+    }
+
     // =====================================================================
     // Property modification (asynchronous - safe from any thread)
     // =====================================================================

--- a/src/mpv/handle.h
+++ b/src/mpv/handle.h
@@ -213,7 +213,7 @@ private:
         SetOptionString("wayland-app-id", "org.jellyfin.JellyfinDesktop");
 #ifdef _WIN32
         // Tell mpv to load window icon from our exe resources
-        SetEnvironmentVariableW(L"MPV_WINDOW_ICON", L"IDI_ICON1");
+        _putenv_s("MPV_WINDOW_ICON", "IDI_ICON1");
 #endif
 
         // Keep window open when idle (no media loaded).

--- a/src/mpv/options.h
+++ b/src/mpv/options.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+constexpr const char* kHwdecDefault = "auto";
+
+inline std::vector<std::string> hwdecOptions() {
+    return {
+        "auto", "no",
+#ifdef __linux__
+        "vaapi", "nvdec", "vulkan",
+#endif
+#ifdef _WIN32
+        "d3d11va", "nvdec", "vulkan",
+#endif
+#ifdef __APPLE__
+        "videotoolbox", "vulkan",
+#endif
+    };
+}
+
+inline bool isValidHwdec(const std::string& value) {
+    for (const auto& o : hwdecOptions())
+        if (o == value) return true;
+    return false;
+}

--- a/src/platform/display_backend.h
+++ b/src/platform/display_backend.h
@@ -1,0 +1,3 @@
+#pragma once
+
+enum class DisplayBackend { Wayland, X11, Windows, macOS };

--- a/src/platform/macos.mm
+++ b/src/platform/macos.mm
@@ -1,10 +1,9 @@
 // platform_macos.mm — macOS platform layer.
-// Two plain CALayers composite CEF IOSurfaces (main + overlay) onto mpv's
+// Two CAMetalLayers composite CEF content (main + overlay) onto mpv's
 // window. CEF delivers straight-alpha BGRA via OnAcceleratedPaint; a Metal
-// pass converts to premultiplied into a small IOSurface pool we own, then
-// assigns that IOSurface as layer.contents — CoreAnimation handles the
-// actual compositing on its render-server thread. No CAMetalLayer, no
-// nextDrawable, no VSync-bound blocking on the main thread.
+// pass converts to premultiplied alpha and renders into the layer's
+// nextDrawable. CAMetalLayer.colorspace = sRGB tells CoreAnimation how to
+// color-manage the content into the window's working space (P3/EDR).
 // Input is owned by src/input/input_macos.mm.
 
 #include "platform/platform.h"
@@ -76,67 +75,32 @@ static void macos_pump();
 @end
 
 // =====================================================================
-// Compositor state (two CALayers: main + overlay)
+// Compositor state (two CAMetalLayers: main + overlay)
 // =====================================================================
 //
 // CEF's OSR pipeline delivers a BGRA8 IOSurface in STRAIGHT alpha via
 // OnAcceleratedPaint (confirmed from Chromium: components/viz/service/
 // frame_sinks/video_capture/video_capture_overlay_unittest.cc:476-477
 // "kUnpremul_SkAlphaType since that is the semantics of PIXEL_FORMAT_ARGB").
-// CoreAnimation expects premultiplied contents, so we can't use the CEF
-// IOSurface as layer.contents directly — CoreAnimation would composite the
-// edges too bright.
-//
-// Design:
-//
-//   [CEF IOSurface, straight alpha]
-//       │ MTLTexture wrap (read)
-//       ▼
-//   Metal render pass (premultiply in fragment shader)
-//       │ writes to
-//       ▼
-//   [Our IOSurface, premultiplied alpha]  ← pool of 3, round-robin
-//       │ command buffer completion handler
-//       │ dispatches to main queue
-//       ▼
-//   layer.contents = (id)ourIOSurface; [CATransaction commit];
-//       │
-//       ▼
-//   CoreAnimation composites on its own render server thread.
-//
-// This is the macOS analogue of the Wayland dmabuf→wl_surface.attach path.
-// The Metal pass is fast (sub-millisecond to encode+commit), non-blocking,
-// and runs the GPU work on Metal's private queue. The main thread's
-// OnAcceleratedPaint returns before CoreAnimation ever touches the result.
-//
-// A pool of 3 IOSurfaces per layer provides safe rotation: when we assign
-// surface N to the layer, surface N-2 (the one we'll overwrite next) is
-// two frames old — well past the point where the render server could still
-// be reading it.
+// CoreAnimation expects premultiplied contents, so we render CEF's
+// IOSurface into a CAMetalLayer drawable with premultiplication in the
+// fragment shader. CAMetalLayer.colorspace = sRGB tells CA how to
+// color-manage the content for the display (P3, EDR, etc.).
 
 static id<MTLDevice> g_mtl_device = nil;
 static id<MTLCommandQueue> g_mtl_queue = nil;
 static id<MTLRenderPipelineState> g_mtl_pipeline = nil;
 
-constexpr int kPoolSize = 3;
 
 struct LayerState {
     NSView* __strong view;
-    CALayer* __strong layer;
+    CAMetalLayer* __strong layer;
 
     // Input side: CEF's IOSurface, wrapped as an MTLTexture for sampling.
     // Recreated when the input IOSurface changes (new frame may use a new
     // backing surface from CEF's own pool).
     IOSurfaceRef cached_input;
     id<MTLTexture> __strong input_texture;
-
-    // Output side: our premultiplied IOSurfaces + render-target MTLTexture
-    // wrappers. All sized pool_w × pool_h in physical pixels.
-    IOSurfaceRef pool[kPoolSize];
-    id<MTLTexture> __strong pool_textures[kPoolSize];
-    int pool_w;
-    int pool_h;
-    int next_write;  // round-robin index into pool[]
 };
 
 static LayerState g_main{};
@@ -190,70 +154,13 @@ fragment float4 fragmentShader(VertexOut in [[stage_in]],
 )";
 
 // =====================================================================
-// IOSurface pool management
+// Input surface caching
 // =====================================================================
 
-static IOSurfaceRef create_premul_iosurface(int w, int h) {
-    NSDictionary* props = @{
-        (__bridge NSString*)kIOSurfaceWidth:           @(w),
-        (__bridge NSString*)kIOSurfaceHeight:          @(h),
-        (__bridge NSString*)kIOSurfaceBytesPerElement: @(4),
-        (__bridge NSString*)kIOSurfacePixelFormat:     @((uint32_t)'BGRA'),
-    };
-    return IOSurfaceCreate((__bridge CFDictionaryRef)props);
-}
-
-static void release_pool(LayerState& s) {
-    for (int i = 0; i < kPoolSize; i++) {
-        s.pool_textures[i] = nil;
-        if (s.pool[i]) {
-            CFRelease(s.pool[i]);
-            s.pool[i] = nullptr;
-        }
-    }
-    s.pool_w = 0;
-    s.pool_h = 0;
-    s.next_write = 0;
-}
-
-// Ensure the output IOSurface pool matches the input pixel dimensions.
-// Recreates everything if the size changed. Returns true if the pool is
-// ready to use.
-static bool ensure_pool(LayerState& s, int w, int h) {
-    if (s.pool_w == w && s.pool_h == h && s.pool[0] != nullptr) return true;
-
-    LOG_INFO(LOG_PLATFORM, "[POOL] resize {}x{} -> {}x{}", s.pool_w, s.pool_h, w, h);
-    release_pool(s);
-
-    for (int i = 0; i < kPoolSize; i++) {
-        s.pool[i] = create_premul_iosurface(w, h);
-        if (!s.pool[i]) {
-            LOG_ERROR(LOG_PLATFORM, "[POOL] IOSurfaceCreate failed i={} {}x{}", i, w, h);
-            release_pool(s);
-            return false;
-        }
-        MTLTextureDescriptor* desc = [MTLTextureDescriptor
-            texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm
-            width:w height:h mipmapped:NO];
-        desc.usage = MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead;
-        desc.storageMode = MTLStorageModeShared;
-        s.pool_textures[i] = [g_mtl_device newTextureWithDescriptor:desc
-                                                            iosurface:s.pool[i]
-                                                                plane:0];
-        if (!s.pool_textures[i]) {
-            LOG_ERROR(LOG_PLATFORM, "[POOL] newTextureWithDescriptor:iosurface: failed i={}", i);
-            release_pool(s);
-            return false;
-        }
-    }
-    s.pool_w = w;
-    s.pool_h = h;
-    s.next_write = 0;
-    return true;
-}
-
 // Wrap the CEF input IOSurface as an MTLTexture for sampling. Recreated
-// when the input surface identity changes.
+// when the input surface identity changes. Also updates the layer's
+// colorspace from the IOSurface's kIOSurfaceColorSpace tag (set by
+// Chromium's viz compositor). Falls back to sRGB if untagged.
 static bool wrap_input_surface(LayerState& s, IOSurfaceRef surface, int w, int h) {
     if (surface == s.cached_input && s.input_texture != nil) return true;
 
@@ -271,13 +178,23 @@ static bool wrap_input_surface(LayerState& s, IOSurfaceRef surface, int w, int h
     }
     s.input_texture = tex;
     s.cached_input = surface;
+
+    CFTypeRef cs = IOSurfaceCopyValue(surface, kIOSurfaceColorSpace);
+    if (cs && CFGetTypeID(cs) == CFStringGetTypeID()) {
+        CGColorSpaceRef cg = CGColorSpaceCreateWithName((CFStringRef)cs);
+        if (cg) {
+            s.layer.colorspace = cg;
+            CGColorSpaceRelease(cg);
+        }
+    }
+    if (cs) CFRelease(cs);
+
     return true;
 }
 
 // =====================================================================
-// Present helper: encode the straight→premultiplied conversion pass to
-// one of our pool IOSurfaces, then asynchronously assign it as the
-// layer's contents once the GPU write is complete.
+// Present helper: render CEF's straight-alpha IOSurface into the
+// CAMetalLayer's next drawable with premultiplied alpha.
 // =====================================================================
 
 static void present_iosurface(LayerState& s, const CefAcceleratedPaintInfo& info) {
@@ -297,21 +214,22 @@ static void present_iosurface(LayerState& s, const CefAcceleratedPaintInfo& info
     int h = IOSurfaceGetHeight(surface);
 
     if (!wrap_input_surface(s, surface, w, h)) return;
-    if (!ensure_pool(s, w, h)) return;
 
-    // Pick the next pool slot. Round-robin through kPoolSize buffers so the
-    // slot we write to is always at least (kPoolSize-1) frames away from
-    // whatever the render server might still be reading.
-    int slot = s.next_write;
-    s.next_write = (s.next_write + 1) % kPoolSize;
-
-    IOSurfaceRef out_surface = s.pool[slot];
-    id<MTLTexture> out_texture = s.pool_textures[slot];
-    CALayer* target_layer = s.layer;
+    // Update drawable size if the input dimensions changed.
+    CGSize cur = s.layer.drawableSize;
+    if ((int)cur.width != w || (int)cur.height != h) {
+        s.layer.drawableSize = CGSizeMake(w, h);
+    }
 
     @autoreleasepool {
+        id<CAMetalDrawable> drawable = [s.layer nextDrawable];
+        if (!drawable) {
+            LOG_WARN(LOG_PLATFORM, "[METAL] nextDrawable returned nil");
+            return;
+        }
+
         MTLRenderPassDescriptor* passDesc = [MTLRenderPassDescriptor renderPassDescriptor];
-        passDesc.colorAttachments[0].texture     = out_texture;
+        passDesc.colorAttachments[0].texture     = drawable.texture;
         passDesc.colorAttachments[0].loadAction  = MTLLoadActionClear;
         passDesc.colorAttachments[0].storeAction = MTLStoreActionStore;
         passDesc.colorAttachments[0].clearColor  = MTLClearColorMake(0, 0, 0, 0);
@@ -323,42 +241,32 @@ static void present_iosurface(LayerState& s, const CefAcceleratedPaintInfo& info
         [enc setFragmentTexture:s.input_texture atIndex:0];
         [enc drawPrimitives:MTLPrimitiveTypeTriangle vertexStart:0 vertexCount:3];
         [enc endEncoding];
+        [cmdBuf presentDrawable:drawable];
         [cmdBuf commit];
-
-        // Assign the output IOSurface as the layer's contents synchronously,
-        // right after commit. The GPU write may not be finished yet, but
-        // Metal tracks IOSurface hazards across GPU contexts: when
-        // WindowServer's render process reads this surface (at the next
-        // CoreAnimation tick), Metal stalls the read until our write is
-        // complete. No explicit fence / completion handler / main-queue hop
-        // needed, and typing latency drops by the cost of those hops.
-        [CATransaction begin];
-        [CATransaction setDisableActions:YES];
-        target_layer.contents = (__bridge id)out_surface;
-        [CATransaction commit];
     }
 }
 
 // =====================================================================
-// Helper: create a plain CALayer + hosting NSView
+// Helper: create a CAMetalLayer + hosting NSView
 // =====================================================================
 
 static void create_content_layer(NSView* contentView, CGRect frame, CGFloat scale,
-                                 NSView* __strong& out_view, CALayer* __strong& out_layer,
+                                 NSView* __strong& out_view, CAMetalLayer* __strong& out_layer,
                                  NSView* positionAbove) {
     out_view = [[NSView alloc] initWithFrame:frame];
     [out_view setWantsLayer:YES];
     [out_view setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
 
-    out_layer = [CALayer layer];
+    out_layer = [CAMetalLayer layer];
+    out_layer.device = g_mtl_device;
+    out_layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
+    CGColorSpaceRef srgb = CGColorSpaceCreateWithName(kCGColorSpaceSRGB);
+    out_layer.colorspace = srgb;
+    CGColorSpaceRelease(srgb);
+    out_layer.framebufferOnly = YES;
     out_layer.frame = frame;
     out_layer.contentsScale = scale;
     out_layer.opaque = NO;
-    // 1:1 pixel mapping: display the contents IOSurface at its native size,
-    // anchored at the top-left. Gaps during resize (when our IOSurface is
-    // smaller than the layer) are acceptable; stretching is not.
-    // See CLAUDE.md: "No texture stretching during resize".
-    out_layer.contentsGravity = kCAGravityTopLeft;
     // Disable implicit animations on property changes — we update contents
     // every frame and don't want CA to cross-fade between them.
     out_layer.actions = @{
@@ -699,12 +607,11 @@ static void macos_toggle_fullscreen() {
 static void macos_begin_transition() {
     g_transitioning = true;
     // Drop cached input-surface wrappers so the next paint re-wraps at
-    // the new size. The output pool is recreated automatically inside
-    // ensure_pool() when the input dimensions change.
-    g_main.input_texture = nil;
-    g_main.cached_input = nullptr;
-    g_overlay.input_texture = nil;
-    g_overlay.cached_input = nullptr;
+    // the new size. drawableSize is updated in present_iosurface.
+    for (LayerState* s : {&g_main, &g_overlay}) {
+        s->input_texture = nil;
+        s->cached_input = nullptr;
+    }
 }
 
 static void macos_end_transition() {}
@@ -832,12 +739,10 @@ static void macos_cleanup() {
     if (g_overlay.view)  { [g_overlay.view removeFromSuperview];  g_overlay.view = nil; }
     if (g_main.view)     { [g_main.view removeFromSuperview];     g_main.view = nil; }
 
-    g_main.input_texture = nil;
-    g_overlay.input_texture = nil;
-    g_main.cached_input = nullptr;
-    g_overlay.cached_input = nullptr;
-    release_pool(g_main);
-    release_pool(g_overlay);
+    for (LayerState* s : {&g_main, &g_overlay}) {
+        s->input_texture = nil;
+        s->cached_input = nullptr;
+    }
 
     g_main.layer = nil;
     g_overlay.layer = nil;

--- a/src/platform/macos.mm
+++ b/src/platform/macos.mm
@@ -821,6 +821,7 @@ static void macos_clipboard_read_text_async(std::function<void(std::string)> on_
 
 Platform make_macos_platform() {
     return Platform{
+        .display = DisplayBackend::macOS,
         .early_init = macos_early_init,
         .init = macos_init,
         .cleanup = macos_cleanup,

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -8,7 +8,11 @@
 
 enum class IdleInhibitLevel { None, System, Display };
 
+#include "display_backend.h"
+
 struct Platform {
+    DisplayBackend display{};
+
     void (*early_init)();
     bool (*init)(mpv_handle* mpv);
     void (*cleanup)();

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -90,7 +90,7 @@ struct Platform {
     // must be non-null.
     bool shared_texture_supported = true;
 
-    // CEF ozone platform. Resolved once in main() from use_wayland / --ozone-platform.
+    // CEF ozone platform. Resolved once in main() from display backend / --ozone-platform.
     // The dmabuf probe tests GL on this display.
     std::string cef_ozone_platform;
 
@@ -108,6 +108,7 @@ struct Platform {
     void (*clipboard_read_text_async)(std::function<void(std::string)> on_done);
 };
 
+// Internal platform factories — called by make_platform()
 #ifdef _WIN32
 Platform make_windows_platform();
 #elif defined(__APPLE__)
@@ -118,3 +119,24 @@ Platform make_wayland_platform();
 Platform make_x11_platform();
 #endif
 #endif
+
+inline Platform make_platform(DisplayBackend backend) {
+    Platform p;
+#ifdef _WIN32
+    (void)backend;
+    p = make_windows_platform();
+#elif defined(__APPLE__)
+    (void)backend;
+    p = make_macos_platform();
+#else
+    switch (backend) {
+    case DisplayBackend::Wayland: p = make_wayland_platform(); break;
+#ifdef HAVE_X11
+    case DisplayBackend::X11: p = make_x11_platform(); break;
+#endif
+    default: __builtin_unreachable();
+    }
+#endif
+    p.early_init();
+    return p;
+}

--- a/src/platform/wayland.cpp
+++ b/src/platform/wayland.cpp
@@ -1322,6 +1322,7 @@ static void wl_set_titlebar_color(uint8_t, uint8_t, uint8_t) {}
 
 Platform make_wayland_platform() {
     return Platform{
+        .display = DisplayBackend::Wayland,
         .early_init = []() {},
         .init = wl_init,
         .cleanup = wl_cleanup,

--- a/src/platform/windows.cpp
+++ b/src/platform/windows.cpp
@@ -711,6 +711,7 @@ static void win_clamp_window_geometry(int* w, int* h, int* x, int* y) {
 
 Platform make_windows_platform() {
     return Platform{
+        .display = DisplayBackend::Windows,
         .early_init = win_early_init,
         .init = win_init,
         .cleanup = win_cleanup,

--- a/src/platform/x11.cpp
+++ b/src/platform/x11.cpp
@@ -617,6 +617,7 @@ static void x11_cleanup() {
 
 Platform make_x11_platform() {
     return Platform{
+        .display = DisplayBackend::X11,
         .early_init = []() {},
         .init = x11_init,
         .cleanup = x11_cleanup,

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1,5 +1,6 @@
 #include "settings.h"
 #include "cjson/cJSON.h"
+#include "mpv/options.h"
 #include "paths/paths.h"
 #include <fstream>
 #include <sstream>
@@ -82,7 +83,7 @@ static std::string buildSettingsJson(const Settings& s, bool pretty) {
     }
     cJSON_AddBoolToObject(root, "windowMaximized", geom.maximized);
 
-    if (!s.hwdec().empty()) cJSON_AddStringToObject(root, "hwdec", s.hwdec().c_str());
+    if (!s.hwdec().empty() && s.hwdec() != kHwdecDefault) cJSON_AddStringToObject(root, "hwdec", s.hwdec().c_str());
     if (!s.audioPassthrough().empty()) cJSON_AddStringToObject(root, "audioPassthrough", s.audioPassthrough().c_str());
     if (s.audioExclusive()) cJSON_AddBoolToObject(root, "audioExclusive", true);
     if (!s.audioChannels().empty()) cJSON_AddStringToObject(root, "audioChannels", s.audioChannels().c_str());
@@ -131,6 +132,10 @@ std::string Settings::cliSettingsJson() const {
     if (!titlebar_theme_color_) cJSON_AddBoolToObject(root, "titlebarThemeColor", false);
     if (!transparent_titlebar_) cJSON_AddBoolToObject(root, "transparentTitlebar", false);
     if (!log_level_.empty()) cJSON_AddStringToObject(root, "logLevel", log_level_.c_str());
+
+    cJSON* opts = cJSON_AddArrayToObject(root, "hwdecOptions");
+    for (const auto& o : hwdecOptions())
+        cJSON_AddItemToArray(opts, cJSON_CreateString(o.c_str()));
 
     char* str = cJSON_PrintUnformatted(root);
     std::string result(str);

--- a/src/web/native-shim.js
+++ b/src/web/native-shim.js
@@ -88,7 +88,7 @@
         settings: {
             main: { enableMPV: true, fullscreen: false, userWebClient: '__SERVER_URL__' },
             playback: {
-                hwdec: _savedSettings.hwdec || 'auto-safe'
+                hwdec: _savedSettings.hwdec || 'auto'
             },
             audio: {
                 audioPassthrough: _savedSettings.audioPassthrough || '',
@@ -102,16 +102,7 @@
         },
         settingsDescriptions: {
             playback: [
-                { key: 'hwdec', displayName: 'Hardware Decoding', help: 'Hardware video decoding mode. Use "auto-safe" for safe auto-detection, "auto" for aggressive auto-detection, or "no" to disable.', options: [
-                    { value: 'auto-safe', title: 'Auto (Safe)' },
-                    { value: 'auto', title: 'Auto' },
-                    { value: 'no', title: 'Disabled' },
-                    { value: 'vaapi', title: 'VA-API (Linux)' },
-                    { value: 'nvdec', title: 'NVDEC (NVIDIA)' },
-                    { value: 'vulkan', title: 'Vulkan' },
-                    { value: 'd3d11va', title: 'D3D11VA (Windows)' },
-                    { value: 'videotoolbox', title: 'VideoToolbox (macOS)' }
-                ]}
+                { key: 'hwdec', displayName: 'Hardware Decoding', help: 'Hardware video decoding mode. Use "auto" for automatic detection or "no" to disable.', options: _savedSettings.hwdecOptions }
             ],
             audio: [
                 { key: 'audioPassthrough', displayName: 'Audio Passthrough', help: 'Comma-separated list of codecs to pass through to the audio device (e.g. ac3,eac3,dts-hd,truehd). Leave empty to disable.', inputType: 'textarea' },
@@ -583,10 +574,12 @@
                     const control = document.createElement('select');
                     control.className = 'emby-select-withcolor emby-select';
                     for (const option of setting.options) {
+                        const val = typeof option === 'string' ? option : option.value;
+                        const title = typeof option === 'string' ? option : option.title;
                         const opt = document.createElement('option');
-                        opt.value = option.value;
-                        opt.selected = String(option.value) === String(values[setting.key]);
-                        opt.textContent = option.title;
+                        opt.value = val;
+                        opt.selected = String(val) === String(values[setting.key]);
+                        opt.textContent = title;
                         control.appendChild(opt);
                     }
                     control.addEventListener('change', () => {


### PR DESCRIPTION
## Summary
- **macOS sRGB fix**: When mpv's sibling `CALayer` enables EDR, the window's compositor switches to an extended-range working color space. CEF's OSR IOSurfaces had no color-space tag, so CoreAnimation guessed how to map BGRA8 bytes into that space — producing a visible color drift on the overlay. Propagate the color-space tag from CEF's input IOSurface onto our premultiplied output pool, falling back to sRGB if CEF delivers an untagged surface.
- **hwdec options to backend**: Move hwdec option definitions from JS to C++ (`src/mpv/options.h`) with per-platform filtering. Linux gets vaapi/nvdec/vulkan, Windows gets d3d11va/nvdec/vulkan, macOS gets videotoolbox/vulkan. Invalid saved values fall back to the default.
- **Drop redundant mpv options**: Remove explicit `vo=gpu-next`, `gpu-api=vulkan`, and `target-colorspace-hint=yes` — mpv's defaults match on all platforms. Default hwdec changed from `auto-safe` to `auto` (identical behavior in our mpv fork).
- **Static options into MpvHandle::Create**: All hardcoded mpv options (OSD, input, window identity, idle) moved into `MpvHandle::Create()`. Typed setters (`SetHwdec`, `SetAudioSpdif`, etc.) replace raw string calls for user-configurable options.

## Test plan
- [ ] Build on macOS, Windows, Linux
- [ ] Confirm CEF overlay colors match standalone Chromium (no video playing)
- [ ] Start HDR video playback on macOS — overlay should not drift when mpv flips the window into EDR
- [ ] Settings UI shows only platform-appropriate hwdec options
- [ ] Changing hwdec in settings persists and applies on restart
- [ ] Saved `auto-safe` in existing config falls back to `auto`