### PR TITLE
feat(wayland): add client-side window controls

### DIFF
--- a/src/browser/web_browser.cpp
+++ b/src/browser/web_browser.cpp
@@ -90,6 +90,7 @@ CefRefPtr<CefDictionaryValue> WebBrowser::injectionProfile() {
         "notifyRateChange",
         "appExit", "setSettingValue", "themeColor",
         "setOsdVisible", "setCursorVisible", "toggleFullscreen",
+        "windowMinimize", "windowToggleMaximize",
         "menuItemSelected", "menuDismissed",
     };
     static const char* const kScripts[] = {
@@ -187,6 +188,10 @@ bool WebBrowser::handleMessage(const std::string& name,
         }
     } else if (name == "toggleFullscreen") {
         g_platform.toggle_fullscreen();
+    } else if (name == "windowMinimize") {
+        g_mpv.SetWindowMinimized(true);
+    } else if (name == "windowToggleMaximize") {
+        g_mpv.SetWindowMaximized(!mpv::window_maximized());
     } else if (name == "saveServerUrl") {
         std::string url = args->GetString(0).ToString();
         Settings::instance().setServerUrl(url);

--- a/src/cef/cef_app.cpp
+++ b/src/cef/cef_app.cpp
@@ -12,6 +12,7 @@
 #include "include/cef_v8.h"
 
 #include <cassert>
+#include <cstdlib>
 #include <filesystem>
 #include <mutex>
 #include <string>
@@ -20,8 +21,6 @@
 
 #ifdef _WIN32
 #include <windows.h>
-#else
-#include <cstdlib>
 #endif
 
 #ifdef __APPLE__
@@ -405,6 +404,8 @@ void App::OnContextCreated(CefRefPtr<CefBrowser> browser,
         size_t pos = code.find(ph);
         if (pos != std::string::npos) code.replace(pos, ph.length(), value);
     };
+    const char* display_backend = getenv("JFD_DISPLAY_BACKEND");
+    replace_first("__DISPLAY_BACKEND__", display_backend ? display_backend : "");
     replace_first("__SERVER_URL__", Settings::instance().serverUrl());
     replace_first("__SETTINGS_JSON__", Settings::instance().cliSettingsJson());
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -508,6 +508,9 @@ int main(int argc, char* argv[]) {
         }
 #endif
         g_platform = make_platform(backend);
+        setenv("JFD_DISPLAY_BACKEND",
+               g_platform.display == DisplayBackend::Wayland ? "wayland" : "x11",
+               1);
     }
     LOG_INFO(LOG_MAIN, "Display backend: {}",
              g_platform.display == DisplayBackend::Wayland ? "wayland" : "x11");

--- a/src/mpv/handle.h
+++ b/src/mpv/handle.h
@@ -138,6 +138,8 @@ public:
     // Window/display state
     void SetFullscreen(bool fs)          { SetPropertyFlagAsync("fullscreen", fs); }
     void ToggleFullscreen()              { CycleFullscreenAsync(); }
+    void SetWindowMinimized(bool v)      { SetPropertyFlagAsync("window-minimized", v); }
+    void SetWindowMaximized(bool v)      { SetPropertyFlagAsync("window-maximized", v); }
     void SetBackgroundColor(const std::string& color) { SetPropertyStringAsync("background-color", color); }
     void SetForceWindowPosition(bool v)  { SetPropertyFlagAsync("force-window-position", v); }
     void SetGeometry(const std::string& geom) { SetPropertyStringAsync("geometry", geom); }

--- a/src/web/native-shim.js
+++ b/src/web/native-shim.js
@@ -1,5 +1,6 @@
 (function() {
     console.log('[Media] Installing native shim...');
+    const _displayBackend = '__DISPLAY_BACKEND__';
 
     // Fullscreen state tracking via HTML5 Fullscreen API
     window._isFullscreen = false;
@@ -13,6 +14,9 @@
         const player = window._mpvVideoPlayerInstance;
         if (player && player.events) {
             player.events.trigger(player, 'fullscreenchange');
+        }
+        if (typeof window._updateNativeWindowControlsVisibility === 'function') {
+            window._updateNativeWindowControlsVisibility();
         }
     });
 
@@ -70,6 +74,46 @@
             console.log('[Media] [Signal] ' + name + ' disconnected, now has', callbacks.length, 'listeners');
         };
         return signal;
