### PR TITLE
ci: guard macOS Monterey deployment target (#248)

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -24,6 +24,9 @@ jobs:
           - runner: macos-15-intel
             arch: x86_64
     runs-on: ${{ matrix.runner }}
+    env:
+      MACOSX_DEPLOYMENT_TARGET: '12.0'
+      CMAKE_OSX_DEPLOYMENT_TARGET: '12.0'
 
     steps:
       - name: Checkout
@@ -65,12 +68,19 @@ jobs:
       - name: Configure and build
         run: |
           cmake -B build -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET="$MACOSX_DEPLOYMENT_TARGET"
           cmake --build build
 
       - name: Create app bundle
         run: |
           cmake --install build --prefix build/output
+
+      - name: Verify Monterey deployment target
+        run: |
+          python3 dev/tools/verify_macos_deployment.py \
+            "build/output/Jellyfin Desktop.app" \
+            --target "$MACOSX_DEPLOYMENT_TARGET"
 
       - name: Create DMG
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -439,8 +439,12 @@ else()
     # Configure meson if not yet configured
     if(NOT EXISTS "${MPV_BUILD_DIR}/build.ninja")
         message(STATUS "Configuring mpv with meson...")
+        set(_MPV_MESON_ENV ${CMAKE_COMMAND} -E env)
+        if(APPLE AND CMAKE_OSX_DEPLOYMENT_TARGET)
+            list(APPEND _MPV_MESON_ENV "MACOSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}")
+        endif()
         execute_process(
-            COMMAND meson setup build --default-library=shared -Dlibmpv=true
+            COMMAND ${_MPV_MESON_ENV} meson setup build --default-library=shared -Dlibmpv=true
             WORKING_DIRECTORY ${MPV_SOURCE_DIR}
             RESULT_VARIABLE MPV_SETUP_RESULT
         )
@@ -451,7 +455,7 @@ else()
 
     # Custom target that always invokes meson compile (meson handles incremental builds)
     add_custom_target(mpv_build
-        COMMAND meson compile -C build
+        COMMAND ${_MPV_MESON_ENV} meson compile -C build
         WORKING_DIRECTORY ${MPV_SOURCE_DIR}
         COMMENT "Building mpv (meson handles incremental builds)"
         BYPRODUCTS ${MPV_LIBRARY}

--- a/dev/tools/verify_macos_deployment.py
+++ b/dev/tools/verify_macos_deployment.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Verify a macOS app bundle does not accidentally target too-new macOS.
+
+The CI runners can build on newer macOS/Xcode while the distributed app is
+intended to support older systems. This script inspects Mach-O load commands in
+an app bundle and fails if any executable/dylib/framework advertises a minimum
+macOS version above the requested deployment target.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import subprocess
+import sys
+
+MACHO_SUFFIXES = {"", ".dylib", ".so"}
+MINOS_RE = re.compile(r"minos\s+(\d+)\.(\d+)(?:\.(\d+))?")
+
+
+def parse_version(value: str) -> tuple[int, int, int]:
+    parts = value.split(".")
+    if not 1 <= len(parts) <= 3:
+        raise argparse.ArgumentTypeError(f"invalid version: {value}")
+    try:
+        nums = [int(part) for part in parts]
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid version: {value}") from exc
+    while len(nums) < 3:
+        nums.append(0)
+    return tuple(nums)  # type: ignore[return-value]
+
+
+def is_candidate(path: pathlib.Path) -> bool:
+    if path.is_dir() or path.is_symlink():
+        return False
+    if path.suffix in MACHO_SUFFIXES:
+        return True
+    return path.parent.name == "MacOS"
+
+
+def file_kind(path: pathlib.Path) -> str:
+    try:
+        return subprocess.check_output(["file", "-b", str(path)], text=True).strip()
+    except subprocess.CalledProcessError:
+        return ""
+
+
+def macho_minos(path: pathlib.Path) -> tuple[int, int, int] | None:
+    kind = file_kind(path)
+    if "Mach-O" not in kind:
+        return None
+    output = subprocess.check_output(["vtool", "-show-build", str(path)], text=True)
+    matches = [parse_version(".".join(part for part in match if part)) for match in MINOS_RE.findall(output)]
+    if not matches:
+        return None
+    return max(matches)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("app", type=pathlib.Path, help="Path to .app bundle")
+    parser.add_argument("--target", default="12.0", type=parse_version)
+    args = parser.parse_args()
+
+    if not args.app.exists():
+        parser.error(f"app bundle does not exist: {args.app}")
+
+    failures: list[str] = []
+    inspected = 0
+    for path in sorted(args.app.rglob("*")):
+        if not is_candidate(path):
+            continue
+        minos = macho_minos(path)
+        if minos is None:
+            continue
+        inspected += 1
+        rel = path.relative_to(args.app)
+        version = ".".join(str(part) for part in minos).rstrip(".0")
+        if minos > args.target:
+            failures.append(f"{rel}: minos {version}")
+
+    if failures:
+        print(f"Found {len(failures)} Mach-O files above target {args.target[0]}.{args.target[1]}:")
+        print("\n".join(failures))
+        return 1
+    print(f"OK: inspected {inspected} Mach-O files; all target <= {args.target[0]}.{args.target[1]}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- set the macOS CI/build deployment target to Monterey (`12.0`) for the app and CMake configure step
- pass the same deployment target into the vendored mpv Meson setup/compile environment
- add a pre-DMG bundle guard that inspects Mach-O `minos` values with `vtool` so CI catches dylibs/frameworks that drift above the target

## Verification
- `git diff --check`
- `python3 -m py_compile dev/tools/verify_macos_deployment.py`
- static workflow/CMake assertions for deployment target propagation and the verification step

I could not run a full macOS/Xcode/Homebrew/CEF/DMG build in this Linux cron environment, so this PR is a CI/build-system guard first slice for #248 rather than a claim that the Monterey runtime crash is fully fixed.

Fixes #248
