### PR TITLE
Add update-cef just recipe

### DIFF
--- a/.github/workflows/build-linux-appimage.yml
+++ b/.github/workflows/build-linux-appimage.yml
@@ -9,6 +9,10 @@ on:
     tags:
       - 'v*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-linux-flatpak.yml
+++ b/.github/workflows/build-linux-flatpak.yml
@@ -9,6 +9,10 @@ on:
     tags:
       - 'v*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-linux-flatpak.yml
+++ b/.github/workflows/build-linux-flatpak.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Check Flatpak manifest matches CEF_VERSION
+        run: python3 dev/flatpak/update_cef.py --check
+
       - name: Install Flatpak
         run: |
           sudo apt-get update

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -9,6 +9,10 @@ on:
     tags:
       - 'v*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -9,6 +9,10 @@ on:
     tags:
       - 'v*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 build/
 dist/
 
+# Python
+__pycache__/
+*.pyc
+
 # Third-party dependencies (except submodules)
 third_party/*
 !third_party/mpv
@@ -20,5 +24,3 @@ third_party/*
 *.swp
 compile_commands.json
 .cache/
-out
-app.log

--- a/dev/download_cef.py
+++ b/dev/download_cef.py
@@ -49,30 +49,29 @@ def get_platform_id():
     return PLATFORM_MAP[key]
 
 
-def fetch_index():
-    """Fetch CEF builds index."""
+def _fetch_index():
     log.info("Fetching CEF builds index")
     with urllib.request.urlopen(CEF_INDEX_URL) as resp:
         return json.load(resp)
 
 
-def find_version_by_prefix(index, platform_id, version_prefix):
-    """Find a CEF version in the index matching the given prefix."""
+def _find_version_by_prefix(index, platform_id, version_prefix):
     for v in index.get(platform_id, {}).get("versions", []):
         if v.get("cef_version", "").startswith(version_prefix):
             return v
     return None
 
 
-def find_latest_stable(index, platform_id):
-    """Find the latest stable CEF version for the given platform."""
+def _find_latest_stable(index, platform_id):
     stable_versions = [
-        v for v in index.get(platform_id, {}).get("versions", [])
+        v
+        for v in index.get(platform_id, {}).get("versions", [])
         if v.get("channel") == "stable"
     ]
     if not stable_versions:
-        raise RuntimeError(f"No stable version found for platform: {platform_id}")
-    # Sort by chromium major version descending
+        raise RuntimeError(
+            f"No stable version found for platform: {platform_id}"
+        )
     stable_versions.sort(
         key=lambda v: int(v.get("chromium_version", "0").split(".")[0]),
         reverse=True,
@@ -80,19 +79,54 @@ def find_latest_stable(index, platform_id):
     return stable_versions[0]
 
 
-def get_minimal_distribution(version_data):
-    """Get the minimal distribution file info."""
+def _get_minimal_distribution(version_data):
     for file_info in version_data.get("files", []):
         if file_info.get("type") == "minimal":
             return file_info
-    # Fall back to standard if no minimal
     for file_info in version_data.get("files", []):
         if file_info.get("type") == "standard":
             return file_info
     raise RuntimeError("No suitable distribution found")
 
 
-def compute_hash(path, algorithm="sha1"):
+def _fetch_sha256(tarball_url):
+    sha256_url = f"{tarball_url}.sha256"
+    log.info("Fetching %s", sha256_url)
+    with urllib.request.urlopen(sha256_url) as resp:
+        sha256 = resp.read().decode().strip()
+    if len(sha256) != 64 or not all(c in "0123456789abcdef" for c in sha256):
+        raise RuntimeError(f"Invalid sha256 from {sha256_url}: {sha256!r}")
+    return sha256
+
+
+def resolve_distribution(version=None, platform_id=None):
+    """Resolve a CEF version (or latest stable if None) to distribution info.
+
+    Returns a dict with: cef_version, chromium_version, filename, url, sha256.
+    """
+    platform_id = platform_id or get_platform_id()
+    index = _fetch_index()
+    if version:
+        data = _find_version_by_prefix(index, platform_id, version)
+        if not data:
+            raise RuntimeError(
+                f"Version {version} not found for {platform_id}"
+            )
+    else:
+        data = _find_latest_stable(index, platform_id)
+    file_info = _get_minimal_distribution(data)
+    filename = file_info["name"]
+    url = f"{CEF_DOWNLOAD_BASE}/{filename}"
+    return {
+        "cef_version": data.get("cef_version"),
+        "chromium_version": data.get("chromium_version"),
+        "filename": filename,
+        "url": url,
+        "sha256": _fetch_sha256(url),
+    }
+
+
+def compute_hash(path, algorithm="sha256"):
     """Compute hash of a file."""
     h = hashlib.new(algorithm)
     with open(path, "rb") as f:
@@ -101,21 +135,21 @@ def compute_hash(path, algorithm="sha1"):
     return h.hexdigest()
 
 
-def verify_sha1(path, expected_sha1):
-    """Verify SHA1 hash of a file."""
-    log.info("Verifying SHA1")
-    actual_sha1 = compute_hash(path, "sha1")
-    if actual_sha1 != expected_sha1:
+def verify_sha256(path, expected_sha256):
+    """Verify SHA256 hash of a file."""
+    log.info("Verifying SHA256")
+    actual = compute_hash(path, "sha256")
+    if actual != expected_sha256:
         raise RuntimeError(
-            f"SHA1 mismatch: expected {expected_sha1}, got {actual_sha1}"
+            f"SHA256 mismatch: expected {expected_sha256}, got {actual}"
         )
 
 
-def download_file(url, dest_path, expected_sha1=None):
+def download_file(url, dest_path, expected_sha256=None):
     """Download a file with progress indication and optional hash verification."""
     log.info("Downloading %s", url)
     temp_path = dest_path.parent / f".{dest_path.name}.tmp"
-    sha1_path = dest_path.parent / f"{dest_path.name}.sha1"
+    sha256_path = dest_path.parent / f"{dest_path.name}.sha256"
 
     def report_progress(block_num, block_size, total_size):
         downloaded = block_num * block_size
@@ -132,9 +166,9 @@ def download_file(url, dest_path, expected_sha1=None):
         urllib.request.urlretrieve(url, temp_path, reporthook=report_progress)
         print()  # newline after progress
 
-        if expected_sha1:
-            verify_sha1(temp_path, expected_sha1)
-            sha1_path.write_text(expected_sha1)
+        if expected_sha256:
+            verify_sha256(temp_path, expected_sha256)
+            sha256_path.write_text(expected_sha256)
 
         temp_path.rename(dest_path)
     except:
@@ -150,7 +184,6 @@ def extract_tarball(tarball_path, extract_dir):
 
     log.info("Extracting to %s", relpath(final_dir))
 
-    # Clean up any previous temp dir
     if temp_dir.exists():
         shutil.rmtree(temp_dir)
     temp_dir.mkdir(parents=True)
@@ -158,7 +191,6 @@ def extract_tarball(tarball_path, extract_dir):
     try:
         with tarfile.open(tarball_path, "r:bz2") as tar:
             tar.extractall(temp_dir)
-        # Move extracted content (it's in a subdir) to final location
         extracted = temp_dir / root_dir
         extracted.rename(final_dir)
         temp_dir.rmdir()
@@ -172,13 +204,15 @@ def extract_tarball(tarball_path, extract_dir):
 
 def create_symlink(target_dir, link_path):
     """Create or update symlink (uses directory junction on Windows)."""
-    if link_path.is_symlink() or (hasattr(link_path, 'is_junction') and link_path.is_junction()):
+    if link_path.is_symlink() or (
+        hasattr(link_path, "is_junction") and link_path.is_junction()
+    ):
         link_path.unlink()
     elif link_path.exists():
         shutil.rmtree(link_path)
     if platform.system() == "Windows":
-        # Use directory junction (no special permissions needed)
         import subprocess
+
         target_abs = (link_path.parent / target_dir.name).resolve()
         subprocess.run(
             ["cmd", "/c", "mklink", "/J", str(link_path), str(target_abs)],
@@ -214,7 +248,14 @@ def main():
     parser = argparse.ArgumentParser(description="Download CEF distribution")
     parser.add_argument(
         "--platform",
-        choices=["linux64", "linuxarm64", "macosx64", "macosarm64", "windows64", "windowsarm64"],
+        choices=[
+            "linux64",
+            "linuxarm64",
+            "macosx64",
+            "macosarm64",
+            "windows64",
+            "windowsarm64",
+        ],
         help="Target platform (default: auto-detect)",
     )
     parser.add_argument(
@@ -240,51 +281,38 @@ def main():
     platform_id = args.platform or get_platform_id()
     cef_link = args.output_dir / "cef"
 
-    # Check for existing tarball and sha1
     existing = find_existing_tarball(args.output_dir, platform_id)
     if existing and args.version:
         _, existing_name = existing
         if not existing_name.startswith(f"cef_binary_{args.version}"):
-            log.info("Existing CEF doesn't match requested version %s, re-downloading",
-                     args.version)
+            log.info(
+                "Existing CEF doesn't match requested version %s, re-downloading",
+                args.version,
+            )
             existing = None
     if existing:
         tarball_path, versioned_dir_name = existing
-        sha1_path = tarball_path.parent / f"{tarball_path.name}.sha1"
-        have_sha1 = sha1_path.exists()
+        sha256_path = tarball_path.parent / f"{tarball_path.name}.sha256"
+        have_sha256 = sha256_path.exists()
     else:
-        have_sha1 = False
+        have_sha256 = False
 
-    # Fetch index if needed (no tarball, no sha1, or --show-latest)
-    if args.show_latest or not existing or not have_sha1:
-        index = fetch_index()
-
-        if args.version:
-            version_data = find_version_by_prefix(index, platform_id, args.version)
-            if not version_data:
-                raise RuntimeError(
-                    f"Version {args.version} not found for {platform_id}"
-                )
-        else:
-            version_data = find_latest_stable(index, platform_id)
-
-        cef_version = version_data.get("cef_version", "unknown")
-        chromium_version = version_data.get("chromium_version", "unknown")
-        file_info = get_minimal_distribution(version_data)
-        filename = file_info["name"]
-        expected_sha1 = file_info.get("sha1")
-        download_url = f"{CEF_DOWNLOAD_BASE}/{filename}"
+    if args.show_latest or not existing or not have_sha256:
+        dist = resolve_distribution(args.version or None, platform_id)
+        filename = dist["filename"]
+        download_url = dist["url"]
+        expected_sha256 = dist["sha256"]
 
         if args.show_latest:
             print(
                 json.dumps(
                     {
                         "platform": platform_id,
-                        "cef_version": cef_version,
-                        "chromium_version": chromium_version,
+                        "cef_version": dist["cef_version"],
+                        "chromium_version": dist["chromium_version"],
                         "url": download_url,
                         "filename": filename,
-                        "sha1": expected_sha1,
+                        "sha256": expected_sha256,
                         "tarball_path": str(args.output_dir / filename),
                         "extract_path": str(args.output_dir / "cef"),
                     },
@@ -296,43 +324,39 @@ def main():
         tarball_path = args.output_dir / filename
         versioned_dir_name = filename.removesuffix(".tar.bz2")
     else:
-        expected_sha1 = sha1_path.read_text().strip()
+        expected_sha256 = sha256_path.read_text().strip()
 
     log.info("Platform: %s", platform_id)
     log.info("Version: %s", versioned_dir_name)
 
     versioned_dir = args.output_dir / versioned_dir_name
 
-    # Check if already at correct version
-    is_link = cef_link.is_symlink() or (hasattr(cef_link, 'is_junction') and cef_link.is_junction())
+    is_link = cef_link.is_symlink() or (
+        hasattr(cef_link, "is_junction") and cef_link.is_junction()
+    )
     if is_link:
         current_target = os.readlink(cef_link)
         if current_target == versioned_dir_name and versioned_dir.exists():
             log.info("Skipping, already set up")
             return
 
-    # Ensure output directory exists
     args.output_dir.mkdir(parents=True, exist_ok=True)
 
-    # Download
-    sha1_path = tarball_path.parent / f"{tarball_path.name}.sha1"
+    sha256_path = tarball_path.parent / f"{tarball_path.name}.sha256"
     if tarball_path.exists():
         log.info("Skipping download, already exists")
-        # Verify existing tarball before extract
-        if expected_sha1:
-            verify_sha1(tarball_path, expected_sha1)
-            if not sha1_path.exists():
-                sha1_path.write_text(expected_sha1)
+        if expected_sha256:
+            verify_sha256(tarball_path, expected_sha256)
+            if not sha256_path.exists():
+                sha256_path.write_text(expected_sha256)
     else:
-        download_file(download_url, tarball_path, expected_sha1)
+        download_file(download_url, tarball_path, expected_sha256)
 
-    # Extract
     if versioned_dir.exists():
         log.info("Skipping extraction, already extracted")
     else:
         extract_tarball(tarball_path, args.output_dir)
 
-    # Symlink
     log.info(
         "Creating symlink: %s -> %s", relpath(cef_link), versioned_dir_name
     )

--- a/dev/flatpak/update_cef.py
+++ b/dev/flatpak/update_cef.py
@@ -1,88 +1,97 @@
 #!/usr/bin/env python3
 """Update CEF URL and SHA256 in the Flatpak manifest from CEF_VERSION."""
 
+import argparse
 import logging
 import pathlib
 import sys
-import tempfile
 
 sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
 from download_cef import (
     CEF_DOWNLOAD_BASE,
     CEF_VERSION_FILE,
-    compute_hash,
-    download_file,
-    fetch_index,
-    find_version_by_prefix,
-    get_minimal_distribution,
     read_pinned_version,
+    resolve_distribution,
 )
 
 log = logging.getLogger(__name__)
-MANIFEST_PATH = pathlib.Path(__file__).parent / "org.jellyfin.JellyfinDesktop.yml"
+MANIFEST_PATH = (
+    pathlib.Path(__file__).parent / "org.jellyfin.JellyfinDesktop.yml"
+)
+URL_PREFIX = f"url: {CEF_DOWNLOAD_BASE}/cef_binary_"
+URL_SUFFIX = "_linux64_minimal.tar.bz2"
+
+
+def manifest_cef_version(manifest_text):
+    """Return the CEF version embedded in the manifest's archive URL, or None."""
+    for line in manifest_text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(URL_PREFIX) and stripped.endswith(URL_SUFFIX):
+            return stripped[len(URL_PREFIX) : -len(URL_SUFFIX)]
+    return None
+
+
+def patch_manifest(manifest_text, url, sha256):
+    """Return manifest text with the CEF url + adjacent sha256 line rewritten."""
+    out = []
+    lines = iter(manifest_text.splitlines())
+    for line in lines:
+        if not line.lstrip().startswith(URL_PREFIX):
+            out.append(line)
+            continue
+        indent = line[: len(line) - len(line.lstrip())]
+        next_line = next(lines, "")
+        if not next_line.lstrip().startswith("sha256:"):
+            raise RuntimeError(
+                f"Expected a 'sha256:' line after the CEF url in {MANIFEST_PATH}"
+            )
+        out.append(f"{indent}url: {url}")
+        out.append(f"{indent}sha256: {sha256}")
+    return "\n".join(out) + "\n"
 
 
 def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if manifest does not match CEF_VERSION; do not modify",
+    )
+    args = parser.parse_args()
+
     logging.basicConfig(level=logging.INFO, format="%(message)s")
 
     version = read_pinned_version()
     if not version:
-        raise RuntimeError(f"CEF_VERSION file not found or empty: {CEF_VERSION_FILE}")
+        raise RuntimeError(
+            f"CEF_VERSION file not found or empty: {CEF_VERSION_FILE}"
+        )
 
-    if not MANIFEST_PATH.exists():
-        raise RuntimeError(f"Flatpak manifest not found: {MANIFEST_PATH}")
-
-    # Early exit if manifest already matches
     manifest_text = MANIFEST_PATH.read_text()
-    if f"cef_binary_{version}" in manifest_text:
-        log.info("Flatpak manifest already matches CEF_VERSION (%s)", version)
+    actual = manifest_cef_version(manifest_text)
+    if actual is None:
+        raise RuntimeError(
+            f"No CEF archive URL found in manifest {MANIFEST_PATH} "
+            f"(expected 'url: {URL_PREFIX}<version>{URL_SUFFIX}')"
+        )
+
+    if actual == version:
+        log.info("Flatpak manifest matches CEF_VERSION (%s)", version)
         return
 
-    # Resolve version info for linux64
-    index = fetch_index()
-    version_data = find_version_by_prefix(index, "linux64", version)
-    if not version_data:
-        raise RuntimeError(f"Version {version} not found for linux64")
+    if args.check:
+        log.error(
+            "Flatpak manifest CEF version %s does not match CEF_VERSION %s",
+            actual,
+            version,
+        )
+        sys.exit(1)
 
-    file_info = get_minimal_distribution(version_data)
-    filename = file_info["name"]
-    url = f"{CEF_DOWNLOAD_BASE}/{filename}"
-    expected_sha1 = file_info.get("sha1")
-
-    # Download tarball to compute sha256
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tarball = pathlib.Path(tmpdir) / filename
-        log.info("Downloading %s to compute sha256...", filename)
-        download_file(url, tarball, expected_sha1)
-        sha256 = compute_hash(tarball, "sha256")
-
-    log.info("Updating Flatpak manifest")
-    log.info("  URL: %s", url)
-    log.info("  SHA256: %s", sha256)
-
-    # Patch manifest in-place
-    lines = manifest_text.splitlines()
-    result = []
-    i = 0
-    while i < len(lines):
-        line = lines[i]
-        stripped = line.lstrip()
-
-        if stripped.startswith("url: https://cef-builds.spotifycdn.com/cef_binary_"):
-            indent = line[: len(line) - len(stripped)]
-            result.append(f"{indent}url: {url}")
-            # Replace next hash line
-            i += 1
-            if i < len(lines) and lines[i].lstrip().startswith(("sha256:", "sha1:", "sha512:")):
-                result.append(f"{indent}sha256: {sha256}")
-                i += 1
-            continue
-
-        result.append(line)
-        i += 1
-
-    MANIFEST_PATH.write_text("\n".join(result) + "\n")
-    log.info("Done")
+    dist = resolve_distribution(version, platform_id="linux64")
+    log.info("Updating Flatpak manifest to %s", dist["url"])
+    MANIFEST_PATH.write_text(
+        patch_manifest(manifest_text, dist["url"], dist["sha256"])
+    )
 
 
 if __name__ == "__main__":

--- a/dev/update_cef.py
+++ b/dev/update_cef.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Update CEF version: write CEF_VERSION and sync Flatpak manifest."""
+
+import argparse
+import logging
+import pathlib
+import subprocess
+import sys
+
+from download_cef import (
+    CEF_VERSION_FILE,
+    read_pinned_version,
+    relpath,
+    resolve_distribution,
+)
+
+log = logging.getLogger(__name__)
+
+FLATPAK_SCRIPT = pathlib.Path(__file__).parent / "flatpak" / "update_cef.py"
+
+
+def check():
+    """Return True if CEF_VERSION matches latest stable and Flatpak manifest."""
+    current = read_pinned_version()
+    latest = resolve_distribution(platform_id="linux64")["cef_version"]
+    if current != latest:
+        log.info("CEF_VERSION out of date: %s (latest: %s)", current, latest)
+        return False
+    if (
+        subprocess.run(
+            [sys.executable, str(FLATPAK_SCRIPT), "--check"]
+        ).returncode
+        != 0
+    ):
+        return False
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "version",
+        nargs="?",
+        help="CEF version (default: latest stable)",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if CEF_VERSION is stale or Flatpak manifest is out of sync",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    if args.check:
+        if args.version:
+            parser.error("--check does not take a version argument")
+        if not check():
+            sys.exit(1)
+        return
+
+    dist = resolve_distribution(args.version or None, platform_id="linux64")
+    version = dist["cef_version"]
+    if not args.version:
+        log.info("Latest stable CEF: %s", version)
+
+    if read_pinned_version() == version:
+        log.info("%s already at %s", relpath(CEF_VERSION_FILE), version)
+    else:
+        CEF_VERSION_FILE.write_text(version + "\n")
+        log.info("Wrote %s -> %s", relpath(CEF_VERSION_FILE), version)
+
+    subprocess.run([sys.executable, str(FLATPAK_SCRIPT)], check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/justfile
+++ b/justfile
@@ -38,6 +38,10 @@ test: build
 run: build
     build/jellyfin-desktop --log-level=debug --log-file=build/run.log
 
+# Update CEF to specified version (or latest stable) and sync Flatpak manifest; pass --check to verify only
+update-cef *args:
+    python3 dev/update_cef.py {{args}}
+
 # Remove build artifacts (keeps CEF SDK download)
 clean:
     rm -rf build third_party/mpv/build


### PR DESCRIPTION
Orchestrates CEF version bumps by writing CEF_VERSION and syncing the Flatpak manifest in one step. Also tidies .gitignore: adds Python caches, drops stale out/app.log entries.