### PR TITLE
Move context menu items to app layer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -514,6 +514,7 @@ if(WIN32)
         src/browser/web_browser.cpp
         src/browser/overlay_browser.cpp
         src/browser/about_browser.cpp
+        src/browser/app_menu.cpp
         src/input/dispatch.cpp
         src/input/hotkeys.cpp
         src/cjson/cJSON.c
@@ -534,6 +535,7 @@ else()
         src/browser/web_browser.cpp
         src/browser/overlay_browser.cpp
         src/browser/about_browser.cpp
+        src/browser/app_menu.cpp
         src/input/dispatch.cpp
         src/input/hotkeys.cpp
         src/single_instance.cpp

--- a/src/browser/about_browser.cpp
+++ b/src/browser/about_browser.cpp
@@ -1,4 +1,5 @@
 #include "about_browser.h"
+#include "app_menu.h"
 #include "browsers.h"
 #include "../common.h"
 #include "../mpv/event.h"
@@ -78,6 +79,8 @@ AboutBrowser::AboutBrowser()
     client_->setCreatedCallback([](CefRefPtr<CefBrowser> browser) {
         input::set_active_browser(browser);
     });
+    client_->setContextMenuBuilder(&app_menu::build);
+    client_->setContextMenuDispatcher(&app_menu::dispatch);
     client_->setBeforeCloseCallback([]() {
         // Null the global now so "About" can be re-opened; defer the actual
         // delete so the CefLayer's OnBeforeClose lambda is not torn down

--- a/src/browser/app_menu.cpp
+++ b/src/browser/app_menu.cpp
@@ -1,0 +1,32 @@
+#include "app_menu.h"
+#include "about_browser.h"
+#include "../common.h"
+#include "../platform/platform.h"
+
+extern Platform g_platform;
+
+namespace app_menu {
+namespace {
+enum {
+    MENU_ID_TOGGLE_FULLSCREEN = MENU_ID_USER_FIRST,
+    MENU_ID_ABOUT,
+    MENU_ID_EXIT,
+};
+}
+
+void build(CefRefPtr<CefMenuModel> model) {
+    model->AddItem(MENU_ID_TOGGLE_FULLSCREEN, "Toggle Fullscreen");
+    model->AddItem(MENU_ID_ABOUT, "About");
+    model->AddItem(MENU_ID_EXIT, "Exit");
+}
+
+bool dispatch(int command_id) {
+    switch (command_id) {
+    case MENU_ID_TOGGLE_FULLSCREEN: g_platform.toggle_fullscreen(); return true;
+    case MENU_ID_ABOUT: AboutBrowser::open(); return true;
+    case MENU_ID_EXIT: initiate_shutdown(); return true;
+    default: return false;
+    }
+}
+
+}

--- a/src/browser/app_menu.h
+++ b/src/browser/app_menu.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "include/cef_menu_model.h"
+
+// App-level context menu: items appended to every CEF context menu and the
+// dispatcher that runs when the user picks one. Lives at the app layer (not
+// in the CEF wrapper) because the items and their actions are jellyfin-desktop
+// policy, not CEF concerns.
+namespace app_menu {
+
+// Append the app's standard items (Toggle Fullscreen, About, Exit) to `model`.
+void build(CefRefPtr<CefMenuModel> model);
+
+// Run the action for `command_id` if it belongs to the app menu.
+// Returns true if handled.
+bool dispatch(int command_id);
+
+}

--- a/src/browser/overlay_browser.cpp
+++ b/src/browser/overlay_browser.cpp
@@ -1,5 +1,5 @@
 #include "overlay_browser.h"
-#include "about_browser.h"
+#include "app_menu.h"
 #include "web_browser.h"
 #include "../common.h"
 #include "../jellyfin_api.h"
@@ -162,6 +162,8 @@ OverlayBrowser::OverlayBrowser(RenderTarget target, WebBrowser& main_browser,
         // Overlay wins input whenever it's created.
         input::set_active_browser(browser);
     });
+    client_->setContextMenuBuilder(&app_menu::build);
+    client_->setContextMenuDispatcher(&app_menu::dispatch);
 }
 
 bool OverlayBrowser::handleMessage(const std::string& name,
@@ -231,8 +233,6 @@ bool OverlayBrowser::handleMessage(const std::string& name,
         // Kill the pre-load: closes the render process and recreates the main
         // browser blank, so no stale JS/service-workers/history survive.
         main_browser_.reset();
-    } else if (name == "openAbout") {
-        AboutBrowser::open();
     } else {
         return false;
     }

--- a/src/browser/web_browser.cpp
+++ b/src/browser/web_browser.cpp
@@ -1,5 +1,5 @@
 #include "web_browser.h"
-#include "about_browser.h"
+#include "app_menu.h"
 #include "browsers.h"
 #include <cmath>
 #include "../common.h"
@@ -128,6 +128,8 @@ WebBrowser::WebBrowser(RenderTarget target, int w, int h, int pw, int ph)
         if (!g_overlay_browser)
             input::set_active_browser(browser);
     });
