### PR TITLE
Add AV1 transcoding support and fix HLS audio track selection

### DIFF
--- a/src/browser/web_browser.cpp
+++ b/src/browser/web_browser.cpp
@@ -143,8 +143,9 @@ bool WebBrowser::handleMessage(const std::string& name,
                  audioIdx, subIdx, startMs, url.c_str());
         MpvHandle::LoadOptions opts;
         opts.startSecs = startMs / 1000.0;
-        opts.audioTrack = audioIdx;
-        opts.subTrack = subIdx;
+        bool isHls = url.find("master.m3u8") != std::string::npos;
+        opts.audioTrack = isHls ? MpvHandle::kTrackAuto : audioIdx;
+        opts.subTrack = isHls ? MpvHandle::kTrackAuto : subIdx;
         g_mpv.LoadFile(url, opts);
     } else if (name == "playerStop") {
         g_mpv.Stop();

--- a/src/web/native-shim.js
+++ b/src/web/native-shim.js
@@ -370,7 +370,7 @@
                     Container: 'mp4',
                     Type: 'Video',
                     Protocol: 'hls',
-                    AudioCodec: 'aac,ac3,eac3,opus,flac,vorbis',
+                    AudioCodec: 'aac,mp3,ac3,eac3,opus,flac,vorbis',
                     VideoCodec: 'av1,h264,h265,hevc,mpeg4,mpeg2video',
                     MaxAudioChannels: '6'
                 },

--- a/src/web/native-shim.js
+++ b/src/web/native-shim.js
@@ -367,11 +367,11 @@
             TranscodingProfiles: [
                 { Type: 'Audio' },
                 {
-                    Container: 'ts',
+                    Container: 'mp4',
                     Type: 'Video',
                     Protocol: 'hls',
-                    AudioCodec: 'aac,mp3,ac3,opus,vorbis',
-                    VideoCodec: 'h264,h265,hevc,mpeg4,mpeg2video',
+                    AudioCodec: 'aac,ac3,eac3,opus,flac,vorbis',
+                    VideoCodec: 'av1,h264,h265,hevc,mpeg4,mpeg2video',
                     MaxAudioChannels: '6'
                 },
                 { Container: 'jpeg', Type: 'Photo' }

--- a/src/web/native-shim.js
+++ b/src/web/native-shim.js
@@ -370,7 +370,7 @@
                     Container: 'mp4',
                     Type: 'Video',
                     Protocol: 'hls',
-                    AudioCodec: 'aac,mp3,ac3,eac3,opus,flac,vorbis',
+                    AudioCodec: 'aac,mp3,ac3,opus,vorbis',
                     VideoCodec: 'av1,h264,h265,hevc,mpeg4,mpeg2video',
                     MaxAudioChannels: '6'
                 },


### PR DESCRIPTION
## Summary
This PR enables AV1 transcoding support. The changes required to implement this are as follows:
- Swap HLS transcoding container from MPEG-TS to fMP4 (`mp4`). This is required as MPEG-TS containers do not support AV1 video streams.
- When using fMP4 for the HLS container, the server only includes the selected audio track (always `aid=1`) in the stream, so requesting `aid=2+` resulted in silent audio when transcoding. Switching to auto track selection for HLS URLs solves this since the server already selects the correct audio track to include in the stream.

Fixes #89

## Test plan
- [x] Play content that forces transcoding (lower bitrate limit) — verify AV1 appears as the video codec in playback info
- [x] Select a non-primary audio track (e.g. 5.1 AC3 on stream index 2) during transcoding — verify audio plays correctly
- [x] Verify surround sound (5.1/7.1) works during both direct play and transcoding
- [x] Verify stereo content still works during transcoding
- [x] Test direct play (no transcoding) is unaffected

🤖 Generated with help from [Claude Code](https://claude.com/claude-code) (Claude Opus 4.6). Reviewed by a real human.