### PR TITLE
Fix flatpak workflow artifact upload path

### DIFF
--- a/.github/workflows/build-linux-flatpak.yml
+++ b/.github/workflows/build-linux-flatpak.yml
@@ -42,5 +42,5 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
-          name: linux-flatpak
-          path: dist/jellyfin-desktop.flatpak
+          name: linux-flatpak-x86_64
+          path: dist/JellyfinDesktop-*.flatpak


### PR DESCRIPTION
## Summary
- `dist/jellyfin-desktop.flatpak` no longer exists after 11c78d5; the bundle is now `JellyfinDesktop-<version>-linux-<arch>.flatpak`, so the upload step silently produced no artifact.
- Update the path to the glob pattern and rename the artifact to `linux-flatpak-x86_64` to match the AppImage workflow.

