### PR TITLE
Fixes a Windows-specific fullscreen regression

### DIFF
--- a/src/platform/windows.cpp
+++ b/src/platform/windows.cpp
@@ -89,6 +89,10 @@ static WinState g_win;
 static void win_begin_transition_locked();
 static void win_end_transition_locked();
 
+static bool win_is_fullscreen_style(LONG_PTR style) {
+    return (style & WS_CAPTION) == 0 && (style & WS_THICKFRAME) == 0;
+}
+
 // =====================================================================
 // D3D11 / DXGI / DComp initialization
 // =====================================================================
@@ -604,9 +608,9 @@ static LRESULT CALLBACK mpv_wndproc_hook(int nCode, WPARAM wp, LPARAM lp) {
                     int lw = static_cast<int>(pw / scale);
                     int lh = static_cast<int>(ph / scale);
 
-                    // Detect fullscreen change via window style
+                    // Detect fullscreen via style bits mpv uses on Windows.
                     LONG_PTR style = GetWindowLongPtr(g_win.mpv_hwnd, GWL_STYLE);
-                    bool fs = !(style & WS_OVERLAPPEDWINDOW);
+                    bool fs = win_is_fullscreen_style(style);
 
                     std::lock_guard<std::mutex> lock(g_win.surface_mtx);
                     if (fs != g_win.was_fullscreen) {
@@ -659,7 +663,7 @@ static bool win_init(mpv_handle* mpv) {
     // doesn't start a spurious transition if already fullscreen.
     {
         LONG_PTR style = GetWindowLongPtr(g_win.mpv_hwnd, GWL_STYLE);
-        g_win.was_fullscreen = !(style & WS_OVERLAPPEDWINDOW);
+        g_win.was_fullscreen = win_is_fullscreen_style(style);
     }
 
     // Install hook to monitor mpv's HWND for size/fullscreen/close


### PR DESCRIPTION
When playback was running in a maximized window, the sequence maximize -> minimize -> restore -> fullscreen could cause the window to minimize instantly instead of entering fullscreen normally.

**Root cause**: fullscreen state detection in the Windows platform layer relied on a style check that did not match mpv’s actual fullscreen window style on Win32.


Result:

- Fullscreen transitions are now correctly tracked on Windows.
- The unexpected minimize behavior after maximize/minimize/restore is resolved.

Fixes the bug: #242 

https://github.com/user-attachments/assets/d4e992d9-1506-4037-adc2-7d2db5086814