+    }
+
+    function installLinuxWaylandWindowControls() {
+        if (_displayBackend !== 'wayland') return;
+        if (!window.jmpNative) return;
+
+        const controls = document.createElement('div');
+        controls.id = 'jfd-wayland-controls';
+
+        const makeButton = (label, title, onClick) => {
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'jfd-wayland-control-btn';
+            btn.textContent = label;
+            btn.title = title;
+            btn.setAttribute('aria-label', title);
+            btn.addEventListener('click', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                onClick();
+            });
+            return btn;
+        };
+
+        controls.appendChild(makeButton('_', 'Minimize', () => {
+            if (window.jmpNative.windowMinimize) window.jmpNative.windowMinimize();
+        }));
+        controls.appendChild(makeButton('[ ]', 'Maximize', () => {
+            if (window.jmpNative.windowToggleMaximize) window.jmpNative.windowToggleMaximize();
+        }));
+        controls.appendChild(makeButton('X', 'Close', () => {
+            if (window.jmpNative.appExit) window.jmpNative.appExit();
+        }));
+
+        document.body.appendChild(controls);
+
+        window._updateNativeWindowControlsVisibility = () => {
+            controls.style.display = window._isFullscreen ? 'none' : 'flex';
+        };
+        window._updateNativeWindowControlsVisibility();
     }
 
     // Saved settings from native (injected as placeholder, replaced at load time)
@@ -309,6 +353,9 @@
     };
     window._nativeFullscreenChanged = function(fullscreen) {
         window._isFullscreen = fullscreen;
+        if (typeof window._updateNativeWindowControlsVisibility === 'function') {
+            window._updateNativeWindowControlsVisibility();
+        }
         const player = window._mpvVideoPlayerInstance;
         if (player && player.events) {
             player.events.trigger(player, 'fullscreenchange');
@@ -478,8 +525,16 @@
             });
         }
 
+        if (_displayBackend === 'wayland') {
+            css += '\n#jfd-wayland-controls { position: fixed; top: 8px; right: 8px; z-index: 2147483647; display: flex; gap: 6px; }';
+            css += '\n#jfd-wayland-controls .jfd-wayland-control-btn { min-width: 28px; height: 24px; padding: 0 6px; border: 1px solid rgba(255,255,255,0.35); border-radius: 6px; background: rgba(20,20,20,0.75); color: #fff; font: 600 12px/1 sans-serif; cursor: pointer; }';
+            css += '\n#jfd-wayland-controls .jfd-wayland-control-btn:hover { background: rgba(255,255,255,0.2); }';
+            css += '\n#jfd-wayland-controls .jfd-wayland-control-btn:active { background: rgba(255,255,255,0.3); }';
+        }
+
         style.textContent = css;
         document.head.appendChild(style);
+        installLinuxWaylandWindowControls();
 
         // Titlebar black during video playback, restore theme color when done
         window.api.player.playing.connect(() => {


### PR DESCRIPTION
## Summary
 
 Implements client-side window controls for Wayland sessions so users still have **minimize**, **maximize**, and **close** even when compositor-provided decorations are missing (e.g. 
GNOME).
 
 ### What changed
 
 - Added Wayland client-side control buttons in `native-shim.js`:
   - Minimize
   - Toggle maximize
   - Close
 - Wired new native IPC handlers in `WebBrowser`:
   - `windowMinimize`
   - `windowToggleMaximize`
 - Added mpv wrappers for window state updates:
   - `window-minimized`
   - `window-maximized`
 - Passed active display backend into renderer script injection:
   - Set `JFD_DISPLAY_BACKEND` in `main.cpp`
   - Injected `__DISPLAY_BACKEND__` in `cef_app.cpp`
 - Made controls Wayland-only and hidden while fullscreen.
 
 ## Why
 
 On some Wayland environments (notably GNOME), server-side decorations are not reliably available for this app, which leaves users without window controls. This adds a client-side 
fallback so window management remains accessible.

Full disclosure, I did this with the help of AI solely because I just wanted the app to work locally so I could use it in my day-to-day. But if it helps the overall project I'd be chuffed.
 
 ## Scope / behavior
 
 - **Wayland:** shows client-side controls in-app.
 - **X11/macOS/Windows:** unchanged.
 
 Closes #141