+    client_->setContextMenuBuilder(&app_menu::build);
+    client_->setContextMenuDispatcher(&app_menu::dispatch);
 }
 
 bool WebBrowser::handleMessage(const std::string& name,
@@ -230,8 +232,6 @@ bool WebBrowser::handleMessage(const std::string& name,
         g_platform.set_cursor(args->GetBool(0) ? CT_POINTER : CT_NONE);
     } else if (name == "appExit") {
         initiate_shutdown();
-    } else if (name == "openAbout") {
-        AboutBrowser::open();
     } else if (name == "openConfigDir") {
         LOG_INFO(LOG_CEF, "Openning mpv home directory");
         paths::openMpvHome();

--- a/src/cef/cef_client.cpp
+++ b/src/cef/cef_client.cpp
@@ -398,12 +398,6 @@ void CefLayer::execJs(const std::string& js) {
         browser_->GetMainFrame()->ExecuteJavaScript(js, "", 0);
 }
 
-enum {
-    MENU_ID_TOGGLE_FULLSCREEN = MENU_ID_USER_FIRST,
-    MENU_ID_ABOUT,
-    MENU_ID_EXIT,
-};
-
 bool CefLayer::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame>,
                                         CefProcessId, CefRefPtr<CefProcessMessage> message) {
     auto name = message->GetName().ToString();
@@ -445,18 +439,9 @@ bool CefLayer::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser, CefRefPtr
             case MENU_ID_COPY: frame->Copy(); break;
             case MENU_ID_PASTE: do_paste(browser_, frame); break;
             case MENU_ID_SELECT_ALL: frame->SelectAll(); break;
-            case MENU_ID_TOGGLE_FULLSCREEN:
-            case MENU_ID_ABOUT:
-            case MENU_ID_EXIT: {
-                const char* name = "appExit";
-                if (cmd == MENU_ID_TOGGLE_FULLSCREEN) name = "toggleFullscreen";
-                else if (cmd == MENU_ID_ABOUT) name = "openAbout";
-                auto msg = CefProcessMessage::Create(name);
-                if (message_handler_)
-                    message_handler_(msg->GetName().ToString(), msg->GetArgumentList(), browser);
+            default:
+                if (context_menu_dispatcher_) context_menu_dispatcher_(cmd);
                 break;
-            }
-            default: break;
             }
         }
         return true;
