### PR TITLE
Replace sync mpv property reads in shutdown with cached observations

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -227,10 +227,7 @@ static void cef_consumer_thread() {
             }
             case MpvEventType::FULLSCREEN:
                 if (ev.flag) {
-                    // Entering fullscreen: capture maximized state for save/restore
-                    bool maximized = false;
-                    g_mpv.GetWindowMaximized(maximized);
-                    g_was_maximized_before_fullscreen = maximized;
+                    g_was_maximized_before_fullscreen = mpv::window_maximized();
                 } else {
                     g_was_maximized_before_fullscreen = false;
                 }
@@ -821,19 +818,9 @@ int main(int argc, char* argv[]) {
     digest_thread.join();
 
     // Save window geometry while mpv is still alive.
-    // Three paths match old SDL implementation:
-    //   Fullscreen: preserve previous saved geometry, update only maximized flag
-    //   Maximized:  zero out size (sentinel), set maximized=true
-    //   Normal:     save current logical size
-    // Safe on macOS: all four properties read here are core-cached and
-    // resolve without a VO roundtrip (mpv's command.c:3113-3138 reads
-    // osd_get_vo_res; fullscreen/window-maximized are option-backed
-    // properties). Neither needs main-thread dispatch, so a sync read from
-    // the shutdown path after run_main_loop returned will not deadlock.
     {
-        bool fs = false, max = false;
-        g_mpv.GetFullscreen(fs);
-        g_mpv.GetWindowMaximized(max);
+        bool fs  = mpv::fullscreen();
+        bool max = mpv::window_maximized();
 
         if (fs) {
             // Preserve previous saved geometry; only update the maximized flag
@@ -851,13 +838,12 @@ int main(int argc, char* argv[]) {
             Settings::instance().setWindowGeometry(geom);
         } else {
             // Normal windowed: save current size and position.
-            int64_t pw = 0, ph = 0;
-            g_mpv.GetOsdWidth(pw);
-            g_mpv.GetOsdHeight(ph);
+            int pw = mpv::osd_pw();
+            int ph = mpv::osd_ph();
             if (pw > 0 && ph > 0) {
                 Settings::WindowGeometry geom;
-                geom.width = static_cast<int>(pw);
-                geom.height = static_cast<int>(ph);
+                geom.width = pw;
+                geom.height = ph;
                 geom.maximized = false;
                 int wx, wy;
                 if (g_platform.query_window_position &&

--- a/src/mpv/event.cpp
+++ b/src/mpv/event.cpp
@@ -1,7 +1,20 @@
 #include "event.h"
 #include "handle.h"
 #include "../common.h"
+#include <atomic>
 #include <cstring>
+
+static std::atomic<bool> s_fullscreen{false};
+static std::atomic<bool> s_window_maximized{false};
+static std::atomic<int>  s_osd_pw{0};
+static std::atomic<int>  s_osd_ph{0};
+
+namespace mpv {
+    bool fullscreen()       { return s_fullscreen.load(std::memory_order_relaxed); }
+    bool window_maximized() { return s_window_maximized.load(std::memory_order_relaxed); }
+    int  osd_pw()           { return s_osd_pw.load(std::memory_order_relaxed); }
+    int  osd_ph()           { return s_osd_ph.load(std::memory_order_relaxed); }
+}
 
 void observe_properties(MpvHandle& mpv) {
     mpv.ObservePropertyNode(MPV_OBSERVE_VIDEO_PARAMS, "video-params");
@@ -14,6 +27,7 @@ void observe_properties(MpvHandle& mpv) {
     mpv.ObservePropertyFlag(MPV_OBSERVE_SEEKING, "seeking");
     mpv.ObservePropertyDouble(MPV_OBSERVE_DISPLAY_FPS, "display-fps");
     mpv.ObservePropertyNode(MPV_OBSERVE_CACHE_STATE, "demuxer-cache-state");
+    mpv.ObservePropertyFlag(MPV_OBSERVE_WINDOW_MAX, "window-maximized");
 }
 
 MpvEvent digest_property(uint64_t id, mpv_event_property* p) {
@@ -26,6 +40,8 @@ MpvEvent digest_property(uint64_t id, mpv_event_property* p) {
         g_mpv.GetPropertyInt("osd-height", h);
         ev.pw = static_cast<int>(w);
         ev.ph = static_cast<int>(h);
+        s_osd_pw.store(ev.pw, std::memory_order_relaxed);
+        s_osd_ph.store(ev.ph, std::memory_order_relaxed);
         float scale = g_platform.get_scale();
         ev.lw = static_cast<int>(ev.pw / scale);
         ev.lh = static_cast<int>(ev.ph / scale);
@@ -58,6 +74,7 @@ MpvEvent digest_property(uint64_t id, mpv_event_property* p) {
         if (p->format != MPV_FORMAT_FLAG) break;
         ev.type = MpvEventType::FULLSCREEN;
         ev.flag = *static_cast<int*>(p->data) != 0;
+        s_fullscreen.store(ev.flag, std::memory_order_relaxed);
         break;
     case MPV_OBSERVE_SPEED:
         if (p->format != MPV_FORMAT_DOUBLE) break;
@@ -68,6 +85,12 @@ MpvEvent digest_property(uint64_t id, mpv_event_property* p) {
         if (p->format != MPV_FORMAT_FLAG) break;
         ev.type = MpvEventType::SEEKING;
         ev.flag = *static_cast<int*>(p->data) != 0;
+        break;
+    case MPV_OBSERVE_WINDOW_MAX:
+        if (p->format != MPV_FORMAT_FLAG) break;
+        ev.type = MpvEventType::WINDOW_MAXIMIZED;
+        ev.flag = *static_cast<int*>(p->data) != 0;
+        s_window_maximized.store(ev.flag, std::memory_order_relaxed);
         break;
     case MPV_OBSERVE_DISPLAY_FPS: {
         if (p->format != MPV_FORMAT_DOUBLE) break;

--- a/src/mpv/event.h
+++ b/src/mpv/event.h
@@ -14,6 +14,7 @@ enum class MpvEventType {
     TIME_POS,
     DURATION,
     FULLSCREEN,
+    WINDOW_MAXIMIZED,
     OSD_DIMS,
     SPEED,
     SEEKING,
@@ -50,9 +51,17 @@ enum MpvObserveId : uint64_t {
     MPV_OBSERVE_SEEKING       = 8,
     MPV_OBSERVE_DISPLAY_FPS   = 9,
     MPV_OBSERVE_CACHE_STATE   = 10,
+    MPV_OBSERVE_WINDOW_MAX    = 11,
 };
 
 class MpvHandle;
 
 void observe_properties(MpvHandle& mpv);
 MpvEvent digest_property(uint64_t id, mpv_event_property* p);
+
+namespace mpv {
+    bool fullscreen();
+    bool window_maximized();
+    int  osd_pw();
+    int  osd_ph();
+}


### PR DESCRIPTION
Fixes https://github.com/jellyfin/jellyfin-desktop/issues/174