### PR TITLE
fix(shim): fix double clicking player buttons toggling fullscreen

### DIFF
--- a/src/web/native-shim.js
+++ b/src/web/native-shim.js
@@ -27,7 +27,9 @@
     (function() {
         let lastTime = 0, lastX = 0, lastY = 0;
         document.addEventListener('mousedown', (e) => {
-            if (e.button !== 0) return;  // left button only
+            // left button only and only if clicked on main content (not header,
+            // or controls)
+            if (e.button !== 0 || !e.target.classList.contains("mainAnimatedPage")) return;
             const now = Date.now();
             const dx = e.clientX - lastX;
             const dy = e.clientY - lastY;


### PR DESCRIPTION
Due to the shim just checking for the existence of the video container class, even if the player buttons were pressed, fullscreen would be toggled. This is circumvented by checking the target of the click. If it is not mainAnimatedPage, then the double click logic is exited.

Fixes #143