### PR TITLE
Don't auto-enable USE_SYSTEM_CEF when third_party/cef is present

### DIFF
--- a/cmake/FindCEF.cmake
+++ b/cmake/FindCEF.cmake
@@ -8,9 +8,16 @@ endif()
 
 set(EXTERNAL_CEF_DIR "${_DEFAULT_EXTERNAL_CEF_DIR}" CACHE PATH "Path to external CEF installation (with prebuilt libcef_dll_wrapper.a)")
 
-# Auto-detect system CEF from the "cef" package (used as last resort)
+# Auto-detect system CEF from the "cef" package (used as last resort).
+# Skip when EXTERNAL_CEF_DIR or CEF_ROOT already point at a real SDK, since
+# those branches win in the elseif chain below; defaulting USE_SYSTEM_CEF=ON
+# anyway leaves the cache flag lying about which CEF is actually selected,
+# which then mis-gates resource-copy and compile-define logic in the parent
+# CMakeLists.txt.
 set(_DEFAULT_USE_SYSTEM_CEF OFF)
-if(EXISTS "/usr/include/cef/include/cef_version.h")
+if(EXISTS "/usr/include/cef/include/cef_version.h"
+   AND NOT EXTERNAL_CEF_DIR
+   AND NOT (CEF_ROOT AND EXISTS "${CEF_ROOT}/include/cef_version.h"))
     set(_DEFAULT_USE_SYSTEM_CEF ON)
 endif()
 


### PR DESCRIPTION
## Summary
- Fresh clones with the Arch \`cef\` package installed crash on startup in \`base::i18n::InitializeICU\` (SIGTRAP).
- \`FindCEF.cmake\` defaulted \`USE_SYSTEM_CEF=ON\` whenever \`/usr/include/cef\` existed, even though the \`CEF_ROOT\` branch (\`third_party/cef\`) wins the elseif chain. The lying cache flag then disabled the POST_BUILD that copies CEF resources into \`build/\`, so \`libcef.so\` loaded from \`third_party/cef/Release/\` with no \`icudtl.dat\` beside it.
- Skip the auto-enable when \`EXTERNAL_CEF_DIR\` or a populated \`CEF_ROOT\` would take precedence, so the cache flag matches the branch that actually runs.

## Test plan
- [x] Clean rebuild on Linux with Arch \`cef\` package installed: \`USE_SYSTEM_CEF=OFF\`, resources land in \`build/\`, app starts and reaches "Main browser loaded".