@@ -489,10 +474,10 @@ void CefLayer::OnBeforeContextMenu(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame>,
     while (model->GetCount() > 0 &&
            model->GetTypeAt(model->GetCount() - 1) == MENUITEMTYPE_SEPARATOR)
         model->RemoveAt(model->GetCount() - 1);
-    model->AddSeparator();
-    model->AddItem(MENU_ID_TOGGLE_FULLSCREEN, "Toggle Fullscreen");
-    model->AddItem(MENU_ID_ABOUT, "About");
-    model->AddItem(MENU_ID_EXIT, "Exit");
+    if (context_menu_builder_) {
+        model->AddSeparator();
+        context_menu_builder_(model);
+    }
 }
 
 bool CefLayer::RunContextMenu(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame>,

--- a/src/cef/cef_client.h
+++ b/src/cef/cef_client.h
@@ -26,6 +26,11 @@ using CreatedCallback = std::function<void(CefRefPtr<CefBrowser>)>;
 // Callback invoked just before the browser is destroyed (OnBeforeClose).
 using BeforeCloseCallback = std::function<void()>;
 
+// Callbacks for app-level context menu items. CefLayer is policy-free: it
+// asks the app to append items and to dispatch unknown command IDs.
+using ContextMenuBuilder = std::function<void(CefRefPtr<CefMenuModel>)>;
+using ContextMenuDispatcher = std::function<bool(int command_id)>;
+
 // Render target callbacks — decouple the client from the platform layer.
 struct RenderTarget {
     void (*present)(const CefAcceleratedPaintInfo& info);
@@ -49,6 +54,8 @@ public:
     void setMessageHandler(MessageHandler handler) { message_handler_ = std::move(handler); }
     void setCreatedCallback(CreatedCallback cb) { on_after_created_ = std::move(cb); }
     void setBeforeCloseCallback(BeforeCloseCallback cb) { on_before_close_ = std::move(cb); }
+    void setContextMenuBuilder(ContextMenuBuilder cb) { context_menu_builder_ = std::move(cb); }
+    void setContextMenuDispatcher(ContextMenuDispatcher cb) { context_menu_dispatcher_ = std::move(cb); }
 
     CefRefPtr<CefRenderHandler> GetRenderHandler() override { return this; }
     CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() override { return this; }
@@ -161,6 +168,8 @@ private:
     MessageHandler message_handler_;
     CreatedCallback on_after_created_;
     BeforeCloseCallback on_before_close_;
+    ContextMenuBuilder context_menu_builder_;
+    ContextMenuDispatcher context_menu_dispatcher_;
     CefWindowInfo window_info_;
     CefBrowserSettings browser_settings_;
     CefRefPtr<CefDictionaryValue> extra_info_;

--- a/src/input/dispatch.cpp
+++ b/src/input/dispatch.cpp
@@ -14,6 +14,13 @@ namespace {
 std::mutex g_active_mtx;
 CefRefPtr<CefBrowser> g_active;  // guarded by g_active_mtx
 
+std::mutex g_last_pos_mtx;
+struct LastPos {
+    bool     valid = false;
+    int      x = 0, y = 0;
+    uint32_t modifiers = 0;
+} g_last_pos;  // guarded by g_last_pos_mtx
+
 cef_mouse_button_type_t to_cef_button(MouseButton b) {
     switch (b) {
     case MouseButton::Left:   return MBT_LEFT;
@@ -42,6 +49,23 @@ void set_active_browser(CefRefPtr<CefBrowser> browser) {
              static_cast<void*>(prev.get()), static_cast<void*>(browser.get()));
     if (prev)    prev->GetHost()->SetFocus(false);
     if (browser) browser->GetHost()->SetFocus(true);
+
+    // Leave-then-move forces the renderer to re-emit OnCursorChange even
+    // when its cached cursor matches the new hit-test result; otherwise the
+    // platform cursor stays on whatever the previous active browser set.
+    if (browser) {
+        LastPos pos;
+        {
+            std::lock_guard<std::mutex> lk(g_last_pos_mtx);
+            pos = g_last_pos;
+        }
+        if (pos.valid) {
+            CefMouseEvent me{};
+            me.x = pos.x; me.y = pos.y; me.modifiers = pos.modifiers;
+            browser->GetHost()->SendMouseMoveEvent(me, true);
+            browser->GetHost()->SendMouseMoveEvent(me, false);
+        }
+    }
 }
 
 void dispatch_key(const KeyEvent& e) {
@@ -87,6 +111,17 @@ void dispatch_mouse_button(const MouseButtonEvent& e) {
 }
 
 void dispatch_mouse_move(const MouseMoveEvent& e) {
+    {
+        std::lock_guard<std::mutex> lk(g_last_pos_mtx);
+        if (e.leave) {
+            g_last_pos.valid = false;
+        } else {
+            g_last_pos.valid = true;
+            g_last_pos.x = e.x;
+            g_last_pos.y = e.y;
+            g_last_pos.modifiers = e.modifiers;
+        }
+    }
     auto b = active_browser();
     if (!b) return;
     CefMouseEvent me{};

--- a/src/mpv/options.h
+++ b/src/mpv/options.h
@@ -3,7 +3,7 @@
 #include <string>
 #include <vector>
 
-constexpr const char* kHwdecDefault = "auto";
+constexpr const char* kHwdecDefault = "no";
 
 inline std::vector<std::string> hwdecOptions() {
     return {


### PR DESCRIPTION
Toggle Fullscreen / About / Exit were defined in cef_client and dispatched by manufacturing fake IPC messages routed through each browser's message handler. Only WebBrowser implemented the handlers, so on a fresh install (overlay server picker) and in the About dialog those items silently no-op'd.

Extract the items and dispatch into src/browser/app_menu so the CEF wrapper stays policy-free, and wire the same provider into all three browsers via setContextMenuBuilder/Dispatcher callbacks.