### PR TITLE
Introduce MessageBus IPC and migrate JS off per-method RPC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -463,6 +463,7 @@ endif()
 
 # Embed JS shims into generated header
 set(JS_SHIMS
+    ${CMAKE_SOURCE_DIR}/src/web/jmp-bus.js
     ${CMAKE_SOURCE_DIR}/src/web/native-shim.js
     ${CMAKE_SOURCE_DIR}/src/web/mpv-player-core.js
     ${CMAKE_SOURCE_DIR}/src/web/mpv-video-player.js
@@ -510,6 +511,7 @@ if(WIN32)
         src/mpv/event.cpp
         src/cef/cef_app.cpp
         src/cef/cef_client.cpp
+        src/cef/message_bus.cpp
         src/cef/resource_handler.cpp
         src/browser/web_browser.cpp
         src/browser/overlay_browser.cpp
@@ -521,6 +523,8 @@ if(WIN32)
         src/jellyfin_api.cpp
         src/settings.cpp
         src/paths/paths.cpp
+        src/player/player_router.cpp
+        src/player/track_resolver.cpp
         src/wake_event_windows.cpp
     )
 else()
@@ -531,6 +535,7 @@ else()
         src/mpv/event.cpp
         src/cef/cef_app.cpp
         src/cef/cef_client.cpp
+        src/cef/message_bus.cpp
         src/cef/resource_handler.cpp
         src/browser/web_browser.cpp
         src/browser/overlay_browser.cpp
@@ -543,6 +548,8 @@ else()
         src/paths/paths.cpp
         src/cjson/cJSON.c
         src/jellyfin_api.cpp
+        src/player/player_router.cpp
+        src/player/track_resolver.cpp
     )
 endif()
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ Available recipes:
     flatpak           # Build Flatpak bundle (outputs to dist/)
     list              # List available recipes
     run               # Run the app with debug logging (logs to build/run.log)
-    test              # Run unit tests
+    test              # Run unit tests (C++ ctest + JS test-web)
+    test-web          # Run JS unit tests for src/web/ via Deno
     update-deps *args # Update vendored/fetched deps (CEF, doctest, quill); pass --check to verify only
 ```
+
+`just test-web` requires [Deno](https://deno.com/) on `PATH`.

--- a/dev/macos/macos.just
+++ b/dev/macos/macos.just
@@ -15,7 +15,7 @@ build: deps
     ./dev/macos/build.sh
 
 [macos]
-test: build
+test: build test-web
     ./dev/macos/test.sh
 
 [macos]

--- a/dev/windows/windows.just
+++ b/dev/windows/windows.just
@@ -9,7 +9,7 @@ build: deps
     cmd /c dev\windows\build.bat
 
 [windows]
-test: build
+test: build test-web
     ctest --test-dir build --output-on-failure
 
 [windows]

--- a/justfile
+++ b/justfile
@@ -28,8 +28,12 @@ deps:
 
 # Run unit tests
 [linux]
-test: build
+test: build test-web
     ctest --test-dir build --output-on-failure
+
+# Run JS unit tests for src/web/ via Deno
+test-web:
+    deno test --allow-read=src/web,tests tests/web/
 
 # Run the app with debug logging (logs to build/run.log)
 [linux]

--- a/src/browser/about_browser.cpp
+++ b/src/browser/about_browser.cpp
@@ -1,6 +1,7 @@
 #include "about_browser.h"
 #include "app_menu.h"
 #include "browsers.h"
+#include "../cef/message_bus.h"
 #include "../common.h"
 #include "../mpv/event.h"
 #include "logging.h"
@@ -48,10 +49,10 @@ int safe_lh() {
 
 CefRefPtr<CefDictionaryValue> AboutBrowser::injectionProfile() {
     static const char* const kFunctions[] = {
-        "aboutOpenPath", "aboutDismiss",
+        "send",
         "menuItemSelected", "menuDismissed",
     };
-    static const char* const kScripts[] = { "context-menu.js" };
+    static const char* const kScripts[] = { "jmp-bus.js", "context-menu.js" };
     CefRefPtr<CefListValue> fns = CefListValue::Create();
     for (size_t i = 0; i < sizeof(kFunctions) / sizeof(*kFunctions); i++)
         fns->SetString(i, kFunctions[i]);
@@ -71,13 +72,9 @@ AboutBrowser::AboutBrowser()
 {
     prev_active_ = input::active_browser();
 
-    client_->setMessageHandler([this](const std::string& name,
-                                      CefRefPtr<CefListValue> args,
-                                      CefRefPtr<CefBrowser> browser) {
-        return handleMessage(name, args, browser);
-    });
     client_->setCreatedCallback([](CefRefPtr<CefBrowser> browser) {
         input::set_active_browser(browser);
+        g_bus.registerNamespace("about", browser);
     });
     client_->setContextMenuBuilder(&app_menu::build);
     client_->setContextMenuDispatcher(&app_menu::dispatch);
@@ -87,8 +84,29 @@ AboutBrowser::AboutBrowser()
         // mid-invocation (we're running inside it right now).
         AboutBrowser* self = g_about_browser;
         g_about_browser = nullptr;
+        g_bus.unregisterNamespace("about");
         if (!self) return;
         CefPostTask(TID_UI, CefRefPtr<CefTask>(new FnTask([self]() { delete self; })));
+    });
+
+    installBusHandlers();
+}
+
+void AboutBrowser::installBusHandlers() {
+    g_bus.on("about.aboutDismiss", [this](CefRefPtr<CefDictionaryValue>) {
+        LOG_INFO(LOG_CEF, "AboutBrowser: aboutDismiss");
+        input::set_active_browser(prev_active_);
+        g_platform.set_about_visible(false);
+        if (auto b = client_->browser()) b->GetHost()->CloseBrowser(false);
+    });
+    g_bus.on("about.aboutOpenPath", [](CefRefPtr<CefDictionaryValue> p) {
+        std::string path = p->HasKey("path") ? p->GetString("path").ToString() : "";
+        if (path.empty()) {
+            LOG_WARN(LOG_CEF, "about.aboutOpenPath: empty path, ignoring");
+            return;
+        }
+        if (g_platform.open_external_url)
+            g_platform.open_external_url("file://" + path);
     });
 }
 
@@ -119,25 +137,3 @@ void AboutBrowser::open() {
                                   injectionProfile(), nullptr);
 }
 
-bool AboutBrowser::handleMessage(const std::string& name,
-                                 CefRefPtr<CefListValue> args,
-                                 CefRefPtr<CefBrowser> browser) {
-    if (name == "aboutDismiss") {
-        LOG_INFO(LOG_CEF, "AboutBrowser: aboutDismiss");
-        input::set_active_browser(prev_active_);
-        g_platform.set_about_visible(false);
-        if (browser) browser->GetHost()->CloseBrowser(false);
-        return true;
-    }
-    if (name == "aboutOpenPath") {
-        std::string path = args->GetString(0).ToString();
-        if (path.empty()) {
-            LOG_WARN(LOG_CEF, "aboutOpenPath: empty path, ignoring");
-            return true;
-        }
-        if (g_platform.open_external_url)
-            g_platform.open_external_url("file://" + path);
-        return true;
-    }
-    return false;
-}

--- a/src/browser/about_browser.h
+++ b/src/browser/about_browser.h
@@ -29,9 +29,8 @@ public:
 private:
     AboutBrowser();
 
-    bool handleMessage(const std::string& name,
-                       CefRefPtr<CefListValue> args,
-                       CefRefPtr<CefBrowser> browser);
+    // Register about.* handlers on g_bus.
+    void installBusHandlers();
 
     CefRefPtr<CefLayer> client_;
     CefRefPtr<CefBrowser> prev_active_;

--- a/src/browser/overlay_browser.cpp
+++ b/src/browser/overlay_browser.cpp
@@ -2,6 +2,7 @@
 #include "app_menu.h"
 #include "web_browser.h"
 #include "../common.h"
+#include "../cef/message_bus.h"
 #include "../jellyfin_api.h"
 #include "../settings.h"
 #include "logging.h"
@@ -127,13 +128,11 @@ OverlayBrowser::~OverlayBrowser() = default;
 
 CefRefPtr<CefDictionaryValue> OverlayBrowser::injectionProfile() {
     static const char* const kFunctions[] = {
-        "getSavedServerUrl",
-        "saveServerUrl", "navigateMain", "dismissOverlay",
-        "checkServerConnectivity", "cancelServerConnectivity",
-        "overlayFadeComplete",
+        "send",
         "menuItemSelected", "menuDismissed",
     };
     static const char* const kScripts[] = {
+        "jmp-bus.js",
         "context-menu.js",
     };
     CefRefPtr<CefListValue> fns = CefListValue::Create();
@@ -153,45 +152,44 @@ OverlayBrowser::OverlayBrowser(RenderTarget target, WebBrowser& main_browser,
     : client_(new CefLayer(target, w, h, pw, ph))
     , main_browser_(main_browser)
 {
-    client_->setMessageHandler([this](const std::string& name,
-                                      CefRefPtr<CefListValue> args,
-                                      CefRefPtr<CefBrowser> browser) {
-        return handleMessage(name, args, browser);
-    });
     client_->setCreatedCallback([](CefRefPtr<CefBrowser> browser) {
         // Overlay wins input whenever it's created.
         input::set_active_browser(browser);
+        g_bus.registerNamespace("overlay", browser);
     });
     client_->setContextMenuBuilder(&app_menu::build);
     client_->setContextMenuDispatcher(&app_menu::dispatch);
+
+    installBusHandlers();
 }
 
-bool OverlayBrowser::handleMessage(const std::string& name,
-                                   CefRefPtr<CefListValue> args,
-                                   CefRefPtr<CefBrowser> browser) {
-    if (name == "getSavedServerUrl") {
-        auto frame = browser ? browser->GetMainFrame() : nullptr;
-        if (!frame) return true;
-        auto reply = CefProcessMessage::Create("savedServerUrl");
-        reply->GetArgumentList()->SetString(0, Settings::instance().serverUrl());
-        frame->SendProcessMessage(PID_RENDERER, reply);
-    } else if (name == "navigateMain") {
-        // Start the main browser loading the given URL. Does NOT hide the
-        // overlay — the JS side owns the pre-fade delay so the user can still
-        // cancel during that window.
-        std::string url = args->GetString(0).ToString();
+// =====================================================================
+// MessageBus handler registration (overlay.*)
+// =====================================================================
+//
+// Runs in parallel with the legacy handleMessage arms. Outbound replies use
+// g_bus.emit (e.g. "overlay.savedServerUrl") instead of hand-built
+// CefProcessMessages so the wire format is uniform.
+
+void OverlayBrowser::installBusHandlers() {
+    g_bus.on("overlay.getSavedServerUrl", [](CefRefPtr<CefDictionaryValue>) {
+        auto reply = CefDictionaryValue::Create();
+        reply->SetString("url", Settings::instance().serverUrl());
+        g_bus.emit("overlay.savedServerUrl", reply);
+    });
+    g_bus.on("overlay.navigateMain", [this](CefRefPtr<CefDictionaryValue> p) {
+        if (!p->HasKey("url") || p->GetType("url") != VTYPE_STRING) return;
+        std::string url = p->GetString("url").ToString();
         LOG_INFO(LOG_CEF, "Overlay: navigateMain {}", url.c_str());
         Settings::instance().setServerUrl(url);
         Settings::instance().saveAsync();
-        // loadUrl handles all cases: live browser, initial create pending,
-        // or mid-reset — buffers the URL when the browser isn't ready.
         main_browser_.loadUrl(url);
-    } else if (name == "dismissOverlay") {
-        // Commit: hand input to main, start the fade, close when done.
+    });
+    g_bus.on("overlay.dismissOverlay", [this](CefRefPtr<CefDictionaryValue>) {
         LOG_INFO(LOG_CEF, "Overlay: dismissOverlay");
         if (auto b = main_browser_.browser())
             input::set_active_browser(b);
-        CefRefPtr<CefBrowser> overlay_browser = browser;
+        CefRefPtr<CefBrowser> overlay_browser = client_->browser();
         g_platform.fade_overlay(OVERLAY_FADE_DURATION_SEC,
             []() {
                 g_mpv.SetBackgroundColor(kVideoBgColor.hex);
@@ -201,40 +199,39 @@ bool OverlayBrowser::handleMessage(const std::string& name,
                 if (overlay_browser)
                     overlay_browser->GetHost()->CloseBrowser(false);
             });
-    } else if (name == "saveServerUrl") {
-        std::string url = args->GetString(0).ToString();
-        Settings::instance().setServerUrl(url);
+    });
+    g_bus.on("overlay.saveServerUrl", [](CefRefPtr<CefDictionaryValue> p) {
+        if (!p->HasKey("url") || p->GetType("url") != VTYPE_STRING) return;
+        Settings::instance().setServerUrl(p->GetString("url").ToString());
         Settings::instance().saveAsync();
-    } else if (name == "setSettingValue") {
-        std::string section = args->GetString(0).ToString();
-        std::string key = args->GetString(1).ToString();
-        std::string value = args->GetString(2).ToString();
+    });
+    g_bus.on("overlay.setSettingValue", [](CefRefPtr<CefDictionaryValue> p) {
+        std::string section = p->HasKey("section") ? p->GetString("section").ToString() : "";
+        std::string key     = p->HasKey("key")     ? p->GetString("key").ToString()     : "";
+        std::string value   = p->HasKey("value")   ? p->GetString("value").ToString()   : "";
         applySettingValue(section, key, value);
-    } else if (name == "checkServerConnectivity") {
-        std::string url = args->GetString(0).ToString();
+    });
+    g_bus.on("overlay.checkServerConnectivity", [this](CefRefPtr<CefDictionaryValue> p) {
+        if (!p->HasKey("url") || p->GetType("url") != VTYPE_STRING) return;
+        std::string url = p->GetString("url").ToString();
         if (active_probe_) active_probe_->Cancel();
         active_probe_ = new ServerProbeClient(
             jellyfin_api::normalize_input(url),
-            [browser, url](bool success, const std::string& base_url) {
-                auto frame = browser ? browser->GetMainFrame() : nullptr;
-                if (!frame) return;
-                auto msg = CefProcessMessage::Create("serverConnectivityResult");
-                msg->GetArgumentList()->SetString(0, url);
-                msg->GetArgumentList()->SetBool(1, success);
-                msg->GetArgumentList()->SetString(2, success ? base_url : url);
-                frame->SendProcessMessage(PID_RENDERER, msg);
+            [url](bool success, const std::string& base_url) {
+                auto reply = CefDictionaryValue::Create();
+                reply->SetString("url", url);
+                reply->SetBool("success", success);
+                reply->SetString("baseUrl", success ? base_url : url);
+                g_bus.emit("overlay.serverConnectivityResult", reply);
             });
         active_probe_->Start();
-    } else if (name == "cancelServerConnectivity") {
+    });
+    g_bus.on("overlay.cancelServerConnectivity", [this](CefRefPtr<CefDictionaryValue>) {
         if (active_probe_) {
             active_probe_->Cancel();
             active_probe_ = nullptr;
         }
-        // Kill the pre-load: closes the render process and recreates the main
-        // browser blank, so no stale JS/service-workers/history survive.
         main_browser_.reset();
-    } else {
-        return false;
-    }
-    return true;
+    });
 }
+

--- a/src/browser/overlay_browser.h
+++ b/src/browser/overlay_browser.h
@@ -30,9 +30,8 @@ public:
     static CefRefPtr<CefDictionaryValue> injectionProfile();
 
 private:
-    bool handleMessage(const std::string& name,
-                       CefRefPtr<CefListValue> args,
-                       CefRefPtr<CefBrowser> browser);
+    // Register overlay.* handlers on g_bus.
+    void installBusHandlers();
 
     CefRefPtr<CefLayer> client_;
     WebBrowser& main_browser_;

--- a/src/browser/web_browser.cpp
+++ b/src/browser/web_browser.cpp
@@ -12,6 +12,8 @@
 #include "../input/dispatch.h"
 #include "../cjson/cJSON.h"
 #include "../paths/paths.h"
+#include "../cef/message_bus.h"
+#include "../player/player_router.h"
 
 extern void update_idle_inhibit();
 
@@ -67,32 +69,17 @@ static void applySettingValue(const std::string& section, const std::string& key
     s.saveAsync();
 }
 
-// Helper to read an int from CefListValue that may have been sent as double.
-static int getIntArg(CefRefPtr<CefListValue> args, size_t idx) {
-    if (args->GetType(idx) == VTYPE_DOUBLE)
-        return static_cast<int>(std::lround(args->GetDouble(idx)));
-    return args->GetInt(idx);
-}
-
 // =====================================================================
 // WebBrowser
 // =====================================================================
 
 CefRefPtr<CefDictionaryValue> WebBrowser::injectionProfile() {
     static const char* const kFunctions[] = {
-        "playerLoad", "playerStop", "playerPause", "playerPlay", "playerSeek",
-        "playerSetVolume", "playerSetMuted", "playerSetSpeed",
-        "playerSetSubtitle", "playerAddSubtitle", "playerSetAudio",
-        "playerSetAudioDelay", "playerSetAspectMode", "playerOsdActive",
-        "openConfigDir", "saveServerUrl",
-        "notifyMetadata", "notifyPosition", "notifySeek",
-        "notifyPlaybackState", "notifyArtwork", "notifyQueueChange",
-        "notifyRateChange",
-        "appExit", "setSettingValue", "themeColor",
-        "setOsdVisible", "setCursorVisible", "toggleFullscreen",
+        "send",
         "menuItemSelected", "menuDismissed",
     };
     static const char* const kScripts[] = {
+        "jmp-bus.js",
         "native-shim.js",
         "mpv-player-core.js",
         "mpv-video-player.js",
@@ -118,125 +105,121 @@ CefRefPtr<CefDictionaryValue> WebBrowser::injectionProfile() {
 WebBrowser::WebBrowser(RenderTarget target, int w, int h, int pw, int ph)
     : client_(new CefLayer(target, w, h, pw, ph))
 {
-    client_->setMessageHandler([this](const std::string& name,
-                                      CefRefPtr<CefListValue> args,
-                                      CefRefPtr<CefBrowser> browser) {
-        return handleMessage(name, args, browser);
-    });
     client_->setCreatedCallback([](CefRefPtr<CefBrowser> browser) {
         // Main browser takes input only if the overlay isn't currently active.
         if (!g_overlay_browser)
             input::set_active_browser(browser);
+        // All web-browser-owned namespaces route to this CefBrowser for
+        // outbound bus emissions. Idempotent — safe across reloads.
+        g_bus.registerNamespace("player",     browser);
+        g_bus.registerNamespace("playback",   browser);
+        g_bus.registerNamespace("fullscreen", browser);
+        g_bus.registerNamespace("osd",        browser);
+        g_bus.registerNamespace("app",        browser);
+        g_bus.registerNamespace("input",      browser);
+        player_router::install();
     });
     client_->setContextMenuBuilder(&app_menu::build);
     client_->setContextMenuDispatcher(&app_menu::dispatch);
+
+    installBusHandlers();
 }
 
-bool WebBrowser::handleMessage(const std::string& name,
-                               CefRefPtr<CefListValue> args,
-                               CefRefPtr<CefBrowser> browser) {
-    if (!g_mpv.IsValid()) return false;
+// =====================================================================
+// MessageBus handler registration (playback / fullscreen / osd / app)
+// =====================================================================
+//
+// Player handlers live in player_router; the rest live here because they
+// reuse existing C++ logic that's tied to WebBrowser-adjacent globals
+// (g_media_session, g_platform, Settings, paths, g_titlebar_color).
+//
+// Registered in parallel with the legacy `handleMessage` arms; old per-method
+// `jmpNative.*` calls keep working until the JS migration step deletes them.
 
-    if (name == "playerLoad") {
-        std::string url = args->GetString(0).ToString();
-        int startMs = args->GetSize() > 1 ? getIntArg(args, 1) : 0;
-        int audioIdx = getIntArg(args, 2);
-        int subIdx = getIntArg(args, 3);
-        LOG_INFO(LOG_CEF, "playerLoad: audio={} sub={} start={}ms url={}",
-                 audioIdx, subIdx, startMs, url.c_str());
-        MpvHandle::LoadOptions opts;
-        opts.startSecs = startMs / 1000.0;
-        opts.audioTrack = audioIdx;
-        opts.subTrack = subIdx;
-        g_mpv.LoadFile(url, opts);
-    } else if (name == "playerStop") {
-        g_mpv.Stop();
-    } else if (name == "playerPause") {
-        g_mpv.Pause();
-    } else if (name == "playerPlay") {
-        g_mpv.Play();
-    } else if (name == "playerSeek") {
-        double pos = getIntArg(args, 0) / 1000.0;
-        g_mpv.SeekAbsolute(pos);
-    } else if (name == "playerSetVolume") {
-        g_mpv.SetVolume(getIntArg(args, 0));
-    } else if (name == "playerSetMuted") {
-        g_mpv.SetMuted(args->GetBool(0));
-    } else if (name == "playerSetSpeed") {
-        g_mpv.SetSpeed(getIntArg(args, 0) / 1000.0);
-    } else if (name == "playerSetSubtitle") {
-        LOG_INFO(LOG_CEF, "playerSetSubtitle: {}", getIntArg(args, 0));
-        g_mpv.SetSubtitleTrack(getIntArg(args, 0));
-    } else if (name == "playerAddSubtitle") {
-        std::string url = args->GetString(0).ToString();
-        LOG_INFO(LOG_CEF, "playerAddSubtitle: {}", url.c_str());
-        g_mpv.SubAdd(url);
-    } else if (name == "playerSetAudio") {
-        g_mpv.SetAudioTrack(getIntArg(args, 0));
-    } else if (name == "playerSetAudioDelay") {
-        g_mpv.SetAudioDelay(args->GetDouble(0));
-    } else if (name == "playerSetAspectMode") {
-        g_mpv.SetAspectMode(args->GetString(0).ToString());
-    } else if (name == "playerOsdActive") {
-        bool active = args->GetBool(0);
+void WebBrowser::installBusHandlers() {
+    // -------- playback (observed player state from JS) --------
+    g_bus.on("playback.metadata", [](CefRefPtr<CefDictionaryValue> p) {
+        if (!p->HasKey("json") || p->GetType("json") != VTYPE_STRING) return;
+        MediaMetadata meta = parseMetadataJson(p->GetString("json").ToString());
+        g_media_type = meta.media_type;
+        update_idle_inhibit();
+        if (g_media_session) g_media_session->setMetadata(meta);
+    });
+    g_bus.on("playback.artwork", [](CefRefPtr<CefDictionaryValue> p) {
+        if (!g_media_session) return;
+        if (p->HasKey("uri") && p->GetType("uri") == VTYPE_STRING)
+            g_media_session->setArtwork(p->GetString("uri").ToString());
+    });
+    g_bus.on("playback.queueChange", [](CefRefPtr<CefDictionaryValue> p) {
+        if (!g_media_session) return;
+        if (p->HasKey("canNext"))
+            g_media_session->setCanGoNext(p->GetBool("canNext"));
+        if (p->HasKey("canPrev"))
+            g_media_session->setCanGoPrevious(p->GetBool("canPrev"));
+    });
+    g_bus.on("playback.state", [](CefRefPtr<CefDictionaryValue> p) {
+        if (!g_media_session) return;
+        if (!p->HasKey("state") || p->GetType("state") != VTYPE_STRING) return;
+        std::string state = p->GetString("state").ToString();
+        if (state == "Playing")      g_media_session->setPlaybackState(PlaybackState::Playing);
+        else if (state == "Paused")  g_media_session->setPlaybackState(PlaybackState::Paused);
+        else                         g_media_session->setPlaybackState(PlaybackState::Stopped);
+    });
+    g_bus.on("playback.position", [](CefRefPtr<CefDictionaryValue> p) {
+        if (!g_media_session) return;
+        int posMs = 0;
+        if (p->HasKey("positionMs")) {
+            auto t = p->GetType("positionMs");
+            if (t == VTYPE_INT)         posMs = p->GetInt("positionMs");
+            else if (t == VTYPE_DOUBLE) posMs = static_cast<int>(std::lround(p->GetDouble("positionMs")));
+        }
+        g_media_session->emitSeeked(static_cast<int64_t>(posMs) * 1000);
+    });
+
+    // -------- fullscreen --------
+    g_bus.on("fullscreen.toggle", [](CefRefPtr<CefDictionaryValue>) {
+        g_platform.toggle_fullscreen();
+    });
+
+    // -------- osd --------
+    g_bus.on("osd.active", [this](CefRefPtr<CefDictionaryValue> p) {
+        bool active = p->HasKey("active") && p->GetBool("active");
         if (active) {
             was_fullscreen_before_osd_ = mpv::fullscreen();
         } else {
             if (!was_fullscreen_before_osd_)
                 g_platform.set_fullscreen(false);
         }
-    } else if (name == "toggleFullscreen") {
-        g_platform.toggle_fullscreen();
-    } else if (name == "saveServerUrl") {
-        std::string url = args->GetString(0).ToString();
-        Settings::instance().setServerUrl(url);
+    });
+    g_bus.on("osd.cursorVisible", [](CefRefPtr<CefDictionaryValue> p) {
+        bool visible = p->HasKey("visible") && p->GetBool("visible");
+        g_platform.set_cursor(visible ? CT_POINTER : CT_NONE);
+    });
+
+    // -------- app --------
+    g_bus.on("app.exit", [](CefRefPtr<CefDictionaryValue>) {
+        initiate_shutdown();
+    });
+    g_bus.on("app.openConfigDir", [](CefRefPtr<CefDictionaryValue>) {
+        LOG_INFO(LOG_CEF, "Opening mpv home directory");
+        paths::openMpvHome();
+    });
+    g_bus.on("app.saveServerUrl", [](CefRefPtr<CefDictionaryValue> p) {
+        if (!p->HasKey("url") || p->GetType("url") != VTYPE_STRING) return;
+        Settings::instance().setServerUrl(p->GetString("url").ToString());
         Settings::instance().saveAsync();
-    } else if (name == "setSettingValue") {
-        std::string section = args->GetString(0).ToString();
-        std::string key = args->GetString(1).ToString();
-        std::string value = args->GetString(2).ToString();
+    });
+    g_bus.on("app.setSettingValue", [](CefRefPtr<CefDictionaryValue> p) {
+        std::string section = p->HasKey("section") ? p->GetString("section").ToString() : "";
+        std::string key     = p->HasKey("key")     ? p->GetString("key").ToString()     : "";
+        std::string value   = p->HasKey("value")   ? p->GetString("value").ToString()   : "";
         applySettingValue(section, key, value);
-    } else if (name == "themeColor") {
-        std::string color = args->GetString(0).ToString();
+    });
+    g_bus.on("app.themeColor", [](CefRefPtr<CefDictionaryValue> p) {
+        if (!p->HasKey("color") || p->GetType("color") != VTYPE_STRING) return;
+        std::string color = p->GetString("color").ToString();
         LOG_DEBUG(LOG_CEF, "themeColor IPC: {}", color.c_str());
         if (g_titlebar_color) g_titlebar_color->onThemeColor(color);
-    } else if (name == "notifyMetadata") {
-        std::string json = args->GetString(0).ToString();
-        MediaMetadata meta = parseMetadataJson(json);
-        g_media_type = meta.media_type;
-        update_idle_inhibit();
-        if (g_media_session)
-            g_media_session->setMetadata(meta);
-    } else if (name == "notifyArtwork") {
-        std::string artworkUri = args->GetString(0).ToString();
-        if (g_media_session) g_media_session->setArtwork(artworkUri);
-    } else if (name == "notifyQueueChange") {
-        bool canNext = args->GetBool(0);
-        bool canPrev = args->GetBool(1);
-        if (g_media_session) {
-            g_media_session->setCanGoNext(canNext);
-            g_media_session->setCanGoPrevious(canPrev);
-        }
-    } else if (name == "notifyPlaybackState") {
-        std::string state = args->GetString(0).ToString();
-        if (g_media_session) {
-            if (state == "Playing") g_media_session->setPlaybackState(PlaybackState::Playing);
-            else if (state == "Paused") g_media_session->setPlaybackState(PlaybackState::Paused);
-            else g_media_session->setPlaybackState(PlaybackState::Stopped);
-        }
-    } else if (name == "notifySeek") {
-        int posMs = getIntArg(args, 0);
-        if (g_media_session)
-            g_media_session->emitSeeked(static_cast<int64_t>(posMs) * 1000);
-    } else if (name == "setCursorVisible") {
-        g_platform.set_cursor(args->GetBool(0) ? CT_POINTER : CT_NONE);
-    } else if (name == "appExit") {
-        initiate_shutdown();
-    } else if (name == "openConfigDir") {
-        LOG_INFO(LOG_CEF, "Openning mpv home directory");
-        paths::openMpvHome();
-    } else {
-        return false;
-    }
-    return true;
+    });
 }
+

--- a/src/browser/web_browser.h
+++ b/src/browser/web_browser.h
@@ -31,9 +31,9 @@ public:
     static CefRefPtr<CefDictionaryValue> injectionProfile();
 
 private:
-    bool handleMessage(const std::string& name,
-                       CefRefPtr<CefListValue> args,
-                       CefRefPtr<CefBrowser> browser);
+    // Register mpris/fullscreen/osd/app handlers on g_bus. Player handlers
+    // live in player_router; the rest are inline lambdas in web_browser.cpp.
+    void installBusHandlers();
 
     CefRefPtr<CefLayer> client_;
     bool was_fullscreen_before_osd_ = false;

--- a/src/cef/cef_app.cpp
+++ b/src/cef/cef_app.cpp
@@ -411,13 +411,75 @@ void App::OnContextCreated(CefRefPtr<CefBrowser> browser,
     frame->ExecuteJavaScript(code, frame->GetURL(), 0);
 }
 
-static void callJsGlobal(CefRefPtr<CefFrame> frame, const char* fn_name,
-                         const CefV8ValueList& v8args) {
-    CefRefPtr<CefV8Context> ctx = frame->GetV8Context();
-    if (!ctx || !ctx->Enter()) return;
-    CefRefPtr<CefV8Value> fn = ctx->GetGlobal()->GetValue(fn_name);
-    if (fn && fn->IsFunction()) fn->ExecuteFunction(nullptr, v8args);
-    ctx->Exit();
+// Recursive V8 → CefValue. Handles primitives, plain objects, and arrays.
+// Functions, dates, typed arrays, etc. become null. The bus payload contract
+// is "JSON-shaped" — anything outside that is a programming error on the JS
+// side, not something we try to round-trip.
+static CefRefPtr<CefValue> v8_to_cef_value(CefRefPtr<CefV8Value> v) {
+    auto out = CefValue::Create();
+    if (!v || v->IsNull() || v->IsUndefined()) {
+        out->SetNull();
+    } else if (v->IsBool()) {
+        out->SetBool(v->GetBoolValue());
+    } else if (v->IsInt()) {
+        out->SetInt(v->GetIntValue());
+    } else if (v->IsUInt()) {
+        out->SetInt(static_cast<int>(v->GetUIntValue()));
+    } else if (v->IsDouble()) {
+        out->SetDouble(v->GetDoubleValue());
+    } else if (v->IsString()) {
+        out->SetString(v->GetStringValue());
+    } else if (v->IsArray()) {
+        CefRefPtr<CefListValue> list = CefListValue::Create();
+        int n = v->GetArrayLength();
+        for (int i = 0; i < n; i++) {
+            list->SetValue(i, v8_to_cef_value(v->GetValue(i)));
+        }
+        out->SetList(list);
+    } else if (v->IsObject()) {
+        CefRefPtr<CefDictionaryValue> dict = CefDictionaryValue::Create();
+        std::vector<CefString> keys;
+        v->GetKeys(keys);
+        for (const auto& key : keys) {
+            dict->SetValue(key, v8_to_cef_value(v->GetValue(key)));
+        }
+        out->SetDictionary(dict);
+    } else {
+        out->SetNull();
+    }
+    return out;
+}
+
+static CefRefPtr<CefV8Value> cef_value_to_v8(CefRefPtr<CefValue> v) {
+    if (!v) return CefV8Value::CreateNull();
+    switch (v->GetType()) {
+        case VTYPE_BOOL:   return CefV8Value::CreateBool(v->GetBool());
+        case VTYPE_INT:    return CefV8Value::CreateInt(v->GetInt());
+        case VTYPE_DOUBLE: return CefV8Value::CreateDouble(v->GetDouble());
+        case VTYPE_STRING: return CefV8Value::CreateString(v->GetString());
+        case VTYPE_LIST: {
+            auto list = v->GetList();
+            int n = static_cast<int>(list->GetSize());
+            auto arr = CefV8Value::CreateArray(n);
+            for (int i = 0; i < n; i++)
+                arr->SetValue(i, cef_value_to_v8(list->GetValue(i)));
+            return arr;
+        }
+        case VTYPE_DICTIONARY: {
+            auto dict = v->GetDictionary();
+            auto obj = CefV8Value::CreateObject(nullptr, nullptr);
+            CefDictionaryValue::KeyList keys;
+            dict->GetKeys(keys);
+            for (const auto& key : keys)
+                obj->SetValue(key, cef_value_to_v8(dict->GetValue(key)),
+                              V8_PROPERTY_ATTRIBUTE_NONE);
+            return obj;
+        }
+        case VTYPE_NULL:
+        case VTYPE_INVALID:
+        default:
+            return CefV8Value::CreateNull();
+    }
 }
 
 bool App::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
@@ -427,19 +489,22 @@ bool App::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
     std::string name = message->GetName().ToString();
     CefRefPtr<CefListValue> args = message->GetArgumentList();
 
-    if (name == "savedServerUrl") {
-        CefV8ValueList v8args;
-        v8args.push_back(CefV8Value::CreateString(args->GetString(0)));
-        callJsGlobal(frame, "_onSavedServerUrl", v8args);
-        return true;
-    }
-
-    if (name == "serverConnectivityResult") {
-        CefV8ValueList v8args;
-        v8args.push_back(CefV8Value::CreateString(args->GetString(0)));
-        v8args.push_back(CefV8Value::CreateBool(args->GetBool(1)));
-        v8args.push_back(CefV8Value::CreateString(args->GetString(2)));
-        callJsGlobal(frame, "_onServerConnectivityResult", v8args);
+    // Bus channel inbound: browser process emits ("jmp.onMessage", [name,
+    // payload]); we hand it to window.jmp.onMessage in the renderer's V8
+    // context, reconstructing payload as a JS object/array. JS dispatches
+    // internally from there.
+    if (name == "jmp.onMessage") {
+        CefRefPtr<CefV8Context> ctx = frame->GetV8Context();
+        if (!ctx || !ctx->Enter()) return true;
+        CefRefPtr<CefV8Value> jmp = ctx->GetGlobal()->GetValue("jmp");
+        CefRefPtr<CefV8Value> fn = jmp && jmp->IsObject() ? jmp->GetValue("onMessage") : nullptr;
+        if (fn && fn->IsFunction()) {
+            CefV8ValueList v8args;
+            v8args.push_back(CefV8Value::CreateString(args->GetString(0)));
+            v8args.push_back(cef_value_to_v8(args->GetValue(1)));
+            fn->ExecuteFunction(jmp, v8args);
+        }
+        ctx->Exit();
         return true;
     }
 
@@ -507,6 +572,26 @@ bool NativeV8Handler::Execute(const CefString& name,
                               const CefV8ValueList& arguments,
                               CefRefPtr<CefV8Value>&,
                               CefString&) {
+    // Bus channel: jmpNative.send(name, payload) → "jmp.send" process message
+    // carrying [name, payload-as-CefValue]. The browser process routes to the
+    // bus dispatcher; per-method packing below stays alive for legacy bindings
+    // until callers migrate.
+    if (name == "send") {
+        if (arguments.empty() || !arguments[0]->IsString()) return true;
+        auto msg = CefProcessMessage::Create("jmp.send");
+        auto args = msg->GetArgumentList();
+        args->SetString(0, arguments[0]->GetStringValue());
+        if (arguments.size() >= 2) {
+            args->SetValue(1, v8_to_cef_value(arguments[1]));
+        } else {
+            auto empty = CefValue::Create();
+            empty->SetDictionary(CefDictionaryValue::Create());
+            args->SetValue(1, empty);
+        }
+        browser_->GetMainFrame()->SendProcessMessage(PID_BROWSER, msg);
+        return true;
+    }
+
     CefRefPtr<CefProcessMessage> msg = CefProcessMessage::Create(name);
     CefRefPtr<CefListValue> args = msg->GetArgumentList();
 

--- a/src/cef/cef_client.cpp
+++ b/src/cef/cef_client.cpp
@@ -1,4 +1,5 @@
 #include "cef_client.h"
+#include "message_bus.h"
 #include "logging.h"
 #include "../cjson/cJSON.h"
 #include "../platform/platform.h"
@@ -403,6 +404,21 @@ bool CefLayer::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser, CefRefPtr
     auto name = message->GetName().ToString();
     auto args = message->GetArgumentList();
 
+    // Bus channel inbound: jmpNative.send(name, payload) from the renderer
+    // arrives here as ("jmp.send", [name, payload]). Hand off to the global
+    // bus, which routes to the registered handler regardless of which browser
+    // sent the message.
+    if (name == "jmp.send") {
+        std::string msg_name = args->GetString(0).ToString();
+        CefRefPtr<CefValue> payload_val = args->GetValue(1);
+        CefRefPtr<CefDictionaryValue> payload =
+            (payload_val && payload_val->GetType() == VTYPE_DICTIONARY)
+                ? payload_val->GetDictionary()
+                : CefDictionaryValue::Create();
+        g_bus.dispatch(msg_name, payload);
+        return true;
+    }
+
     if (name == "popupOptions") {
         CefRefPtr<CefListValue> list = args->GetList(0);
         popup_options_.clear();
@@ -453,9 +469,6 @@ bool CefLayer::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser, CefRefPtr
         return true;
     }
 
-    // Everything else delegates to the business logic handler.
-    if (message_handler_)
-        return message_handler_(name, args, browser);
     return false;
 }
 

--- a/src/cef/cef_client.h
+++ b/src/cef/cef_client.h
@@ -14,12 +14,6 @@
 #include <string>
 #include <vector>
 
-// Callback invoked for IPC messages from the renderer process.
-// Returns true if the message was handled.
-using MessageHandler = std::function<bool(const std::string& name,
-                                         CefRefPtr<CefListValue> args,
-                                         CefRefPtr<CefBrowser> browser)>;
-
 // Callback invoked after the browser is created (OnAfterCreated).
 using CreatedCallback = std::function<void(CefRefPtr<CefBrowser>)>;
 
@@ -39,7 +33,8 @@ struct RenderTarget {
 };
 
 // Generic CEF browser client — pure rendering, lifecycle, context menu,
-// keyboard. Business logic is injected via setMessageHandler / setCreatedCallback.
+// keyboard. Business logic registers handlers on the global MessageBus;
+// per-browser hooks are installed via setCreatedCallback.
 // Used for both the main browser and overlay browser; the only difference
 // is the RenderTarget passed at construction.
 class CefLayer : public CefClient, public CefRenderHandler,
@@ -51,7 +46,6 @@ public:
         : target_(target), width_(w), height_(h),
           physical_w_(pw), physical_h_(ph) {}
 
-    void setMessageHandler(MessageHandler handler) { message_handler_ = std::move(handler); }
     void setCreatedCallback(CreatedCallback cb) { on_after_created_ = std::move(cb); }
     void setBeforeCloseCallback(BeforeCloseCallback cb) { on_before_close_ = std::move(cb); }
     void setContextMenuBuilder(ContextMenuBuilder cb) { context_menu_builder_ = std::move(cb); }
@@ -165,7 +159,6 @@ private:
     std::mutex load_mtx_;
     std::condition_variable load_cv_;
     CefRefPtr<CefRunContextMenuCallback> pending_menu_callback_;
-    MessageHandler message_handler_;
     CreatedCallback on_after_created_;
     BeforeCloseCallback on_before_close_;
     ContextMenuBuilder context_menu_builder_;

--- a/src/cef/message_bus.cpp
+++ b/src/cef/message_bus.cpp
@@ -1,0 +1,85 @@
+#include "message_bus.h"
+
+#include "logging.h"
+
+#include "include/cef_task.h"
+
+#include <functional>
+
+MessageBus g_bus;
+
+namespace {
+std::string namespace_of(const std::string& name) {
+    auto dot = name.find('.');
+    return dot == std::string::npos ? name : name.substr(0, dot);
+}
+
+// Posts a lambda to TID_UI without pulling in base::BindOnce. Same pattern as
+// the FnTask classes in cef_client.cpp / about_browser.cpp.
+class FnTask : public CefTask {
+public:
+    explicit FnTask(std::function<void()> fn) : fn_(std::move(fn)) {}
+    void Execute() override { if (fn_) fn_(); }
+private:
+    std::function<void()> fn_;
+    IMPLEMENT_REFCOUNTING(FnTask);
+};
+}
+
+void MessageBus::on(const std::string& name, Handler handler) {
+    handlers_[name] = std::move(handler);
+}
+
+void MessageBus::registerNamespace(const std::string& ns, CefRefPtr<CefBrowser> browser) {
+    namespaces_[ns] = browser;
+}
+
+void MessageBus::unregisterNamespace(const std::string& ns) {
+    namespaces_.erase(ns);
+}
+
+bool MessageBus::dispatch(const std::string& name, CefRefPtr<CefDictionaryValue> payload) {
+    auto it = handlers_.find(name);
+    if (it == handlers_.end()) {
+        LOG_WARN(LOG_CEF, "MessageBus: no handler for '{}'", name);
+        return false;
+    }
+    if (!payload) payload = CefDictionaryValue::Create();
+    it->second(payload);
+    return true;
+}
+
+void MessageBus::emit(const std::string& name, CefRefPtr<CefDictionaryValue> payload) {
+    // SendProcessMessage requires TID_UI under multi_threaded_message_loop.
+    // mpv events feed us from cef_consumer_thread; MPRIS/SMTC backends fire
+    // transport callbacks from their own poll threads. Self-hop so every
+    // caller is correct without each one re-implementing the post.
+    if (!CefCurrentlyOn(TID_UI)) {
+        std::string captured_name = name;
+        CefRefPtr<CefDictionaryValue> captured_payload =
+            payload ? payload->Copy(false) : CefDictionaryValue::Create();
+        CefPostTask(TID_UI, CefRefPtr<CefTask>(new FnTask(
+            [captured_name, captured_payload]() {
+                g_bus.emit(captured_name, captured_payload);
+            })));
+        return;
+    }
+
+    std::string ns = namespace_of(name);
+    auto it = namespaces_.find(ns);
+    if (it == namespaces_.end() || !it->second) return;
+    CefRefPtr<CefBrowser> browser = it->second;
+    auto frame = browser->GetMainFrame();
+    if (!frame) return;
+    auto msg = CefProcessMessage::Create("jmp.onMessage");
+    auto args = msg->GetArgumentList();
+    args->SetString(0, name);
+    auto pv = CefValue::Create();
+    pv->SetDictionary(payload ? payload : CefDictionaryValue::Create());
+    args->SetValue(1, pv);
+    frame->SendProcessMessage(PID_RENDERER, msg);
+}
+
+void MessageBus::clearNamespaces() {
+    namespaces_.clear();
+}

--- a/src/cef/message_bus.h
+++ b/src/cef/message_bus.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "include/cef_browser.h"
+#include "include/cef_values.h"
+
+#include <functional>
+#include <string>
+#include <unordered_map>
+
+// Single global JS↔C++ message bus.
+//
+// Wire shape:
+//   JS → C++:  jmpNative.send(name, payload)
+//              → "jmp.send" process message (cef_app.cpp NativeV8Handler)
+//              → CefLayer::OnProcessMessageReceived
+//              → MessageBus::dispatch(name, payload)
+//              → registered Handler
+//
+//   C++ → JS:  MessageBus::emit(name, payload)
+//              → "jmp.onMessage" process message to the namespace's browser
+//              → cef_app.cpp App::OnProcessMessageReceived (render side)
+//              → window.jmp.onMessage(name, payload)
+//
+// `emit` is callable from any thread — it self-hops to TID_UI when needed.
+// `dispatch`, `on`, `registerNamespace`, and `unregisterNamespace` are not
+// synchronized; call them on TID_UI (or pre-CefInitialize, before TID_UI
+// exists). In practice handlers are registered during browser construction
+// and dispatch fires from `OnProcessMessageReceived`, both already TID_UI.
+class MessageBus {
+public:
+    using Handler = std::function<void(CefRefPtr<CefDictionaryValue> payload)>;
+
+    // Register a handler for an exact message name (e.g. "player.load").
+    void on(const std::string& name, Handler handler);
+
+    // Map a namespace prefix (the part of a name before the first '.') to the
+    // browser that owns it for outbound emissions.
+    void registerNamespace(const std::string& ns, CefRefPtr<CefBrowser> browser);
+    void unregisterNamespace(const std::string& ns);
+
+    // Drop all namespace → browser mappings. Call before CefShutdown so the
+    // bus doesn't keep CefRefPtr<CefBrowser> alive past the framework's
+    // teardown.
+    void clearNamespaces();
+
+    // Inbound: invoke the handler registered for `name`. Returns true if one
+    // was registered (whether or not it threw); false if no handler exists.
+    bool dispatch(const std::string& name, CefRefPtr<CefDictionaryValue> payload);
+
+    // Outbound: ship `name`/`payload` to the renderer that owns the namespace
+    // prefix of `name`. Silently drops if the namespace has no registered
+    // browser (e.g. emit during shutdown, or before browsers are up).
+    void emit(const std::string& name, CefRefPtr<CefDictionaryValue> payload);
+
+private:
+    std::unordered_map<std::string, Handler> handlers_;
+    std::unordered_map<std::string, CefRefPtr<CefBrowser>> namespaces_;
+};
+
+extern MessageBus g_bus;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,6 +26,8 @@
 
 #include "player/media_session.h"
 #include "player/media_session_thread.h"
+#include "player/player_router.h"
+#include "cef/message_bus.h"
 
 #include "logging.h"
 
@@ -221,75 +223,53 @@ static void cef_consumer_thread() {
         MpvEvent ev;
         while (g_cef_queue.try_pop(ev)) {
             if (!g_web_browser) continue;
+            // Player events fan out to JS via the bus; media-session and
+            // platform-side bookkeeping stay here.
+            player_router::on_mpv_event(ev);
             switch (ev.type) {
             case MpvEventType::PAUSE:
                 g_playback_state = ev.flag ? PlaybackState::Paused : PlaybackState::Playing;
                 update_idle_inhibit();
-                g_web_browser->execJs(ev.flag ? "window._nativeEmit('paused')" : "window._nativeEmit('playing')");
                 if (g_media_session)
                     g_media_session->setPlaybackState(ev.flag ? PlaybackState::Paused : PlaybackState::Playing);
                 break;
             case MpvEventType::TIME_POS: {
-                int ms = static_cast<int>(ev.dbl * 1000);
-                g_web_browser->execJs("window._nativeUpdatePosition(" + std::to_string(ms) + ")");
                 if (g_media_session)
                     g_media_session->setPosition(static_cast<int64_t>(ev.dbl * 1000000));
                 break;
             }
-            case MpvEventType::DURATION: {
-                int ms = static_cast<int>(ev.dbl * 1000);
-                g_web_browser->execJs("window._nativeUpdateDuration(" + std::to_string(ms) + ")");
-                // Duration is set via metadata, not a separate call
+            case MpvEventType::DURATION:
                 break;
-            }
-            case MpvEventType::FULLSCREEN:
+            case MpvEventType::FULLSCREEN: {
                 if (ev.flag) {
                     g_was_maximized_before_fullscreen = mpv::window_maximized();
                 } else {
                     g_was_maximized_before_fullscreen = false;
                 }
-                g_web_browser->execJs("window._nativeFullscreenChanged(" + std::string(ev.flag ? "true" : "false") + ")");
+                auto p = CefDictionaryValue::Create();
+                p->SetBool("fullscreen", ev.flag);
+                g_bus.emit("fullscreen.changed", p);
                 break;
+            }
             case MpvEventType::SPEED:
-                g_web_browser->execJs("window._nativeSetRate(" + std::to_string(ev.dbl) + ")");
                 if (g_media_session)
                     g_media_session->setRate(ev.dbl);
                 break;
             case MpvEventType::SEEKING:
-                if (ev.flag) {
-                    g_web_browser->execJs("window._nativeEmit('seeking')");
-                    if (g_media_session) g_media_session->emitSeeking();
-                }
+                if (ev.flag && g_media_session)
+                    g_media_session->emitSeeking();
                 break;
             case MpvEventType::FILE_LOADED:
                 g_playback_state = PlaybackState::Playing;
                 update_idle_inhibit();
-                g_web_browser->execJs("window._nativeEmit('playing')");
                 if (g_media_session)
                     g_media_session->setPlaybackState(PlaybackState::Playing);
                 break;
             case MpvEventType::END_FILE_EOF:
-                g_playback_state = PlaybackState::Stopped;
-                update_idle_inhibit();
-                g_web_browser->execJs("window._nativeEmit('finished')");
-                if (g_media_session)
-                    g_media_session->setPlaybackState(PlaybackState::Stopped);
-                break;
-            case MpvEventType::END_FILE_ERROR: {
-                g_playback_state = PlaybackState::Stopped;
-                update_idle_inhibit();
-                auto val = CefValue::Create();
-                val->SetString(ev.err_msg ? ev.err_msg : "Playback error");
-                auto json = CefWriteJSON(val, JSON_WRITER_DEFAULT);
-                g_web_browser->execJs("window._nativeEmit('error'," + json.ToString() + ")");
-                if (g_media_session)
-                    g_media_session->setPlaybackState(PlaybackState::Stopped);
-                break;
-            }
+            case MpvEventType::END_FILE_ERROR:
             case MpvEventType::END_FILE_CANCEL:
                 g_playback_state = PlaybackState::Stopped;
                 update_idle_inhibit();
-                g_web_browser->execJs("window._nativeEmit('canceled')");
                 if (g_media_session)
                     g_media_session->setPlaybackState(PlaybackState::Stopped);
                 break;
@@ -305,20 +285,9 @@ static void cef_consumer_thread() {
                     g_platform.about_resize(ev.lw, ev.lh, ev.pw, ev.ph);
                 }
                 break;
-            case MpvEventType::BUFFERED_RANGES: {
-                auto list = CefListValue::Create();
-                for (int i = 0; i < ev.range_count; i++) {
-                    auto range = CefDictionaryValue::Create();
-                    range->SetDouble("start", static_cast<double>(ev.ranges[i].start_ticks));
-                    range->SetDouble("end", static_cast<double>(ev.ranges[i].end_ticks));
-                    list->SetDictionary(static_cast<size_t>(i), range);
-                }
-                auto val = CefValue::Create();
-                val->SetList(list);
-                auto json = CefWriteJSON(val, JSON_WRITER_DEFAULT);
-                g_web_browser->execJs("window._nativeUpdateBufferedRanges(" + json.ToString() + ")");
+            case MpvEventType::BUFFERED_RANGES:
+                // Already routed to player.bufferedRangesChanged via player_router::on_mpv_event.
                 break;
-            }
             case MpvEventType::DISPLAY_FPS: {
                 int hz = g_display_hz.load(std::memory_order_relaxed);
                 LOG_INFO(LOG_MAIN, "Display refresh rate changed: {} Hz", hz);
@@ -980,6 +949,9 @@ int main(int argc, char* argv[]) {
     // g_about_browser is normally self-deleted via its BeforeCloseCallback.
     // If shutdown races the callback (unlikely), we take responsibility here.
     if (g_about_browser) { delete g_about_browser; g_about_browser = nullptr; }
+    // Drop CefRefPtr<CefBrowser> still held by g_bus.namespaces_ before
+    // CefShutdown — otherwise the framework asserts on live browser refs.
+    g_bus.clearNamespaces();
     CefRuntime::Shutdown();
 
     // Platform cleanup (joins input thread, destroys subsurfaces)

--- a/src/player/media_session.cpp
+++ b/src/player/media_session.cpp
@@ -1,7 +1,6 @@
 #include "player/media_session.h"
 #include "common.h"
-#include "browser/browsers.h"
-#include "browser/web_browser.h"
+#include "cef/message_bus.h"
 
 #ifdef __APPLE__
 #include "player/macos/media_session_macos.h"
@@ -37,14 +36,23 @@ void MediaSession::wireTransportCallbacks() {
     onStop = []() { g_mpv.Stop(); };
     onSetRate = [](double rate) { g_mpv.SetSpeed(rate); };
     onNext = []() {
-        if (g_web_browser) g_web_browser->execJs("if(window._nativeHostInput) window._nativeHostInput(['next']);");
+        auto p = CefDictionaryValue::Create();
+        auto actions = CefListValue::Create();
+        actions->SetString(0, "next");
+        p->SetList("actions", actions);
+        g_bus.emit("input.hostInput", p);
     };
     onPrevious = []() {
-        if (g_web_browser) g_web_browser->execJs("if(window._nativeHostInput) window._nativeHostInput(['previous']);");
+        auto p = CefDictionaryValue::Create();
+        auto actions = CefListValue::Create();
+        actions->SetString(0, "previous");
+        p->SetList("actions", actions);
+        g_bus.emit("input.hostInput", p);
     };
     onSeek = [](int64_t position_us) {
-        int ms = static_cast<int>(position_us / 1000);
-        if (g_web_browser) g_web_browser->execJs("if(window._nativeSeek) window._nativeSeek(" + std::to_string(ms) + ");");
+        auto p = CefDictionaryValue::Create();
+        p->SetInt("positionMs", static_cast<int>(position_us / 1000));
+        g_bus.emit("input.positionSeek", p);
     };
 }
 

--- a/src/player/player_router.cpp
+++ b/src/player/player_router.cpp
@@ -1,0 +1,304 @@
+#include "player_router.h"
+#include "track_resolver.h"
+
+#include "../cef/message_bus.h"
+#include "../common.h"
+#include "logging.h"
+
+#include "include/cef_values.h"
+
+#include <cmath>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace player_router {
+
+namespace {
+
+// =====================================================================
+// State
+// =====================================================================
+
+// Streams cached on player.load and consulted on selectAudio/selectSubtitle.
+// Owned and mutated solely on TID_UI.
+std::vector<track_resolver::MediaStream> g_streams;
+
+// Last-known time-pos in ms, sourced from MPV_OBSERVE_TIME_POS. Used to
+// reply synchronously to player.getPosition.
+int64_t g_last_position_ms = 0;
+
+// =====================================================================
+// Helpers
+// =====================================================================
+
+std::optional<int> opt_int(const CefRefPtr<CefDictionaryValue>& d,
+                           const std::string& key) {
+    if (!d->HasKey(key)) return std::nullopt;
+    auto t = d->GetType(key);
+    if (t == VTYPE_NULL) return std::nullopt;
+    if (t == VTYPE_INT) return d->GetInt(key);
+    if (t == VTYPE_DOUBLE) return static_cast<int>(std::lround(d->GetDouble(key)));
+    return std::nullopt;
+}
+
+double get_double(const CefRefPtr<CefDictionaryValue>& d,
+                  const std::string& key, double fallback = 0.0) {
+    if (!d->HasKey(key)) return fallback;
+    auto t = d->GetType(key);
+    if (t == VTYPE_DOUBLE) return d->GetDouble(key);
+    if (t == VTYPE_INT)    return static_cast<double>(d->GetInt(key));
+    return fallback;
+}
+
+int64_t get_int64(const CefRefPtr<CefDictionaryValue>& d,
+                  const std::string& key, int64_t fallback = 0) {
+    if (!d->HasKey(key)) return fallback;
+    auto t = d->GetType(key);
+    if (t == VTYPE_INT)    return d->GetInt(key);
+    if (t == VTYPE_DOUBLE) return static_cast<int64_t>(std::llround(d->GetDouble(key)));
+    return fallback;
+}
+
+// Parse Jellyfin MediaSource.MediaStreams from a CefListValue into the
+// resolver's pure-C++ shape. Lives here, not in track_resolver, because
+// track_resolver is kept CEF-free for doctest unit testing.
+std::vector<track_resolver::MediaStream>
+parse_media_streams(CefRefPtr<CefListValue> list) {
+    std::vector<track_resolver::MediaStream> out;
+    if (!list) return out;
+    out.reserve(list->GetSize());
+    for (size_t i = 0; i < list->GetSize(); i++) {
+        if (list->GetType(i) != VTYPE_DICTIONARY) continue;
+        auto d = list->GetDictionary(i);
+        track_resolver::MediaStream s;
+        if (d->HasKey("Index"))
+            s.index = d->GetInt("Index");
+        if (d->HasKey("Type") && d->GetType("Type") == VTYPE_STRING)
+            s.type = d->GetString("Type").ToString();
+        if (d->HasKey("IsExternal") && d->GetType("IsExternal") == VTYPE_BOOL)
+            s.is_external = d->GetBool("IsExternal");
+        if (d->HasKey("DeliveryMethod") && d->GetType("DeliveryMethod") == VTYPE_STRING)
+            s.delivery_method = d->GetString("DeliveryMethod").ToString();
+        if (d->HasKey("DeliveryUrl") && d->GetType("DeliveryUrl") == VTYPE_STRING)
+            s.delivery_url = d->GetString("DeliveryUrl").ToString();
+        out.push_back(std::move(s));
+    }
+    return out;
+}
+
+CefRefPtr<CefDictionaryValue> empty_payload() {
+    return CefDictionaryValue::Create();
+}
+
+void emit(const std::string& name, CefRefPtr<CefDictionaryValue> payload) {
+    g_bus.emit(name, payload ? payload : empty_payload());
+}
+
+// =====================================================================
+// Inbound handlers
+// =====================================================================
+
+void on_load(CefRefPtr<CefDictionaryValue> p) {
+    if (!g_mpv.IsValid()) return;
+    std::string url = p->HasKey("url") ? p->GetString("url").ToString() : "";
+    int64_t startMs = get_int64(p, "startMs", 0);
+    auto defaultAudio = opt_int(p, "defaultAudioIdx");
+    auto defaultSub   = opt_int(p, "defaultSubIdx");
+
+    g_streams.clear();
+    if (p->HasKey("mediaSource") && p->GetType("mediaSource") == VTYPE_DICTIONARY) {
+        auto ms = p->GetDictionary("mediaSource");
+        if (ms->HasKey("MediaStreams") && ms->GetType("MediaStreams") == VTYPE_LIST)
+            g_streams = parse_media_streams(ms->GetList("MediaStreams"));
+    }
+
+    int64_t aid = track_resolver::resolve_audio_aid(g_streams, defaultAudio);
+    auto sub = track_resolver::resolve_subtitle(
+        g_streams, defaultSub,
+        track_resolver::SubtitleUnresolvedFallback::AutoFallback);
+
+    MpvHandle::LoadOptions opts;
+    opts.startSecs = startMs / 1000.0;
+    opts.audioTrack = aid;
+    if (sub.kind == track_resolver::SubtitleSelection::Kind::Embedded)
+        opts.subTrack = sub.sid;
+    else
+        opts.subTrack = MpvHandle::kTrackDisable;
+
+    LOG_INFO(LOG_CEF, "player.load: audio={} sub={} start={}ms url={}",
+             aid, opts.subTrack, startMs, url);
+    g_mpv.LoadFile(url, opts);
+
+    if (sub.kind == track_resolver::SubtitleSelection::Kind::External)
+        g_mpv.SubAdd(sub.url);
+}
+
+void on_play (CefRefPtr<CefDictionaryValue>) { if (g_mpv.IsValid()) g_mpv.Play(); }
+void on_pause(CefRefPtr<CefDictionaryValue>) { if (g_mpv.IsValid()) g_mpv.Pause(); }
+void on_stop (CefRefPtr<CefDictionaryValue>) { if (g_mpv.IsValid()) g_mpv.Stop(); }
+
+void on_seek(CefRefPtr<CefDictionaryValue> p) {
+    if (g_mpv.IsValid())
+        g_mpv.SeekAbsolute(get_int64(p, "positionMs", 0) / 1000.0);
+}
+
+void on_select_audio(CefRefPtr<CefDictionaryValue> p) {
+    if (!g_mpv.IsValid()) return;
+    auto idx = opt_int(p, "jellyfinIndex");
+    int64_t aid = track_resolver::resolve_audio_aid(g_streams, idx);
+    LOG_INFO(LOG_CEF, "player.selectAudio: jf={} aid={}",
+             idx ? std::to_string(*idx) : "null", aid);
+    g_mpv.SetAudioTrack(aid);
+}
+
+void on_select_subtitle(CefRefPtr<CefDictionaryValue> p) {
+    if (!g_mpv.IsValid()) return;
+    auto idx = opt_int(p, "jellyfinIndex");
+    auto sub = track_resolver::resolve_subtitle(
+        g_streams, idx,
+        track_resolver::SubtitleUnresolvedFallback::DisableFallback);
+    switch (sub.kind) {
+    case track_resolver::SubtitleSelection::Kind::Disable:
+        LOG_INFO(LOG_CEF, "player.selectSubtitle: disable");
+        g_mpv.SetSubtitleTrack(track_resolver::kTrackDisable);
+        break;
+    case track_resolver::SubtitleSelection::Kind::Embedded:
+        LOG_INFO(LOG_CEF, "player.selectSubtitle: sid={}", sub.sid);
+        g_mpv.SetSubtitleTrack(sub.sid);
+        break;
+    case track_resolver::SubtitleSelection::Kind::External:
+        LOG_INFO(LOG_CEF, "player.selectSubtitle: external {}", sub.url);
+        g_mpv.SubAdd(sub.url);
+        break;
+    }
+}
+
+void on_set_rate(CefRefPtr<CefDictionaryValue> p) {
+    if (g_mpv.IsValid()) g_mpv.SetSpeed(get_double(p, "rate", 1.0));
+}
+
+void on_set_subtitle_offset(CefRefPtr<CefDictionaryValue> p) {
+    if (g_mpv.IsValid()) g_mpv.SetAudioDelay(-get_double(p, "seconds", 0.0));
+    // NOTE: sub-delay would be more correct than audio-delay, but the
+    // existing code path used audio-delay (negative for sub-shift). Preserve
+    // legacy behavior in this scaffolding step; the JS migration step
+    // revisits semantics.
+}
+
+void on_set_volume(CefRefPtr<CefDictionaryValue> p) {
+    if (g_mpv.IsValid()) g_mpv.SetVolume(get_double(p, "volume", 100.0));
+}
+
+void on_set_muted(CefRefPtr<CefDictionaryValue> p) {
+    if (g_mpv.IsValid() && p->HasKey("muted"))
+        g_mpv.SetMuted(p->GetBool("muted"));
+}
+
+void on_set_aspect_ratio(CefRefPtr<CefDictionaryValue> p) {
+    if (!g_mpv.IsValid()) return;
+    if (p->HasKey("mode") && p->GetType("mode") == VTYPE_STRING)
+        g_mpv.SetAspectMode(p->GetString("mode").ToString());
+}
+
+void on_set_video_rectangle(CefRefPtr<CefDictionaryValue>) {
+    // Currently a no-op: the desktop client renders mpv on the parent surface
+    // and CEF as a subsurface; geometry is owned by the platform layer, not
+    // jellyfin-web. Kept registered so messages don't fall through to the
+    // "no handler" warning path.
+}
+
+void on_get_position(CefRefPtr<CefDictionaryValue> p) {
+    auto reply = CefDictionaryValue::Create();
+    if (p->HasKey("requestId"))
+        reply->SetValue("requestId", p->GetValue("requestId")->Copy());
+    reply->SetInt("positionMs", static_cast<int>(g_last_position_ms));
+    emit("player.positionReply", reply);
+}
+
+}  // namespace
+
+// =====================================================================
+// Public entry points
+// =====================================================================
+
+void install() {
+    g_bus.on("player.load",              on_load);
+    g_bus.on("player.play",              on_play);
+    g_bus.on("player.pause",             on_pause);
+    g_bus.on("player.stop",              on_stop);
+    g_bus.on("player.seek",              on_seek);
+    g_bus.on("player.selectAudio",       on_select_audio);
+    g_bus.on("player.selectSubtitle",    on_select_subtitle);
+    g_bus.on("player.setRate",           on_set_rate);
+    g_bus.on("player.setSubtitleOffset", on_set_subtitle_offset);
+    g_bus.on("player.setVolume",         on_set_volume);
+    g_bus.on("player.setMuted",          on_set_muted);
+    g_bus.on("player.setAspectRatio",    on_set_aspect_ratio);
+    g_bus.on("player.setVideoRectangle", on_set_video_rectangle);
+    g_bus.on("player.getPosition",       on_get_position);
+}
+
+void on_mpv_event(const MpvEvent& ev) {
+    switch (ev.type) {
+    case MpvEventType::PAUSE:
+        emit(ev.flag ? "player.paused" : "player.playing", nullptr);
+        break;
+    case MpvEventType::TIME_POS: {
+        g_last_position_ms = static_cast<int64_t>(ev.dbl * 1000);
+        auto p = CefDictionaryValue::Create();
+        p->SetInt("positionMs", static_cast<int>(g_last_position_ms));
+        emit("player.tick", p);
+        break;
+    }
+    case MpvEventType::DURATION: {
+        auto p = CefDictionaryValue::Create();
+        p->SetInt("durationMs", static_cast<int>(ev.dbl * 1000));
+        emit("player.durationChanged", p);
+        break;
+    }
+    case MpvEventType::SPEED: {
+        auto p = CefDictionaryValue::Create();
+        p->SetDouble("rate", ev.dbl);
+        emit("player.rateChanged", p);
+        break;
+    }
+    case MpvEventType::SEEKING: {
+        auto p = CefDictionaryValue::Create();
+        p->SetBool("active", ev.flag);
+        emit("player.seeking", p);
+        break;
+    }
+    case MpvEventType::FILE_LOADED:
+        emit("player.playing", nullptr);
+        break;
+    case MpvEventType::END_FILE_EOF:
+    case MpvEventType::END_FILE_CANCEL:
+        emit("player.stopped", nullptr);
+        break;
+    case MpvEventType::END_FILE_ERROR: {
+        auto p = CefDictionaryValue::Create();
+        p->SetString("message", ev.err_msg ? ev.err_msg : "Playback error");
+        emit("player.error", p);
+        emit("player.stopped", nullptr);
+        break;
+    }
+    case MpvEventType::BUFFERED_RANGES: {
+        auto ranges = CefListValue::Create();
+        for (int i = 0; i < ev.range_count; i++) {
+            auto r = CefDictionaryValue::Create();
+            r->SetDouble("start", static_cast<double>(ev.ranges[i].start_ticks));
+            r->SetDouble("end",   static_cast<double>(ev.ranges[i].end_ticks));
+            ranges->SetDictionary(static_cast<size_t>(i), r);
+        }
+        auto p = CefDictionaryValue::Create();
+        p->SetList("ranges", ranges);
+        emit("player.bufferedRangesChanged", p);
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+}  // namespace player_router

--- a/src/player/player_router.h
+++ b/src/player/player_router.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "../mpv/event.h"
+
+// Player-subsystem consumer of the global MessageBus. Owns:
+//   - Inbound `player.*` handler registration with `g_bus`.
+//   - The cached MediaStream[] for the currently-loaded item (consulted by
+//     player.selectAudio / player.selectSubtitle).
+//   - The reverse path: translation of mpv property-observer events into
+//     `player.*` outbound notifications via `g_bus.emit`.
+//
+// `install` runs on the construction thread before browsers exist (no TID_UI
+// requirement). `on_mpv_event` is invoked from the cef_consumer_thread and
+// emits on the bus; `MessageBus::emit` self-hops to TID_UI internally, so no
+// CefPostTask wrapping is needed here.
+namespace player_router {
+
+// Register all `player.*` handlers with `g_bus`. Idempotent — intended to be
+// called once during WebBrowser construction.
+void install();
+
+// Translate an mpv property/lifecycle event into the matching `player.*`
+// bus notification. Called from main.cpp's TID_UI event drain loop.
+void on_mpv_event(const MpvEvent& ev);
+
+}  // namespace player_router

--- a/src/player/track_resolver.cpp
+++ b/src/player/track_resolver.cpp
@@ -1,0 +1,69 @@
+#include "track_resolver.h"
+
+namespace track_resolver {
+
+namespace {
+
+// Walk type-filtered, non-external streams in declaration order to find a
+// 1-based relative index matching `jellyfin_index`. Returns 0 if not found.
+int relative_index_by_type(const std::vector<MediaStream>& streams,
+                           int jellyfin_index,
+                           const std::string& stream_type) {
+    int rel = 1;
+    for (const auto& s : streams) {
+        if (s.type != stream_type || s.is_external) continue;
+        if (s.index == jellyfin_index) return rel;
+        ++rel;
+    }
+    return 0;
+}
+
+const MediaStream* find_by_index(const std::vector<MediaStream>& streams,
+                                 int jellyfin_index) {
+    for (const auto& s : streams) {
+        if (s.index == jellyfin_index) return &s;
+    }
+    return nullptr;
+}
+
+}  // namespace
+
+int64_t resolve_audio_aid(const std::vector<MediaStream>& streams,
+                          std::optional<int> jellyfin_index) {
+    if (!jellyfin_index || *jellyfin_index < 0) return kTrackAuto;
+    int rel = relative_index_by_type(streams, *jellyfin_index, "Audio");
+    return rel == 0 ? kTrackAuto : static_cast<int64_t>(rel);
+}
+
+SubtitleSelection resolve_subtitle(const std::vector<MediaStream>& streams,
+                                   std::optional<int> jellyfin_index,
+                                   SubtitleUnresolvedFallback fallback) {
+    SubtitleSelection out;
+    if (!jellyfin_index || *jellyfin_index < 0) {
+        out.kind = SubtitleSelection::Kind::Disable;
+        return out;
+    }
+
+    if (const MediaStream* s = find_by_index(streams, *jellyfin_index)) {
+        if (s->delivery_method == "External" && !s->delivery_url.empty()) {
+            out.kind = SubtitleSelection::Kind::External;
+            out.url = s->delivery_url;
+            return out;
+        }
+    }
+
+    int rel = relative_index_by_type(streams, *jellyfin_index, "Subtitle");
+    if (rel != 0) {
+        out.kind = SubtitleSelection::Kind::Embedded;
+        out.sid = rel;
+        return out;
+    }
+
+    if (fallback == SubtitleUnresolvedFallback::AutoFallback) {
+        out.kind = SubtitleSelection::Kind::Embedded;
+        out.sid = kTrackAuto;
+    }  // else: Disable (default)
+    return out;
+}
+
+}  // namespace track_resolver

--- a/src/player/track_resolver.h
+++ b/src/player/track_resolver.h
@@ -1,0 +1,57 @@
+#pragma once
+
+// Pure translation between Jellyfin's MediaStream view of tracks and mpv's
+// internal track numbering. Kept free of CEF so the logic can be unit-tested
+// directly with doctest.
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace track_resolver {
+
+// Subset of Jellyfin's MediaStream the resolver actually consults.
+struct MediaStream {
+    int index = 0;                    // Jellyfin's global stream index
+    std::string type;                 // "Video" / "Audio" / "Subtitle"
+    bool is_external = false;         // skipped during relative-index walk
+    std::string delivery_method;      // "External" routes via sub-add URL
+    std::string delivery_url;
+};
+
+// mpv conventions; mirror MpvHandle::kTrackAuto / kTrackDisable.
+inline constexpr int64_t kTrackAuto    = -1;
+inline constexpr int64_t kTrackDisable =  0;
+
+// Audio track resolution.
+//
+// missing/null  -> kTrackAuto
+// found         -> mpv 1-based aid (relative within audio streams)
+// not found     -> kTrackAuto (let mpv decide)
+int64_t resolve_audio_aid(const std::vector<MediaStream>& streams,
+                          std::optional<int> jellyfin_index);
+
+struct SubtitleSelection {
+    enum class Kind { Disable, External, Embedded };
+    Kind kind = Kind::Disable;
+    int64_t sid = kTrackDisable;  // when Embedded
+    std::string url;              // when External
+};
+
+// Behavior when the requested index doesn't resolve to an embedded subtitle:
+//   AutoFallback   -> Embedded { sid = kTrackAuto } (matches load() path)
+//   DisableFallback-> Disable                       (matches setSubtitleStreamIndex path)
+enum class SubtitleUnresolvedFallback { AutoFallback, DisableFallback };
+
+// Subtitle resolution.
+//
+// missing/null  -> Disable
+// external      -> External { url }
+// found embed   -> Embedded { sid = relative index }
+// not found     -> per `fallback`
+SubtitleSelection resolve_subtitle(const std::vector<MediaStream>& streams,
+                                   std::optional<int> jellyfin_index,
+                                   SubtitleUnresolvedFallback fallback);
+
+}  // namespace track_resolver

--- a/src/web/about.js
+++ b/src/web/about.js
@@ -67,7 +67,7 @@
             v.className += ' path';
             v.textContent = value;
             v.addEventListener('click', function () {
-                if (window.jmpNative) jmpNative.aboutOpenPath(value);
+                window.jmp.send('about.aboutOpenPath', { path: value });
             });
         } else {
             v.textContent = value || '';
@@ -88,7 +88,7 @@
         dismissed = true;
         window.removeEventListener('keydown', onKeyDown, true);
         host.remove();
-        if (window.jmpNative) jmpNative.aboutDismiss();
+        window.jmp.send('about.aboutDismiss');
     }
 
     function onKeyDown(e) {

--- a/src/web/client-settings.js
+++ b/src/web/client-settings.js
@@ -213,10 +213,7 @@
             btn.textContent = 'Open mpv config directory';
             btn.type = 'button';
             btn.addEventListener('click', () => {
-                if (window.jmpNative && window.jmpNative.openConfigDir) {
-                    console.log('[SETTINGS] called openConfigDir');
-                    window.jmpNative.openConfigDir();
-                }
+                window.jmp.send('app.openConfigDir');
             });
             group.appendChild(btn);
         }
@@ -237,9 +234,7 @@
             btn.textContent = 'Reset Saved Server';
             btn.addEventListener('click', () => {
                 jmpInfo.settings.main.userWebClient = '';
-                if (window.jmpNative && window.jmpNative.saveServerUrl) {
-                    window.jmpNative.saveServerUrl('');
-                }
+                window.jmp.send('app.saveServerUrl', { url: '' });
                 window.location.reload();
             });
             group.appendChild(btn);

--- a/src/web/connectivityHelper.js
+++ b/src/web/connectivityHelper.js
@@ -4,46 +4,29 @@ window.jmpCheckServerConnectivity = (() => {
     let pendingReject = null;
     let pendingUrl = null;
 
-    // Called by native code when result is ready
-    window._onServerConnectivityResult = (url, success, resolvedUrl) => {
-        console.log('Connectivity result:', url, success, resolvedUrl);
-        if (pendingUrl === url) {
-            if (success) {
-                pendingResolve(resolvedUrl);
-            } else {
-                pendingReject(new Error('Connection failed'));
-            }
-            pendingResolve = null;
-            pendingReject = null;
-            pendingUrl = null;
+    window.jmp.on('overlay.serverConnectivityResult', (p) => {
+        if (!p || pendingUrl !== p.url) return;
+        if (p.success) {
+            pendingResolve(p.baseUrl);
+        } else {
+            pendingReject(new Error('Connection failed'));
         }
-    };
+        pendingResolve = null;
+        pendingReject = null;
+        pendingUrl = null;
+    });
 
-    const checkFunc = async function(url) {
-        // Wait for jmpNative
-        let attempts = 0;
-        while (!window.jmpNative?.checkServerConnectivity && attempts < 50) {
-            await new Promise(resolve => setTimeout(resolve, 100));
-            attempts++;
-        }
-        if (!window.jmpNative?.checkServerConnectivity) {
-            throw new Error('Native connectivity check not available');
-        }
-
+    const checkFunc = function(url) {
         return new Promise((resolve, reject) => {
             pendingResolve = resolve;
             pendingReject = reject;
             pendingUrl = url;
-
-            console.log('Checking connectivity:', url);
-            window.jmpNative.checkServerConnectivity(url);
+            window.jmp.send('overlay.checkServerConnectivity', { url });
         });
     };
 
     checkFunc.abort = () => {
-        if (window.jmpNative?.cancelServerConnectivity) {
-            window.jmpNative.cancelServerConnectivity();
-        }
+        window.jmp.send('overlay.cancelServerConnectivity');
         if (pendingReject) {
             pendingReject(new Error('Connection cancelled'));
             pendingResolve = null;

--- a/src/web/input-plugin.js
+++ b/src/web/input-plugin.js
@@ -19,7 +19,7 @@
         }
 
         notifyMetadata(item) {
-            if (!item || !window.jmpNative) return;
+            if (!item) return;
             const meta = {
                 Name: item.Name || '',
                 Type: item.Type || '',
@@ -32,8 +32,7 @@
                 RunTimeTicks: item.RunTimeTicks || 0,
                 Id: item.Id || ''
             };
-            console.log('[Media] notifyMetadata:', meta.Name);
-            window.jmpNative.notifyMetadata(JSON.stringify(meta));
+            window.jmp.send('playback.metadata', { json: JSON.stringify(meta) });
             this.fetchAlbumArt(item);
         }
 
@@ -68,7 +67,7 @@
         }
 
         fetchAlbumArt(item) {
-            if (!item || !window.jmpNative) return;
+            if (!item) return;
 
             if (this.artworkAbortController) {
                 this.artworkAbortController.abort();
@@ -108,8 +107,7 @@
                     reader.onloadend = () => {
                         if (signal.aborted) return;
                         const dataUri = reader.result;
-                        console.log('[Media] Album art fetched, sending data URI');
-                        window.jmpNative.notifyArtwork(dataUri);
+                        window.jmp.send('playback.artwork', { uri: dataUri });
                         this.pendingArtworkUrl = null;
                     };
                     reader.readAsDataURL(blob);
@@ -129,9 +127,6 @@
             const player = this.attachedPlayer;
 
             const initialPos = pm.currentTime ? pm.currentTime() : 0;
-            if (typeof initialPos === 'number' && initialPos >= 0) {
-                window.jmpNative.notifyPosition(Math.floor(initialPos));
-            }
 
             this.positionTracking = {
                 startTime: Date.now(),
@@ -162,12 +157,8 @@
             const drift = actual - expected;
 
             if (Math.abs(drift) > 2000) {
-                console.log('[Media] Position drift detected: expected=' + Math.floor(expected) + ' actual=' + Math.floor(actual) + ' drift=' + Math.floor(drift));
                 if (drift > 0) {
-                    window.jmpNative.notifySeek(Math.floor(actual));
-                } else {
-                    window.jmpNative.notifyRateChange(0.0);
-                    window.jmpNative.notifyPosition(Math.floor(actual));
+                    window.jmp.send('playback.position', { positionMs: Math.floor(actual) });
                 }
                 this.resetPositionTracking();
             }
@@ -179,8 +170,6 @@
 
         updateQueueState() {
             try {
-                if (!window.jmpNative) return;
-
                 const pm = this.playbackManager;
                 if (!pm) return;
 
@@ -190,7 +179,6 @@
 
                 if (!playlist || !Array.isArray(playlist) || playlist.length === 0 ||
                     currentIndex === undefined || currentIndex === null || currentIndex < 0) {
-                    console.log('[Media] updateQueueState: queue invalid (idx=' + currentIndex + ' len=' + (playlist?.length || 0) + '), keeping last state');
                     return;
                 }
 
@@ -200,8 +188,7 @@
                 const isMusic = state?.NowPlayingItem?.MediaType === 'Audio';
                 const canPrev = isMusic ? true : (currentIndex > 0);
 
-                console.log('[Media] updateQueueState: idx=' + currentIndex + ' len=' + playlist.length + ' canNext=' + canNext + ' canPrev=' + canPrev);
-                window.jmpNative.notifyQueueChange(canNext, canPrev);
+                window.jmp.send('playback.queueChange', { canNext, canPrev });
             } catch (e) {
                 console.error('[Media] updateQueueState error:', e);
             }
@@ -220,8 +207,7 @@
                     self.notifyMetadata(state.NowPlayingItem);
                 }
 
-                console.log('[Media] Sending Playing state from playbackstart');
-                if (window.jmpNative) window.jmpNative.notifyPlaybackState('Playing');
+                window.jmp.send('playback.state', { state: 'Playing' });
                 self.startPositionUpdates();
                 self.updateQueueState();
 
@@ -235,41 +221,16 @@
                     self.attachedPlayer = player;
 
                     window.Events.on(player, 'playing', () => {
-                        console.log('[Media] player.playing event');
-                        if (window.jmpNative) window.jmpNative.notifyPlaybackState('Playing');
+                        window.jmp.send('playback.state', { state: 'Playing' });
                         self.updateQueueState();
-
-                        const pos = pm.currentTime ? pm.currentTime() : 0;
-                        if (pos !== undefined && pos !== null) {
-                            window.jmpNative.notifyPosition(Math.floor(pos));
-                        }
                         self.resetPositionTracking();
-
-                        const rate = player.getPlaybackRate ? player.getPlaybackRate() : 1.0;
-                        window.jmpNative.notifyRateChange(rate);
                     });
 
                     window.Events.on(player, 'pause', () => {
-                        console.log('[Media] player.pause event');
-                        if (window.jmpNative) {
-                            window.jmpNative.notifyPlaybackState('Paused');
-                            const pos = pm.currentTime ? pm.currentTime() : 0;
-                            if (typeof pos === 'number' && pos >= 0) {
-                                window.jmpNative.notifyPosition(Math.floor(pos));
-                            }
-                        }
+                        window.jmp.send('playback.state', { state: 'Paused' });
                     });
 
                     window.Events.on(player, 'ratechange', () => {
-                        const rate = player.getPlaybackRate ? player.getPlaybackRate() : 1.0;
-                        console.log('[Media] player.ratechange event, rate:', rate);
-                        if (window.jmpNative) {
-                            window.jmpNative.notifyRateChange(rate);
-                            const pos = pm.currentTime ? pm.currentTime() : 0;
-                            if (typeof pos === 'number' && pos >= 0) {
-                                window.jmpNative.notifyPosition(Math.floor(pos));
-                            }
-                        }
                         self.resetPositionTracking();
                     });
 
@@ -289,10 +250,7 @@
 
                 const isNavigating = !!(stopInfo && stopInfo.nextMediaType);
                 if (!isNavigating) {
-                    console.log('[Media] Playback truly stopped, clearing state');
-                    if (window.jmpNative) window.jmpNative.notifyPlaybackState('Stopped');
-                } else {
-                    console.log('[Media] Navigating to next item, keeping metadata');
+                    window.jmp.send('playback.state', { state: 'Stopped' });
                 }
                 self.updateQueueState();
             });

--- a/src/web/jmp-bus.js
+++ b/src/web/jmp-bus.js
@@ -1,0 +1,30 @@
+// JS-side message bus. Available in every CEF browser that injects this
+// script. Pairs with the C++ MessageBus (src/cef/message_bus.cpp).
+(function() {
+    const handlers = Object.create(null);
+    window.jmp = {
+        send(name, payload) {
+            if (!window.jmpNative || !window.jmpNative.send) return;
+            window.jmpNative.send(name, payload || {});
+        },
+        on(name, fn) {
+            (handlers[name] = handlers[name] || []).push(fn);
+        },
+        off(name, fn) {
+            const list = handlers[name];
+            if (!list) return;
+            const i = list.indexOf(fn);
+            if (i >= 0) list.splice(i, 1);
+        },
+        // Invoked by App::OnProcessMessageReceived in cef_app.cpp on the
+        // renderer process when the C++ side emits via g_bus.emit.
+        onMessage(name, payload) {
+            const list = handlers[name];
+            if (!list) return;
+            for (const fn of list.slice()) {
+                try { fn(payload || {}); }
+                catch (e) { console.error('[jmp]', name, 'handler error:', e); }
+            }
+        }
+    };
+})();

--- a/src/web/mpv-audio-player.js
+++ b/src/web/mpv-audio-player.js
@@ -51,7 +51,6 @@
             this._started = false;
             this._isFadingOut = false;
 
-            // Set up event handlers
             this._core.handlers.onPlaying = () => {
                 if (!this._started) {
                     this._started = true;
@@ -112,18 +111,34 @@
             return new Promise((resolve) => {
                 const val = options.url;
                 this._currentSrc = val;
-                console.log('[Media] [Audio] Playing:', val);
 
                 const ms = Math.round((options.playerStartPositionTicks || 0) / 10000);
                 this._currentPlayOptions = options;
                 this._core._currentTime = ms;
 
-                window.api.player.load(val,
-                    { startMilliseconds: ms, autoplay: true },
-                    { type: 'music', metadata: options.item },
-                    MpvPlayerCore.TRACK_AUTO,
-                    MpvPlayerCore.TRACK_AUTO,
-                    resolve);
+                window._jmpVideoActive = false;
+
+                const onPlaying = () => {
+                    window.api.player.playing.disconnect(onPlaying);
+                    window.api.player.error.disconnect(onError);
+                    resolve();
+                };
+                const onError = () => {
+                    window.api.player.playing.disconnect(onPlaying);
+                    window.api.player.error.disconnect(onError);
+                    resolve();
+                };
+                window.api.player.playing.connect(onPlaying);
+                window.api.player.error.connect(onError);
+
+                window.jmp.send('player.load', {
+                    url: val,
+                    startMs: ms,
+                    item: options.item,
+                    mediaSource: options.mediaSource,
+                    defaultAudioIdx: null,
+                    defaultSubIdx: null,
+                });
             });
         }
 
@@ -159,7 +174,7 @@
 
         destroy() {
             this._core.stopTimeUpdateTimer();
-            window.api.player.stop();
+            window.jmp.send('player.stop');
             this._core.disconnectSignals();
             this._core._duration = undefined;
         }
@@ -177,7 +192,6 @@
             return Promise.resolve({});
         }
 
-        // Delegate to core
         currentTime(val) { return this._core.currentTime(val); }
         currentTimeAsync() { return this._core.currentTimeAsync(); }
         duration() { return this._core.duration(); }
@@ -208,5 +222,4 @@
     }
 
     window._mpvAudioPlayer = mpvAudioPlayer;
-    console.log('[Media] mpvAudioPlayer plugin installed');
 })();

--- a/src/web/mpv-player-core.js
+++ b/src/web/mpv-player-core.js
@@ -49,7 +49,9 @@
             }
         }
 
-        // Signal management
+        // Signal management — wires player.* notifications into the local
+        // handlers object. api.player is the in-process signal bus that
+        // native-shim hooks up to bus subscriptions.
         connectSignals() {
             if (this._hasConnection) return;
             this._hasConnection = true;
@@ -76,7 +78,6 @@
             p.paused.disconnect(this.handlers.onPause);
         }
 
-        // Default event handlers (can be overridden via handlers object)
         defaultOnPause() {
             this._paused = true;
             this.stopTimeUpdateTimer();
@@ -87,41 +88,41 @@
             this._duration = duration;
         }
 
-        // Playback control
-        pause() { window.api.player.pause(); }
-        resume() { this._paused = false; window.api.player.play(); }
-        unpause() { window.api.player.play(); }
-        paused() { return this._paused; }
+        // Playback control — direct bus dispatch
+        pause()   { window.jmp.send('player.pause'); }
+        resume()  { this._paused = false; window.jmp.send('player.play'); }
+        unpause() { window.jmp.send('player.play'); }
+        paused()  { return this._paused; }
 
-        // Time
         currentTime(val) {
             if (val != null) {
                 this._currentTime = val;
                 this._lastTimerTick = Date.now();
-                window.api.player.seekTo(val);
+                window.jmp.send('player.seek', { positionMs: val });
                 return;
             }
             return this._currentTime;
         }
 
         currentTimeAsync() {
-            return new Promise(resolve => window.api.player.getPosition(resolve));
+            return new Promise(resolve => window.api.player.getPositionAsync(resolve));
         }
 
         duration() { return this._duration || null; }
         seekable() { return Boolean(this._duration); }
-        getBufferedRanges() { return window._bufferedRanges || []; }
+        getBufferedRanges() { return window.api.player.getBufferedRanges(); }
 
-        // Playback rate
+        // Playback rate — plain double; mpv side no longer expects scaling.
         setPlaybackRate(value) {
             this._playRate = value;
-            window.api.player.setPlaybackRate(value * 1000);
+            window.jmp.send('player.setRate', { rate: value });
         }
 
         getPlaybackRate() { return this._playRate || 1; }
 
         getSupportedPlaybackRates() {
-            return [0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0, 3.5, 4.0].map(id => ({ name: id + 'x', id }));
+            return [0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0, 3.5, 4.0]
+                .map(id => ({ name: id + 'x', id }));
         }
 
         saveVolume(value) {
@@ -132,35 +133,30 @@
             return this.appSettings.get('volume') || 1;
         }
 
-        // Volume
         setVolume(val, save = true) {
             val = Number(val);
-             if (!isNaN(val)) {
+            if (!isNaN(val)) {
                 this._volume = val;
                 if (save) {
                     this.appSettings.set('volume', (val || 100) / 100);
                     this.events.trigger(this.player, 'volumechange');
                 }
-                window.api.player.setVolume(val);
+                window.jmp.send('player.setVolume', { volume: val });
             }
         }
 
         getVolume() { return this._volume; }
-        volumeUp() { this.setVolume(Math.min(this._volume + 2, 100)); }
+        volumeUp()   { this.setVolume(Math.min(this._volume + 2, 100)); }
         volumeDown() { this.setVolume(Math.max(this._volume - 2, 0)); }
 
         setMute(mute, triggerEvent = true) {
             this._muted = mute;
-            window.api.player.setMuted(mute);
+            window.jmp.send('player.setMuted', { muted: !!mute });
             if (triggerEvent) this.events.trigger(this.player, 'volumechange');
         }
 
         isMuted() { return this._muted; }
     }
-
-    // mpv track selection (1-based track indices)
-    MpvPlayerCore.TRACK_AUTO    = -1;  // mpv auto-selects
-    MpvPlayerCore.TRACK_DISABLE =  0;  // disable track (sid=0, aid=0)
 
     window.MpvPlayerCore = MpvPlayerCore;
 })();

--- a/src/web/mpv-video-player.js
+++ b/src/web/mpv-video-player.js
@@ -1,23 +1,4 @@
 (function() {
-    function getMediaStreamAudioTracks(mediaSource) {
-        return mediaSource.MediaStreams.filter(s => s.Type === 'Audio');
-    }
-
-    // Convert Jellyfin global MediaStream.Index to 1-based type-relative index
-    function getRelativeIndexByType(mediaStreams, jellyIndex, streamType) {
-        let relIndex = 1;
-        for (const source of mediaStreams) {
-            if (source.Type !== streamType || source.IsExternal) continue;
-            if (source.Index === jellyIndex) return relIndex;
-            relIndex += 1;
-        }
-        return null;
-    }
-
-    function getStreamByIndex(mediaStreams, index) {
-        return mediaStreams.find(s => s.Index === index) || null;
-    }
-
     class mpvVideoPlayer {
         constructor({ events, loading, appRouter, globalize, appHost, appSettings, confirm, dashboard }) {
             this.events = events;
@@ -41,7 +22,6 @@
             this.isLocalPlayer = true;
             this.isFetching = false;
 
-            // Register for fullscreen notifications
             window._mpvVideoPlayerInstance = this;
 
             // Use defineProperty to avoid circular reference in JSON.stringify
@@ -68,17 +48,15 @@
                     this._started = true;
                     this.loading.hide();
                     const dlg = this._videoDialog;
-                    // Remove poster so video shows through from subsurface
                     if (dlg) {
                         const poster = dlg.querySelector('.mpvPoster');
                         if (poster) poster.remove();
                     }
-                    // "fullscreen" = fills entire web content area, not the actual screen
                     if (this._currentPlayOptions?.fullscreen) {
                         this.appRouter.showVideoOsd();
                         if (dlg) dlg.style.zIndex = 'unset';
                     }
-                    window.api.player.setVideoRectangle(0, 0, 0, 0);
+                    window.jmp.send('player.setVideoRectangle', { x: 0, y: 0, w: 0, h: 0 });
                 }
                 if (this._core._paused) {
                     this._core._paused = false;
@@ -86,7 +64,6 @@
                 }
                 this._core.startTimeUpdateTimer();
                 this.events.trigger(this, 'playing');
-                console.log('[Media] [MPV] playing event triggered');
             };
 
             this._core.handlers.onTimeUpdate = (time) => {
@@ -128,14 +105,12 @@
         currentSrc() { return this._currentSrc; }
 
         async play(options) {
-            console.log('[Media] [MPV] play() called with options:', options);
             this._started = false;
             this._timeUpdated = false;
             this._core._currentTime = null;
             this._endedPending = false;
-            if (options.fullscreen) this.loading.show();  // fills entire web content area, not the actual screen
+            if (options.fullscreen) this.loading.show();
             await this.createMediaElement(options);
-            console.log('[Media] [MPV] createMediaElement done, calling setCurrentSrc');
             return await this.setCurrentSrc(options);
         }
 
@@ -143,85 +118,63 @@
             return new Promise((resolve) => {
                 const val = options.url;
                 this._currentSrc = val;
-                console.log('[Media] [MPV] Playing:', val);
 
                 const ms = Math.round((options.playerStartPositionTicks || 0) / 10000);
                 this._currentPlayOptions = options;
                 this._core._currentTime = ms;
 
-                const streams = options.mediaSource?.MediaStreams || [];
-                const defaultAudioIdx = options.mediaSource.DefaultAudioStreamIndex ?? -1;
-                const defaultSubIdx = options.mediaSource.DefaultSubtitleStreamIndex ?? -1;
+                window._jmpVideoActive = true;
 
-                // Convert audio index from Jellyfin global stream index to mpv 1-based audio track index
-                let audioParam = MpvPlayerCore.TRACK_AUTO;
-                if (defaultAudioIdx >= 0) {
-                    const relIdx = getRelativeIndexByType(streams, defaultAudioIdx, 'Audio');
-                    audioParam = relIdx != null ? relIdx : MpvPlayerCore.TRACK_AUTO;
-                }
+                // Wait for first playing/error to resolve play().
+                const onPlaying = () => {
+                    window.api.player.playing.disconnect(onPlaying);
+                    window.api.player.error.disconnect(onError);
+                    resolve();
+                };
+                const onError = () => {
+                    window.api.player.playing.disconnect(onPlaying);
+                    window.api.player.error.disconnect(onError);
+                    resolve();
+                };
+                window.api.player.playing.connect(onPlaying);
+                window.api.player.error.connect(onError);
 
-                // Convert subtitle index to relative
-                let subParam = MpvPlayerCore.TRACK_DISABLE;
-                let externalSubUrl = null;
-                if (defaultSubIdx >= 0) {
-                    const subStream = getStreamByIndex(streams, defaultSubIdx);
-                    if (subStream && subStream.DeliveryMethod === 'External' && subStream.DeliveryUrl) {
-                        externalSubUrl = subStream.DeliveryUrl;
-                    } else {
-                        const relIdx = getRelativeIndexByType(streams, defaultSubIdx, 'Subtitle');
-                        subParam = relIdx != null ? relIdx : MpvPlayerCore.TRACK_AUTO;
-                    }
-                }
-
-                window.api.player.setAspectMode(this.getAspectRatio());
-                window.api.player.load(val,
-                    { startMilliseconds: ms, autoplay: true },
-                    { type: 'video', metadata: options.item },
-                    audioParam,
-                    subParam,
-                    resolve);
-
-                if (externalSubUrl) {
-                    window.api.player.addSubtitleStream(externalSubUrl);
-                }
+                window.jmp.send('player.setAspectRatio', { mode: this.getAspectRatio() });
+                window.jmp.send('player.load', {
+                    url: val,
+                    startMs: ms,
+                    item: options.item,
+                    mediaSource: options.mediaSource,
+                    defaultAudioIdx: options.mediaSource?.DefaultAudioStreamIndex ?? null,
+                    defaultSubIdx:   options.mediaSource?.DefaultSubtitleStreamIndex ?? null,
+                });
             });
         }
 
         setSubtitleStreamIndex(index) {
-            if (index == null || index < 0) {
-                window.api.player.setSubtitleStream(MpvPlayerCore.TRACK_DISABLE);
-                return;
-            }
-            const streams = this._currentPlayOptions?.mediaSource?.MediaStreams || [];
-            const stream = getStreamByIndex(streams, index);
-            if (stream && stream.DeliveryMethod === 'External' && stream.DeliveryUrl) {
-                window.api.player.addSubtitleStream(stream.DeliveryUrl);
-                return;
-            }
-            const relIdx = getRelativeIndexByType(streams, index, 'Subtitle');
-            window.api.player.setSubtitleStream(relIdx != null ? relIdx : MpvPlayerCore.TRACK_DISABLE);
+            window.jmp.send('player.selectSubtitle', {
+                jellyfinIndex: (index == null || index < 0) ? null : index,
+            });
         }
 
-        setSecondarySubtitleStreamIndex(index) {}
+        setSecondarySubtitleStreamIndex() {}
 
         resetSubtitleOffset() {
-            window.api.player.setSubtitleDelay(0);
+            window.jmp.send('player.setSubtitleOffset', { seconds: 0 });
         }
 
         enableShowingSubtitleOffset() {}
         disableShowingSubtitleOffset() {}
         isShowingSubtitleOffsetEnabled() { return false; }
-        setSubtitleOffset(offset) { window.api.player.setSubtitleDelay(Math.round(offset * 1000)); }
+        setSubtitleOffset(offset) {
+            window.jmp.send('player.setSubtitleOffset', { seconds: offset });
+        }
         getSubtitleOffset() { return 0; }
 
         setAudioStreamIndex(index) {
-            if (index == null || index < 0) {
-                window.api.player.setAudioStream(MpvPlayerCore.TRACK_AUTO);
-                return;
-            }
-            const streams = this._currentPlayOptions?.mediaSource?.MediaStreams || [];
-            const relIdx = getRelativeIndexByType(streams, index, 'Audio');
-            window.api.player.setAudioStream(relIdx != null ? relIdx : MpvPlayerCore.TRACK_AUTO);
+            window.jmp.send('player.selectAudio', {
+                jellyfinIndex: (index == null || index < 0) ? null : index,
+            });
         }
 
         onEndedInternal() {
@@ -242,16 +195,15 @@
                     dlg.appendChild(poster);
                 }
             }
-            window.api.player.stop();
+            window.jmp.send('player.stop');
             this._core.handlers.onEnded();
             if (destroyPlayer) this.destroy();
             return Promise.resolve();
         }
 
         removeMediaDialog() {
-            window.api.player.stop();
-            if (window.jmpNative) window.jmpNative.playerOsdActive(false);
-            window.api.player.setVideoRectangle(-1, 0, 0, 0);
+            window.jmp.send('player.stop');
+            window.jmp.send('osd.active', { active: false });
             document.body.classList.remove('hide-scroll');
             const dlg = this._videoDialog;
             if (dlg) {
@@ -265,27 +217,23 @@
             this._core.stopTimeUpdateTimer();
             this.removeMediaDialog();
             this._core.disconnectSignals();
-
-            // Support jellyfin-web v10.10.7
             this._currentAspectRatio = undefined;
         }
 
         createMediaElement(options) {
             let dlg = document.querySelector('.videoPlayerContainer');
             if (!dlg) {
-                if (window.jmpNative) window.jmpNative.playerOsdActive(true);
+                window.jmp.send('osd.active', { active: true });
                 dlg = document.createElement('div');
                 dlg.classList.add('videoPlayerContainer');
                 dlg.style.cssText = 'position:fixed;top:0;bottom:0;left:0;right:0;display:flex;align-items:center;background:transparent;';
-                if (options.fullscreen) dlg.style.zIndex = 1000;  // fills entire web content area, not the actual screen
+                if (options.fullscreen) dlg.style.zIndex = 1000;
                 document.body.insertBefore(dlg, document.body.firstChild);
                 this.setTransparency(2);
                 this._videoDialog = dlg;
 
                 this._core.connectSignals();
-                if (window.jmpNative) {
-                    window.jmpNative.notifyRateChange(this._core._playRate);
-                }
+                window.jmp.send('input.rateChanged', { rate: this._core._playRate });
             } else {
                 this._videoDialog = dlg;
             }
@@ -297,7 +245,7 @@
                 poster.style.cssText = `position:absolute;top:0;left:0;right:0;bottom:0;background:#000 url('${options.backdropUrl}') center/cover no-repeat;`;
                 dlg.appendChild(poster);
             }
-            if (options.fullscreen) document.body.classList.add('hide-scroll');  // fills entire web content area, not the actual screen
+            if (options.fullscreen) document.body.classList.add('hide-scroll');
             return Promise.resolve();
         }
 
@@ -313,7 +261,7 @@
         supports(feature) { return mpvVideoPlayer.getSupportedFeatures().includes(feature); }
         isFullscreen() { return window._isFullscreen === true; }
         toggleFullscreen() {
-            if (window.jmpNative) window.jmpNative.toggleFullscreen();
+            window.jmp.send('fullscreen.toggle');
         }
 
         // Delegate to core
@@ -329,7 +277,7 @@
 
         setPlaybackRate(value) {
             this._core.setPlaybackRate(value);
-            if (window.jmpNative) window.jmpNative.notifyRateChange(value);
+            window.jmp.send('input.rateChanged', { rate: value });
         }
         getPlaybackRate() { return this._core.getPlaybackRate(); }
         getSupportedPlaybackRates() { return this._core.getSupportedPlaybackRates(); }
@@ -365,22 +313,18 @@
         getAspectRatio() {
             const aspectRatio = typeof this.appSettings.aspectRatio === 'function'
                 ? this.appSettings.aspectRatio()
-                // Support jellyfin-web v10.10.7
                 : this._currentAspectRatio;
-
             return aspectRatio || 'auto';
         }
         setAspectRatio(value) {
             if (typeof this.appSettings.aspectRatio === 'function') {
                 this.appSettings.aspectRatio(value);
             } else {
-                // Support jellyfin-web v10.10.7
                 this._currentAspectRatio = value;
             }
-            window.api.player.setAspectMode(value);
+            window.jmp.send('player.setAspectRatio', { mode: value });
         }
     }
 
     window._mpvVideoPlayer = mpvVideoPlayer;
-    console.log('[Media] mpvVideoPlayer class installed');
 })();

--- a/src/web/native-shim.js
+++ b/src/web/native-shim.js
@@ -8,8 +8,6 @@
         const fullscreen = !!document.fullscreenElement;
         if (window._isFullscreen === fullscreen) return;
         window._isFullscreen = fullscreen;
-        console.log('[Media] Fullscreen changed:', fullscreen);
-        // Notify player so UI updates (jellyfin-web listens for this)
         const player = window._mpvVideoPlayerInstance;
         if (player && player.events) {
             player.events.trigger(player, 'fullscreenchange');
@@ -27,15 +25,13 @@
     (function() {
         let lastTime = 0, lastX = 0, lastY = 0;
         document.addEventListener('mousedown', (e) => {
-            // left button only and only if clicked on main content (not header,
-            // or controls)
             if (e.button !== 0 || !e.target.classList.contains("mainAnimatedPage")) return;
             const now = Date.now();
             const dx = e.clientX - lastX;
             const dy = e.clientY - lastY;
             if ((now - lastTime) < 500 && (dx * dx + dy * dy) < 25) {
                 if (document.querySelector('.videoPlayerContainer')) {
-                    if (window.jmpNative) window.jmpNative.toggleFullscreen();
+                    jmp.send('fullscreen.toggle');
                 }
                 lastTime = 0;
             } else {
@@ -43,14 +39,8 @@
                 lastX = e.clientX;
                 lastY = e.clientY;
             }
-        }, true);  // capture phase — before jellyfin-web can stopPropagation
+        }, true);
     })();
-
-    // Buffered ranges storage (updated by native code)
-    window._bufferedRanges = [];
-    window._nativeUpdateBufferedRanges = function(ranges) {
-        window._bufferedRanges = ranges || [];
-    };
 
     // Signal emulation (Qt-style connect/disconnect)
     function createSignal(name) {
@@ -60,14 +50,10 @@
                 try { cb(...args); } catch(e) { console.error('[Media] [Signal] ' + name + ' error:', e); }
             }
         };
-        signal.connect = (cb) => {
-            callbacks.push(cb);
-            console.log('[Media] [Signal] ' + name + ' connected, now has', callbacks.length, 'listeners');
-        };
+        signal.connect = (cb) => { callbacks.push(cb); };
         signal.disconnect = (cb) => {
             const idx = callbacks.indexOf(cb);
             if (idx >= 0) callbacks.splice(idx, 1);
-            console.log('[Media] [Signal] ' + name + ' disconnected, now has', callbacks.length, 'listeners');
         };
         return signal;
     }
@@ -139,118 +125,43 @@
         });
     }
 
-    // Player state
+    // Buffered ranges cache, populated by player.bufferedRangesChanged.
+    let _bufferedRanges = [];
+
+    // Player state cache
     const playerState = {
         position: 0,
         duration: 0,
         volume: 100,
         muted: false,
-        paused: false
+        paused: false,
+        pendingPositionRequests: new Map(),
+        nextRequestId: 1
     };
 
-    // window.api.player - MPV control API
-    window.api = {
-        player: {
-            // Signals (Qt-style)
-            playing: createSignal('playing'),
-            paused: createSignal('paused'),
-            finished: createSignal('finished'),
-            stopped: createSignal('stopped'),
-            canceled: createSignal('canceled'),
-            error: createSignal('error'),
-            buffering: createSignal('buffering'),
-            seeking: createSignal('seeking'),
-            positionUpdate: createSignal('positionUpdate'),
-            updateDuration: createSignal('updateDuration'),
-            stateChanged: createSignal('stateChanged'),
-            videoPlaybackActive: createSignal('videoPlaybackActive'),
-            windowVisible: createSignal('windowVisible'),
-            onVideoRecangleChanged: createSignal('onVideoRecangleChanged'),
-            onMetaData: createSignal('onMetaData'),
+    // window.api.player - signal-driven plugin contract used by mpv-player-core
+    // and friends. Routes through jmp.send/jmp.on.
+    const playerSignals = {
+        playing: createSignal('playing'),
+        paused: createSignal('paused'),
+        finished: createSignal('finished'),
+        stopped: createSignal('stopped'),
+        canceled: createSignal('canceled'),
+        error: createSignal('error'),
+        buffering: createSignal('buffering'),
+        seeking: createSignal('seeking'),
+        positionUpdate: createSignal('positionUpdate'),
+        updateDuration: createSignal('updateDuration'),
+        stateChanged: createSignal('stateChanged'),
+        videoPlaybackActive: createSignal('videoPlaybackActive'),
+        windowVisible: createSignal('windowVisible'),
+        onVideoRecangleChanged: createSignal('onVideoRecangleChanged'),
+        onMetaData: createSignal('onMetaData'),
+    };
 
-            // Methods
-            load(url, options, streamdata, audioStream, subtitleStream, callback) {
-                console.log('[Media] player.load:', url);
-                window._jmpVideoActive = streamdata?.type === 'video';
-                if (callback) {
-                    // Wait for playing signal before calling callback
-                    const onPlaying = () => {
-                        this.playing.disconnect(onPlaying);
-                        this.error.disconnect(onError);
-                        callback();
-                    };
-                    const onError = () => {
-                        this.playing.disconnect(onPlaying);
-                        this.error.disconnect(onError);
-                        callback();
-                    };
-                    this.playing.connect(onPlaying);
-                    this.error.connect(onError);
-                }
-                if (window.jmpNative && window.jmpNative.playerLoad) {
-                    const metadataJson = streamdata?.metadata ? JSON.stringify(streamdata.metadata) : '{}';
-                    window.jmpNative.playerLoad(url, options.startMilliseconds, audioStream, subtitleStream, metadataJson);
-                }
-            },
-            stop() {
-                console.log('[Media] player.stop');
-                restoreThemeColor();
-                if (window.jmpNative) window.jmpNative.playerStop();
-            },
-            pause() {
-                console.log('[Media] player.pause');
-                if (window.jmpNative) window.jmpNative.playerPause();
-                playerState.paused = true;
-            },
-            play() {
-                console.log('[Media] player.play');
-                if (window.jmpNative) window.jmpNative.playerPlay();
-                playerState.paused = false;
-            },
-            seekTo(ms) {
-                console.log('[Media] player.seekTo:', ms);
-                if (window.jmpNative) window.jmpNative.playerSeek(ms);
-            },
-            setVolume(vol) {
-                console.log('[Media] player.setVolume:', vol);
-                playerState.volume = vol;
-                if (window.jmpNative) window.jmpNative.playerSetVolume(vol);
-            },
-            setMuted(muted) {
-                console.log('[Media] player.setMuted:', muted);
-                playerState.muted = muted;
-                if (window.jmpNative) window.jmpNative.playerSetMuted(muted);
-            },
-            setPlaybackRate(rate) {
-                console.log('[Media] player.setPlaybackRate:', rate);
-                if (window.jmpNative) window.jmpNative.playerSetSpeed(rate);
-            },
-            setSubtitleStream(index) {
-                console.log('[Media] player.setSubtitleStream:', index);
-                if (window.jmpNative) window.jmpNative.playerSetSubtitle(index);
-            },
-            addSubtitleStream(url) {
-                console.log('[Media] player.addSubtitleStream:', url);
-                if (window.jmpNative) window.jmpNative.playerAddSubtitle(url);
-            },
-            setAudioStream(index) {
-                console.log('[Media] player.setAudioStream:', index);
-                if (window.jmpNative) window.jmpNative.playerSetAudio(index);
-            },
-            setSubtitleDelay(ms) {
-                console.log('[Media] player.setSubtitleDelay:', ms);
-            },
-            setAudioDelay(ms) {
-                console.log('[Media] player.setAudioDelay:', ms);
-                if (window.jmpNative) window.jmpNative.playerSetAudioDelay(ms / 1000.0);
-            },
-            setAspectMode(mode) {
-                console.log('[Media] player.setAspectMode:', mode);
-                if (window.jmpNative) window.jmpNative.playerSetAspectMode(mode);
-            },
-            setVideoRectangle(x, y, w, h) {
-                // No-op for now, we always render fullscreen
-            },
+    window.api = {
+        player: Object.assign(playerSignals, {
+            getBufferedRanges() { return _bufferedRanges; },
             getPosition(callback) {
                 if (callback) callback(playerState.position);
                 return playerState.position;
@@ -259,13 +170,13 @@
                 if (callback) callback(playerState.duration);
                 return playerState.duration;
             },
-        },
+        }),
         system: {
             openExternalUrl(url) {
                 window.open(url, '_blank');
             },
             exit() {
-                if (window.jmpNative) window.jmpNative.appExit();
+                jmp.send('app.exit');
             },
             cancelServerConnectivity() {
                 if (window.jmpCheckServerConnectivity && window.jmpCheckServerConnectivity.abort) {
@@ -275,16 +186,18 @@
         },
         settings: {
             setValue(section, key, value, callback) {
-                if (window.jmpNative && window.jmpNative.setSettingValue) {
-                    window.jmpNative.setSettingValue(section, key, typeof value === 'boolean' ? (value ? 'true' : 'false') : String(value));
-                }
+                jmp.send('app.setSettingValue', {
+                    section,
+                    key,
+                    value: typeof value === 'boolean' ? (value ? 'true' : 'false') : String(value),
+                });
                 if (callback) callback();
             },
             sectionValueUpdate: createSignal('sectionValueUpdate'),
             groupUpdate: createSignal('groupUpdate')
         },
         input: {
-            // Signals for media session control commands
+            // Signals for media session control commands (driven by bus inbound)
             hostInput: createSignal('hostInput'),
             positionSeek: createSignal('positionSeek'),
             rateChanged: createSignal('rateChanged'),
@@ -297,44 +210,74 @@
         }
     };
 
-    // Expose signal emitter for native code
-    window._nativeEmit = function(signal, ...args) {
-        console.log('[Media] _nativeEmit called with signal:', signal, 'args:', args);
-        if (window.api && window.api.player && window.api.player[signal]) {
-            console.log('[Media] Firing signal:', signal);
-            window.api.player[signal](...args);
-        } else {
-            console.error('[Media] Signal not found:', signal, 'api exists:', !!window.api);
+    // Inbound bus subscriptions — translate player.* notifications into the
+    // signal surface mpv-player-core depends on.
+    jmp.on('player.playing', () => { playerSignals.playing(); });
+    jmp.on('player.paused', () => {
+        playerState.paused = true;
+        playerSignals.paused();
+    });
+    jmp.on('player.stopped', () => {
+        playerState.paused = false;
+        // mpv-player-core treats `finished` as end-of-media; preserve that mapping.
+        playerSignals.finished();
+        playerSignals.stopped();
+    });
+    jmp.on('player.error', (p) => { playerSignals.error(p && p.message); });
+    jmp.on('player.tick', (p) => {
+        if (!p) return;
+        const ms = p.positionMs || 0;
+        playerState.position = ms;
+        playerSignals.positionUpdate(ms);
+    });
+    jmp.on('player.durationChanged', (p) => {
+        if (!p) return;
+        const ms = p.durationMs || 0;
+        playerState.duration = ms;
+        playerSignals.updateDuration(ms);
+    });
+    jmp.on('player.seeking', (p) => {
+        if (p && p.active) playerSignals.seeking();
+    });
+    jmp.on('player.bufferedRangesChanged', (p) => {
+        _bufferedRanges = (p && p.ranges) || [];
+    });
+    jmp.on('player.positionReply', (p) => {
+        if (!p || p.requestId == null) return;
+        const cb = playerState.pendingPositionRequests.get(p.requestId);
+        if (cb) {
+            playerState.pendingPositionRequests.delete(p.requestId);
+            cb(p.positionMs || 0);
         }
+    });
+
+    // Async position lookup — replaces the old getPosition(callback) sync path
+    // for callers that need a real-time fetch from mpv. Stored on the player
+    // object so MpvPlayerCore.currentTimeAsync can use it.
+    window.api.player.getPositionAsync = function(callback) {
+        const id = playerState.nextRequestId++;
+        playerState.pendingPositionRequests.set(id, callback);
+        jmp.send('player.getPosition', { requestId: id });
     };
-    window._nativeFullscreenChanged = function(fullscreen) {
-        window._isFullscreen = fullscreen;
+
+    // Inbound media session / fullscreen commands
+    jmp.on('input.hostInput', (p) => {
+        if (p && Array.isArray(p.actions)) window.api.input.hostInput(p.actions);
+    });
+    jmp.on('input.positionSeek', (p) => {
+        if (p && p.positionMs != null) window.api.input.positionSeek(p.positionMs);
+    });
+    jmp.on('input.rateChanged', (p) => {
+        if (p && p.rate != null) window.api.input.rateChanged(p.rate);
+    });
+    jmp.on('fullscreen.changed', (p) => {
+        const fs = !!(p && p.fullscreen);
+        window._isFullscreen = fs;
         const player = window._mpvVideoPlayerInstance;
         if (player && player.events) {
             player.events.trigger(player, 'fullscreenchange');
         }
-    };
-    window._nativeUpdatePosition = function(ms) {
-        playerState.position = ms;
-        window.api.player.positionUpdate(ms);
-    };
-    window._nativeUpdateDuration = function(ms) {
-        playerState.duration = ms;
-        window.api.player.updateDuration(ms);
-    };
-    // Native emitters for media session control commands
-    window._nativeHostInput = function(actions) {
-        console.log('[Media] _nativeHostInput:', actions);
-        window.api.input.hostInput(actions);
-    };
-    window._nativeSetRate = function(rate) {
-        console.log('[Media] _nativeSetRate:', rate);
-        window.api.input.rateChanged(rate);
-    };
-    window._nativeSeek = function(positionMs) {
-        console.log('[Media] _nativeSeek:', positionMs);
-        window.api.input.positionSeek(positionMs);
-    };
+    });
 
     // window.NativeShell - app info and plugins
     const plugins = ['mpvVideoPlayer', 'mpvAudioPlayer', 'inputPlugin'];
@@ -343,7 +286,7 @@
     }
 
     window.NativeShell = {
-        openUrl(url, target) {
+        openUrl(url) {
             window.api.system.openExternalUrl(url);
         },
         downloadFile(info) {
@@ -429,11 +372,8 @@
     window.apiPromise = Promise.resolve(window.api);
 
     // Observe <meta name="theme-color"> for titlebar color sync.
-    // jellyfin-web's themeManager.js updates this tag when the user switches themes.
     function sendThemeColor(color) {
-        if (color && window.jmpNative && window.jmpNative.themeColor) {
-            window.jmpNative.themeColor(color);
-        }
+        if (color) jmp.send('app.themeColor', { color });
     }
 
     function restoreThemeColor() {
@@ -448,33 +388,22 @@
     }
 
     document.addEventListener('DOMContentLoaded', () => {
-        // Inject CSS to hide cursor when jellyfin-web signals mouse idle.
-        // jellyfin-web adds 'mouseIdle' to body after inactivity during video playback.
-        // This CSS makes CEF report CT_NONE so the native side can hide the OS cursor.
         const style = document.createElement('style');
         let css = 'body.mouseIdle, body.mouseIdle * { cursor: none !important; }';
 
-        // macOS: offset UI elements so traffic lights don't overlap content
         if (navigator.platform.startsWith('Mac') && jmpInfo.settings.advanced.transparentTitlebar) {
             css += '\n:root { --mac-titlebar-height: 28px; }';
             css += '\n.skinHeader { padding-top: var(--mac-titlebar-height) !important; }';
             css += '\n.mainAnimatedPage { top: var(--mac-titlebar-height) !important; }';
             css += '\n.touch-menu-la { padding-top: var(--mac-titlebar-height); }';
-            // Dashboard uses MUI AppBar + Drawer instead of .skinHeader
             css += '\n.MuiAppBar-positionFixed { padding-top: var(--mac-titlebar-height) !important; }';
             css += '\n.MuiDrawer-paper { padding-top: var(--mac-titlebar-height) !important; }';
-            // Dialog headers (e.g. client settings modal)
             css += '\n.formDialogHeader { padding-top: var(--mac-titlebar-height) !important; }';
 
-            // Hide/show traffic lights with the video OSD.
-            // jellyfin-web uses an internal Events.trigger() system (obj._callbacks),
-            // not DOM events. Register directly on that callback structure.
             document._callbacks = document._callbacks || {};
             document._callbacks['SHOW_VIDEO_OSD'] = document._callbacks['SHOW_VIDEO_OSD'] || [];
             document._callbacks['SHOW_VIDEO_OSD'].push((_e, visible) => {
-                if (window.jmpNative && window.jmpNative.setOsdVisible) {
-                    window.jmpNative.setOsdVisible(!!visible);
-                }
+                jmp.send('osd.active', { active: !!visible });
             });
         }
 
@@ -491,10 +420,9 @@
         window.api.player.error.connect(() => { window._jmpVideoActive = false; restoreThemeColor(); });
 
         // Watch for mouseIdle class on body and tell native to hide/show cursor.
-        // Direct IPC is more reliable than CSS cursor:none → OnCursorChange in OSR mode.
         new MutationObserver(() => {
             const idle = document.body.classList.contains('mouseIdle');
-            window.jmpNative.setCursorVisible(!idle);
+            jmp.send('osd.cursorVisible', { visible: !idle });
         }).observe(document.body, { attributes: true, attributeFilter: ['class'] });
 
         // Sync titlebar color with theme-color meta tag
@@ -502,7 +430,6 @@
         if (meta) {
             observeThemeColorMeta(meta);
         } else {
-            // Tag may be added dynamically — watch for it
             new MutationObserver((mutations, obs) => {
                 for (const m of mutations) {
                     for (const node of m.addedNodes) {

--- a/src/web/overlay.js
+++ b/src/web/overlay.js
@@ -5,12 +5,12 @@ let cancelWait = null;
 // and resolves savedServerUrlReady.
 let savedServerUrl = null;
 const savedServerUrlReady = new Promise((resolve) => {
-    window._onSavedServerUrl = (url) => {
-        savedServerUrl = url || null;
+    window.jmp.on('overlay.savedServerUrl', (p) => {
+        savedServerUrl = (p && p.url) || null;
         resolve(savedServerUrl);
-    };
+    });
 });
-window.jmpNative.getSavedServerUrl();
+window.jmp.send('overlay.getSavedServerUrl');
 
 // True whenever the main browser is loading the URL we currently care about.
 // Set by the auto-connect path once we know a saved URL exists (main.cpp
@@ -45,9 +45,7 @@ async function tryConnect(server, spinnerStartTime = Date.now()) {
 
         // Save the normalized URL returned by native, not the raw user input.
         savedServerUrl = resolvedUrl;
-        if (window.jmpNative && window.jmpNative.saveServerUrl) {
-            window.jmpNative.saveServerUrl(resolvedUrl);
-        }
+        window.jmp.send('overlay.saveServerUrl', { url: resolvedUrl });
 
         // Kick off main-browser navigation immediately, then wait long enough
         // to satisfy both constraints simultaneously: spinner visible ≥1s AND
@@ -55,13 +53,8 @@ async function tryConnect(server, spinnerStartTime = Date.now()) {
         // saves up to ~900ms compared to running the two waits sequentially.
         // Skip when main is already loading (startup pre-load or prior nav).
         if (!mainLoaded) {
-            if (window.jmpNative && window.jmpNative.navigateMain) {
-                window.jmpNative.navigateMain(resolvedUrl);
-                mainLoaded = true;
-            } else {
-                console.error("navigateMain IPC not available");
-                return false;
-            }
+            window.jmp.send('overlay.navigateMain', { url: resolvedUrl });
+            mainLoaded = true;
         }
 
         const elapsed = Date.now() - spinnerStartTime;
@@ -69,9 +62,7 @@ async function tryConnect(server, spinnerStartTime = Date.now()) {
         await cancellableDelay(waitMs, 'pre-fade');
         if (!isConnecting) return false;
 
-        if (window.jmpNative && window.jmpNative.dismissOverlay) {
-            window.jmpNative.dismissOverlay();
-        }
+        window.jmp.send('overlay.dismissOverlay');
         return true;
     } catch (e) {
         if (/cancel/i.test(e && e.message)) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,3 +10,15 @@ target_include_directories(jellyfin_api_test PRIVATE
 )
 
 add_test(NAME jellyfin_api_test COMMAND jellyfin_api_test)
+
+add_executable(track_resolver_test
+    track_resolver_test.cpp
+    ${CMAKE_SOURCE_DIR}/src/player/track_resolver.cpp
+)
+
+target_include_directories(track_resolver_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/third_party/doctest/include
+)
+
+add_test(NAME track_resolver_test COMMAND track_resolver_test)

--- a/tests/track_resolver_test.cpp
+++ b/tests/track_resolver_test.cpp
@@ -1,0 +1,211 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+
+#include "player/track_resolver.h"
+
+using track_resolver::kTrackAuto;
+using track_resolver::kTrackDisable;
+using track_resolver::MediaStream;
+using track_resolver::resolve_audio_aid;
+using track_resolver::resolve_subtitle;
+using track_resolver::SubtitleSelection;
+using track_resolver::SubtitleUnresolvedFallback;
+
+namespace {
+
+MediaStream video(int idx) { return {idx, "Video", false, "", ""}; }
+MediaStream audio(int idx) { return {idx, "Audio", false, "", ""}; }
+MediaStream sub_embedded(int idx) { return {idx, "Subtitle", false, "Embed", ""}; }
+MediaStream sub_external(int idx, std::string url) {
+    return {idx, "Subtitle", false, "External", std::move(url)};
+}
+MediaStream sub_external_marked(int idx, std::string url) {
+    // Same as sub_external but with IsExternal=true to confirm both flags
+    // independently route to the External path.
+    return {idx, "Subtitle", true, "External", std::move(url)};
+}
+
+}  // namespace
+
+// =====================================================================
+// Audio
+// =====================================================================
+
+TEST_CASE("audio: missing/null index → kTrackAuto") {
+    std::vector<MediaStream> streams{video(0), audio(1)};
+    CHECK(resolve_audio_aid(streams, std::nullopt) == kTrackAuto);
+}
+
+TEST_CASE("audio: negative index → kTrackAuto") {
+    std::vector<MediaStream> streams{video(0), audio(1)};
+    CHECK(resolve_audio_aid(streams, -1) == kTrackAuto);
+}
+
+TEST_CASE("audio: first audio stream → 1") {
+    std::vector<MediaStream> streams{video(0), audio(1), audio(2), audio(3)};
+    CHECK(resolve_audio_aid(streams, 1) == 1);
+}
+
+TEST_CASE("audio: third audio stream → 3") {
+    std::vector<MediaStream> streams{video(0), audio(1), audio(2), audio(3)};
+    CHECK(resolve_audio_aid(streams, 3) == 3);
+}
+
+TEST_CASE("audio: index of non-audio stream → kTrackAuto") {
+    std::vector<MediaStream> streams{video(0), audio(1)};
+    CHECK(resolve_audio_aid(streams, 0) == kTrackAuto);  // points at video
+}
+
+TEST_CASE("audio: index that doesn't exist → kTrackAuto") {
+    std::vector<MediaStream> streams{video(0), audio(1)};
+    CHECK(resolve_audio_aid(streams, 99) == kTrackAuto);
+}
+
+TEST_CASE("audio: external streams are skipped during relative walk") {
+    std::vector<MediaStream> streams{
+        video(0),
+        audio(1),
+        {2, "Audio", true, "", ""},  // external audio (rare but possible)
+        audio(3),
+    };
+    // Stream 3 should resolve to relative index 2 because the external (2) is skipped.
+    CHECK(resolve_audio_aid(streams, 3) == 2);
+}
+
+TEST_CASE("audio: empty streams → kTrackAuto") {
+    std::vector<MediaStream> streams;
+    CHECK(resolve_audio_aid(streams, 0) == kTrackAuto);
+    CHECK(resolve_audio_aid(streams, std::nullopt) == kTrackAuto);
+}
+
+// =====================================================================
+// Subtitle (load fallback = AutoFallback)
+// =====================================================================
+
+TEST_CASE("subtitle load: missing/null → Disable") {
+    std::vector<MediaStream> streams{sub_embedded(1)};
+    auto r = resolve_subtitle(streams, std::nullopt,
+                              SubtitleUnresolvedFallback::AutoFallback);
+    CHECK(r.kind == SubtitleSelection::Kind::Disable);
+    CHECK(r.sid == kTrackDisable);
+    CHECK(r.url == "");
+}
+
+TEST_CASE("subtitle load: negative → Disable") {
+    std::vector<MediaStream> streams{sub_embedded(1)};
+    auto r = resolve_subtitle(streams, -1,
+                              SubtitleUnresolvedFallback::AutoFallback);
+    CHECK(r.kind == SubtitleSelection::Kind::Disable);
+}
+
+TEST_CASE("subtitle load: external by DeliveryMethod → External + URL") {
+    std::vector<MediaStream> streams{
+        video(0),
+        sub_external(1, "http://srv/en.vtt"),
+    };
+    auto r = resolve_subtitle(streams, 1,
+                              SubtitleUnresolvedFallback::AutoFallback);
+    CHECK(r.kind == SubtitleSelection::Kind::External);
+    CHECK(r.url == "http://srv/en.vtt");
+}
+
+TEST_CASE("subtitle load: External with empty URL falls through to relative path") {
+    std::vector<MediaStream> streams{
+        video(0),
+        {1, "Subtitle", false, "External", ""},  // no URL
+    };
+    auto r = resolve_subtitle(streams, 1,
+                              SubtitleUnresolvedFallback::AutoFallback);
+    // Falls through to relative index walk; this is still a Subtitle so it
+    // resolves to embedded sid=1.
+    CHECK(r.kind == SubtitleSelection::Kind::Embedded);
+    CHECK(r.sid == 1);
+}
+
+TEST_CASE("subtitle load: embedded → Embedded + relative sid") {
+    std::vector<MediaStream> streams{
+        video(0),
+        audio(1),
+        sub_embedded(2),
+        sub_embedded(3),
+    };
+    auto r = resolve_subtitle(streams, 3,
+                              SubtitleUnresolvedFallback::AutoFallback);
+    CHECK(r.kind == SubtitleSelection::Kind::Embedded);
+    CHECK(r.sid == 2);
+}
+
+TEST_CASE("subtitle load: index of non-subtitle stream → AutoFallback Embedded sid=kTrackAuto") {
+    std::vector<MediaStream> streams{video(0), audio(1)};
+    auto r = resolve_subtitle(streams, 1,  // points at audio
+                              SubtitleUnresolvedFallback::AutoFallback);
+    CHECK(r.kind == SubtitleSelection::Kind::Embedded);
+    CHECK(r.sid == kTrackAuto);
+}
+
+TEST_CASE("subtitle load: index that doesn't exist → AutoFallback Embedded sid=kTrackAuto") {
+    std::vector<MediaStream> streams{sub_embedded(1)};
+    auto r = resolve_subtitle(streams, 99,
+                              SubtitleUnresolvedFallback::AutoFallback);
+    CHECK(r.kind == SubtitleSelection::Kind::Embedded);
+    CHECK(r.sid == kTrackAuto);
+}
+
+// =====================================================================
+// Subtitle (runtime change fallback = DisableFallback)
+// =====================================================================
+
+TEST_CASE("subtitle change: missing/null → Disable") {
+    std::vector<MediaStream> streams{sub_embedded(1)};
+    auto r = resolve_subtitle(streams, std::nullopt,
+                              SubtitleUnresolvedFallback::DisableFallback);
+    CHECK(r.kind == SubtitleSelection::Kind::Disable);
+}
+
+TEST_CASE("subtitle change: external → External + URL (regardless of fallback)") {
+    std::vector<MediaStream> streams{sub_external(4, "http://srv/x.vtt")};
+    auto r = resolve_subtitle(streams, 4,
+                              SubtitleUnresolvedFallback::DisableFallback);
+    CHECK(r.kind == SubtitleSelection::Kind::External);
+    CHECK(r.url == "http://srv/x.vtt");
+}
+
+TEST_CASE("subtitle change: index doesn't exist → Disable (NOT auto)") {
+    std::vector<MediaStream> streams{sub_embedded(1)};
+    auto r = resolve_subtitle(streams, 99,
+                              SubtitleUnresolvedFallback::DisableFallback);
+    CHECK(r.kind == SubtitleSelection::Kind::Disable);
+    CHECK(r.sid == kTrackDisable);
+}
+
+TEST_CASE("subtitle change: embedded resolves the same in both modes") {
+    std::vector<MediaStream> streams{
+        video(0), audio(1), sub_embedded(2), sub_embedded(3),
+    };
+    auto a = resolve_subtitle(streams, 3, SubtitleUnresolvedFallback::AutoFallback);
+    auto b = resolve_subtitle(streams, 3, SubtitleUnresolvedFallback::DisableFallback);
+    CHECK(a.kind == SubtitleSelection::Kind::Embedded);
+    CHECK(b.kind == SubtitleSelection::Kind::Embedded);
+    CHECK(a.sid == 2);
+    CHECK(b.sid == 2);
+}
+
+TEST_CASE("subtitle: IsExternal=true streams are skipped during relative walk") {
+    std::vector<MediaStream> streams{
+        video(0),
+        sub_embedded(1),
+        sub_external_marked(2, "http://srv/ext.vtt"),  // IsExternal=true, External method
+        sub_embedded(3),
+    };
+    // Stream 3 should be relative index 2 (external 2 skipped).
+    auto r = resolve_subtitle(streams, 3,
+                              SubtitleUnresolvedFallback::AutoFallback);
+    CHECK(r.kind == SubtitleSelection::Kind::Embedded);
+    CHECK(r.sid == 2);
+
+    // Stream 2 itself goes through External path because of DeliveryMethod.
+    auto r2 = resolve_subtitle(streams, 2,
+                               SubtitleUnresolvedFallback::AutoFallback);
+    CHECK(r2.kind == SubtitleSelection::Kind::External);
+    CHECK(r2.url == "http://srv/ext.vtt");
+}

--- a/tests/web/connectivity_helper_test.js
+++ b/tests/web/connectivity_helper_test.js
@@ -1,0 +1,67 @@
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { loadScript } from "./helpers/load.js";
+import { makeWindow, makeJmpBus, lastSend, sendsOf } from "./helpers/mocks.js";
+
+function setup() {
+  const jmp = makeJmpBus();
+  const win = makeWindow({ jmp });
+  loadScript("connectivityHelper.js", win);
+  return { win, jmp, check: win.jmpCheckServerConnectivity };
+}
+
+test("exposes jmpCheckServerConnectivity as a function with .abort", () => {
+  const { check } = setup();
+  assert.equal(typeof check, "function");
+  assert.equal(typeof check.abort, "function");
+});
+
+test("success path: bus inbound resolves with baseUrl", async () => {
+  const { jmp, check } = setup();
+  const promise = check("http://example");
+  assert.deepEqual(lastSend(jmp, "overlay.checkServerConnectivity"), { url: "http://example" });
+
+  jmp.deliver("overlay.serverConnectivityResult", {
+    url: "http://example",
+    success: true,
+    baseUrl: "http://example/resolved",
+  });
+  const result = await promise;
+  assert.equal(result, "http://example/resolved");
+});
+
+test("failure path: bus inbound rejects", async () => {
+  const { jmp, check } = setup();
+  const promise = check("http://x");
+  jmp.deliver("overlay.serverConnectivityResult", { url: "http://x", success: false, baseUrl: "" });
+  await assert.rejects(promise, /Connection failed/);
+});
+
+test("stale-URL callback (mismatched URL) is ignored", async () => {
+  const { jmp, check } = setup();
+  const promise = check("http://current");
+  jmp.deliver("overlay.serverConnectivityResult", {
+    url: "http://previous",
+    success: true,
+    baseUrl: "ignored",
+  });
+
+  const sentinel = new Promise((r) => setTimeout(() => r("timeout"), 30));
+  const winner = await Promise.race([promise, sentinel]);
+  assert.equal(winner, "timeout");
+
+  jmp.deliver("overlay.serverConnectivityResult", {
+    url: "http://current",
+    success: true,
+    baseUrl: "resolved",
+  });
+  assert.equal(await promise, "resolved");
+});
+
+test("abort() emits overlay.cancelServerConnectivity and rejects the pending promise", async () => {
+  const { jmp, check } = setup();
+  const promise = check("http://x");
+  check.abort();
+  assert.equal(sendsOf(jmp, "overlay.cancelServerConnectivity").length, 1);
+  await assert.rejects(promise, /Connection cancelled/);
+});

--- a/tests/web/helpers/load.js
+++ b/tests/web/helpers/load.js
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import vm from "node:vm";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const webDir = resolve(here, "..", "..", "..", "src", "web");
+
+export function loadScript(relPath, sandbox) {
+  const src = readFileSync(resolve(webDir, relPath), "utf8");
+  if (!vm.isContext(sandbox)) vm.createContext(sandbox);
+  vm.runInContext(src, sandbox, { filename: relPath });
+  return sandbox;
+}

--- a/tests/web/helpers/mocks.js
+++ b/tests/web/helpers/mocks.js
@@ -1,0 +1,206 @@
+// Recording stub: returns a function that records each call's arguments
+// and returns whatever `impl` returns (or undefined).
+export function recorder(impl) {
+  const fn = (...args) => {
+    fn.calls.push(args);
+    return impl ? impl(...args) : undefined;
+  };
+  fn.calls = [];
+  return fn;
+}
+
+// Connect/disconnect-style signal slot.
+function makeSignal() {
+  const handlers = [];
+  const sig = (...args) => { for (const h of handlers.slice()) h(...args); };
+  sig.connect = (h) => { handlers.push(h); };
+  sig.disconnect = (h) => {
+    const i = handlers.indexOf(h);
+    if (i >= 0) handlers.splice(i, 1);
+  };
+  sig.emit = (...args) => sig(...args);
+  sig.handlers = handlers;
+  return sig;
+}
+
+// Build a bus mock matching window.jmp's contract.
+//
+// `bus.send` is a recorder so tests can assert on outbound traffic.
+// `bus.deliver(name, payload)` simulates inbound messages from C++ (the
+// test-side equivalent of g_bus.emit).
+export function makeJmpBus() {
+  const handlers = Object.create(null);
+  const bus = {
+    send: recorder(),
+    on(name, fn) { (handlers[name] = handlers[name] || []).push(fn); },
+    off(name, fn) {
+      const list = handlers[name];
+      if (!list) return;
+      const i = list.indexOf(fn);
+      if (i >= 0) list.splice(i, 1);
+    },
+    onMessage(name, payload) {
+      const list = handlers[name] || [];
+      for (const fn of list.slice()) fn(payload || {});
+    },
+    deliver(name, payload) {
+      bus.onMessage(name, payload);
+    },
+    _handlers: handlers,
+  };
+  return bus;
+}
+
+// api.player signal surface — what mpv-player-core's connectSignals/
+// disconnectSignals interacts with. native-shim wires these to bus inbound
+// messages in production; tests usually trigger the signals directly.
+export function makeApiPlayer() {
+  return {
+    playing: makeSignal(),
+    paused: makeSignal(),
+    finished: makeSignal(),
+    stopped: makeSignal(),
+    canceled: makeSignal(),
+    error: makeSignal(),
+    seeking: makeSignal(),
+    positionUpdate: makeSignal(),
+    updateDuration: makeSignal(),
+    buffering: makeSignal(),
+    stateChanged: makeSignal(),
+    videoPlaybackActive: makeSignal(),
+    windowVisible: makeSignal(),
+    onVideoRecangleChanged: makeSignal(),
+    onMetaData: makeSignal(),
+
+    _bufferedRanges: [],
+    getBufferedRanges() { return this._bufferedRanges; },
+    getPositionAsync(cb) { this._lastPositionCb = cb; },
+  };
+}
+
+// Build a vm-runnable sandbox that doubles as window/globalThis.
+export function makeWindow({ jmp, apiPlayer, document: docOverride } = {}) {
+  const win = {};
+  win.window = win;
+  win.globalThis = win;
+  win.console = { log: () => {}, warn: () => {}, error: () => {} };
+  win.setTimeout = (fn, ms, ...args) => setTimeout(fn, ms, ...args);
+  win.clearTimeout = (id) => clearTimeout(id);
+  win.setInterval = (fn, ms, ...args) => setInterval(fn, ms, ...args);
+  win.clearInterval = (id) => clearInterval(id);
+  win.Promise = Promise;
+  win.Date = Date;
+  win.Math = Math;
+  win.Number = Number;
+  win.Boolean = Boolean;
+  win.Array = Array;
+  win.Object = Object;
+  win.Error = Error;
+  win.JSON = JSON;
+  win.isNaN = isNaN;
+  win.document = docOverride || makeDocument();
+  if (jmp !== undefined) win.jmp = jmp;
+  if (apiPlayer) win.api = { player: apiPlayer };
+  return win;
+}
+
+export function makeDocument() {
+  return {
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    getElementById: () => null,
+    createElement: () => makeElement(),
+    body: makeElement(),
+  };
+}
+
+function makeElement() {
+  const el = {
+    style: {},
+    classList: {
+      add: () => {},
+      remove: () => {},
+      contains: () => false,
+    },
+    children: [],
+    appendChild: (c) => { el.children.push(c); return c; },
+    insertBefore: (c) => { el.children.unshift(c); return c; },
+    removeChild: () => {},
+    remove: () => {},
+    querySelector: () => null,
+    setAttribute: () => {},
+    addEventListener: () => {},
+    parentNode: null,
+  };
+  return el;
+}
+
+// Minimal jellyfin-web Events shim: trigger(target, name, args) → handlers.
+export function makeEvents() {
+  const map = new Map();
+  const ev = {
+    on: (target, name, fn) => {
+      const key = keyOf(target, name);
+      if (!map.has(key)) map.set(key, []);
+      map.get(key).push(fn);
+    },
+    off: (target, name, fn) => {
+      const list = map.get(keyOf(target, name));
+      if (!list) return;
+      const i = list.indexOf(fn);
+      if (i >= 0) list.splice(i, 1);
+    },
+    trigger: (target, name, args) => {
+      ev.triggers.push({ target, name, args });
+      const list = map.get(keyOf(target, name));
+      if (!list) return;
+      for (const fn of list.slice()) fn({ type: name, target }, ...(args || []));
+    },
+    triggers: [],
+  };
+  return ev;
+}
+
+function keyOf(target, name) {
+  return `${name}::${target ? "T" : "_"}`;
+}
+
+export function makeAppSettings({ aspectRatio = undefined } = {}) {
+  const store = new Map();
+  const settings = {
+    get: (k) => store.get(k),
+    set: (k, v) => { store.set(k, v); },
+    _store: store,
+  };
+  if (aspectRatio !== undefined) {
+    let val = aspectRatio;
+    settings.aspectRatio = (v) => {
+      if (v !== undefined) val = v;
+      return val;
+    };
+  }
+  return settings;
+}
+
+// Bring a sandbox-realm object into the outer realm so deepEqual works.
+function reify(v) {
+  if (v == null) return v;
+  return JSON.parse(JSON.stringify(v));
+}
+
+// Find the last `bus.send` call for a given message name (payload reified).
+export function lastSend(bus, name) {
+  for (let i = bus.send.calls.length - 1; i >= 0; i--) {
+    if (bus.send.calls[i][0] === name) return reify(bus.send.calls[i][1] || {});
+  }
+  return null;
+}
+
+// All `bus.send` payloads for a name (reified).
+export function sendsOf(bus, name) {
+  return bus.send.calls
+    .filter(c => c[0] === name)
+    .map(c => reify(c[1] || {}));
+}

--- a/tests/web/mpv_audio_player_test.js
+++ b/tests/web/mpv_audio_player_test.js
@@ -1,0 +1,158 @@
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { loadScript } from "./helpers/load.js";
+import {
+  makeWindow,
+  makeApiPlayer,
+  makeJmpBus,
+  makeEvents,
+  makeAppSettings,
+  lastSend,
+  sendsOf,
+} from "./helpers/mocks.js";
+
+function setup() {
+  const apiPlayer = makeApiPlayer();
+  const jmp = makeJmpBus();
+  const events = makeEvents();
+  const appSettings = makeAppSettings();
+  const win = makeWindow({ apiPlayer, jmp });
+  loadScript("mpv-player-core.js", win);
+  loadScript("mpv-audio-player.js", win);
+  const Audio = win._mpvAudioPlayer;
+  const audio = new Audio({
+    events,
+    appHost: { getDeviceProfile: () => Promise.resolve({ profileTag: "x" }) },
+    appSettings,
+  });
+  return { win, apiPlayer, jmp, events, appSettings, audio };
+}
+
+test("plugin metadata fields are set", () => {
+  const { audio } = setup();
+  assert.equal(audio.name, "MPV Audio Player");
+  assert.equal(audio.type, "mediaplayer");
+  assert.equal(audio.id, "mpvaudioplayer");
+  assert.equal(audio.syncPlayWrapAs, "htmlaudioplayer");
+  assert.equal(audio.useServerPlaybackInfoForAudio, true);
+});
+
+test("constructor wires MpvPlayerCore from window", () => {
+  const { win, audio } = setup();
+  assert.ok(audio._core instanceof win.MpvPlayerCore);
+  assert.equal(audio._core.player, audio);
+});
+
+test("canPlayMediaType is case-insensitive and only matches audio", () => {
+  const { audio } = setup();
+  assert.equal(audio.canPlayMediaType("Audio"), true);
+  assert.equal(audio.canPlayMediaType("audio"), true);
+  assert.equal(audio.canPlayMediaType("video"), false);
+  assert.equal(audio.canPlayMediaType(undefined), false);
+});
+
+test("supports advertises only PlaybackRate", () => {
+  const { audio } = setup();
+  assert.equal(audio.supports("PlaybackRate"), true);
+  assert.equal(audio.supports("SetAspectRatio"), false);
+});
+
+test("getDeviceProfile delegates to appHost when present", async () => {
+  const { audio } = setup();
+  const result = await audio.getDeviceProfile({}, {});
+  assert.equal(result.profileTag, "x");
+});
+
+test("getDeviceProfile returns {} when appHost has no getDeviceProfile", async () => {
+  const apiPlayer = makeApiPlayer();
+  const jmp = makeJmpBus();
+  const events = makeEvents();
+  const appSettings = makeAppSettings();
+  const win = makeWindow({ apiPlayer, jmp });
+  loadScript("mpv-player-core.js", win);
+  loadScript("mpv-audio-player.js", win);
+  const audio = new win._mpvAudioPlayer({ events, appHost: {}, appSettings });
+  const result = await audio.getDeviceProfile({}, {});
+  assert.equal(typeof result, "object");
+});
+
+test("setCurrentSrc emits player.load with null defaults (resolver auto-selects)", async () => {
+  const { apiPlayer, jmp, audio } = setup();
+
+  const p = audio.setCurrentSrc({
+    url: "http://stream/song.mp3",
+    playerStartPositionTicks: 50_000_000, // 5000ms
+    item: { Id: "abc" },
+  });
+  apiPlayer.playing.emit();
+  await p;
+
+  const load = lastSend(jmp, "player.load");
+  assert.equal(load.url, "http://stream/song.mp3");
+  assert.equal(load.startMs, 5000);
+  assert.equal(load.defaultAudioIdx, null);
+  assert.equal(load.defaultSubIdx, null);
+  assert.equal(load.item.Id, "abc");
+  assert.equal(audio._currentSrc, "http://stream/song.mp3");
+});
+
+test("play() resets state and connects signals before delegating to setCurrentSrc", async () => {
+  const { audio } = setup();
+  audio._core._duration = 1234;
+  // Don't fire `playing` — just probe state set up by play() itself.
+  audio.play({ url: "u", playerStartPositionTicks: 0, item: {} });
+  assert.equal(audio._started, false);
+  assert.equal(audio._core._currentTime, 0);
+  assert.equal(audio._core._duration, undefined);
+  assert.equal(audio._core._hasConnection, true);
+});
+
+test("stop without destroyPlayer pauses, fires stopped, clears src", async () => {
+  const { apiPlayer, jmp, events, audio } = setup();
+  const p1 = audio.play({ url: "u", playerStartPositionTicks: 0, item: {} });
+  apiPlayer.playing.emit();
+  await p1;
+
+  await audio.stop(false);
+
+  assert.ok(sendsOf(jmp, "player.pause").length >= 1);
+  assert.equal(events.triggers.filter(t => t.name === "stopped").length, 1);
+  assert.equal(audio.currentSrc(), null);
+});
+
+test("destroy emits player.stop, disconnects signals, clears duration", async () => {
+  const { apiPlayer, jmp, audio } = setup();
+  const p = audio.play({ url: "u", playerStartPositionTicks: 0, item: {} });
+  apiPlayer.playing.emit();
+  await p;
+  audio._core._duration = 1000;
+  audio.destroy();
+  assert.ok(sendsOf(jmp, "player.stop").length >= 1);
+  assert.equal(audio._core._hasConnection, false);
+  assert.equal(audio._core._duration, undefined);
+});
+
+test("onPlaying handler fires 'playing' event and starts time update timer", () => {
+  const { events, audio } = setup();
+  audio._core.handlers.onPlaying();
+  assert.equal(events.triggers.filter(t => t.name === "playing").length, 1);
+  assert.ok(audio._core._timeUpdateTimer);
+  audio._core.stopTimeUpdateTimer();
+});
+
+test("onError handler fires 'error' with mediadecodeerror payload", () => {
+  const { events, audio } = setup();
+  audio._core.handlers.onError(new Error("boom"));
+  const errs = events.triggers.filter(t => t.name === "error");
+  assert.equal(errs.length, 1);
+  assert.equal(errs[0].args[0].type, "mediadecodeerror");
+});
+
+test("onPause handler fires 'pause' and stops timer", () => {
+  const { events, audio } = setup();
+  audio._core.startTimeUpdateTimer();
+  audio._core.handlers.onPause();
+  assert.equal(events.triggers.filter(t => t.name === "pause").length, 1);
+  assert.equal(audio._core._timeUpdateTimer, null);
+  assert.equal(audio._core._paused, true);
+});

--- a/tests/web/mpv_player_core_test.js
+++ b/tests/web/mpv_player_core_test.js
@@ -1,0 +1,226 @@
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { loadScript } from "./helpers/load.js";
+import {
+  makeWindow,
+  makeJmpBus,
+  makeApiPlayer,
+  makeEvents,
+  makeAppSettings,
+  lastSend,
+  sendsOf,
+} from "./helpers/mocks.js";
+
+function setup(opts = {}) {
+  const jmp = makeJmpBus();
+  const apiPlayer = makeApiPlayer();
+  const events = makeEvents();
+  const appSettings = makeAppSettings(opts.appSettings);
+  const win = makeWindow({ jmp, apiPlayer });
+  loadScript("mpv-player-core.js", win);
+  const Core = win.MpvPlayerCore;
+  const core = new Core(events, appSettings);
+  core.player = { id: "test-player" };
+  return { win, jmp, apiPlayer, events, appSettings, Core, core };
+}
+
+test("constructor uses default volume of 100 when nothing saved", () => {
+  const { jmp, core } = setup();
+  assert.equal(core.getVolume(), 100);
+  assert.deepEqual(lastSend(jmp, "player.setVolume"), { volume: 100 });
+});
+
+test("constructor reads saved volume from appSettings", () => {
+  const jmp = makeJmpBus();
+  const apiPlayer = makeApiPlayer();
+  const events = makeEvents();
+  const appSettings = makeAppSettings();
+  appSettings.set("volume", 0.4);
+  const win = makeWindow({ jmp, apiPlayer });
+  loadScript("mpv-player-core.js", win);
+  const core = new win.MpvPlayerCore(events, appSettings);
+  assert.equal(core.getVolume(), 40);
+  assert.deepEqual(lastSend(jmp, "player.setVolume"), { volume: 40 });
+});
+
+test("constructor with save=false suppresses volumechange event", () => {
+  const { events } = setup();
+  assert.equal(events.triggers.filter(t => t.name === "volumechange").length, 0);
+});
+
+test("pause/play/unpause emit player.* messages", () => {
+  const { jmp, core } = setup();
+  core.pause();
+  core._paused = true;
+  core.resume();
+  assert.equal(core._paused, false);
+  core.unpause();
+  assert.equal(sendsOf(jmp, "player.pause").length, 1);
+  assert.equal(sendsOf(jmp, "player.play").length, 2);
+});
+
+test("setVolume(50) sends player.setVolume, persists, fires volumechange", () => {
+  const { jmp, events, appSettings, core } = setup();
+  jmp.send.calls.length = 0;
+  core.setVolume(50);
+  assert.deepEqual(lastSend(jmp, "player.setVolume"), { volume: 50 });
+  assert.equal(appSettings.get("volume"), 0.5);
+  assert.equal(events.triggers.filter(t => t.name === "volumechange").length, 1);
+});
+
+test("setVolume(val, false) skips persist and event", () => {
+  const { jmp, events, appSettings, core } = setup();
+  jmp.send.calls.length = 0;
+  core.setVolume(75, false);
+  assert.deepEqual(lastSend(jmp, "player.setVolume"), { volume: 75 });
+  assert.equal(appSettings.get("volume"), undefined);
+  assert.equal(events.triggers.filter(t => t.name === "volumechange").length, 0);
+});
+
+test("setVolume ignores NaN", () => {
+  const { jmp, core } = setup();
+  jmp.send.calls.length = 0;
+  core.setVolume("not-a-number");
+  assert.equal(sendsOf(jmp, "player.setVolume").length, 0);
+});
+
+test("volumeUp/volumeDown clamp to [0, 100]", () => {
+  const { core } = setup();
+  core.setVolume(99);
+  core.volumeUp();
+  assert.equal(core.getVolume(), 100);
+  core.volumeUp();
+  assert.equal(core.getVolume(), 100);
+
+  core.setVolume(1);
+  core.volumeDown();
+  assert.equal(core.getVolume(), 0);
+  core.volumeDown();
+  assert.equal(core.getVolume(), 0);
+});
+
+test("setMute(true) sends player.setMuted and fires volumechange", () => {
+  const { jmp, events, core } = setup();
+  core.setMute(true);
+  assert.deepEqual(lastSend(jmp, "player.setMuted"), { muted: true });
+  assert.equal(core.isMuted(), true);
+  assert.equal(events.triggers.filter(t => t.name === "volumechange").length, 1);
+});
+
+test("setMute(true, false) suppresses event but still sends", () => {
+  const { jmp, events, core } = setup();
+  core.setMute(true, false);
+  assert.deepEqual(lastSend(jmp, "player.setMuted"), { muted: true });
+  assert.equal(events.triggers.filter(t => t.name === "volumechange").length, 0);
+});
+
+test("setPlaybackRate sends rate as plain double (no scaling)", () => {
+  const { jmp, core } = setup();
+  core.setPlaybackRate(1.5);
+  assert.deepEqual(lastSend(jmp, "player.setRate"), { rate: 1.5 });
+  assert.equal(core.getPlaybackRate(), 1.5);
+});
+
+test("getPlaybackRate falls back to 1 when unset", () => {
+  const { core } = setup();
+  core._playRate = 0;
+  assert.equal(core.getPlaybackRate(), 1);
+});
+
+test("currentTime(val) sends player.seek with positionMs", () => {
+  const { jmp, core } = setup();
+  core.currentTime(42);
+  assert.deepEqual(lastSend(jmp, "player.seek"), { positionMs: 42 });
+  assert.equal(core._currentTime, 42);
+});
+
+test("currentTime() returns last known position", () => {
+  const { core } = setup();
+  core._currentTime = 1234;
+  assert.equal(core.currentTime(), 1234);
+});
+
+test("currentTimeAsync resolves via api.player.getPositionAsync", async () => {
+  const { apiPlayer, core } = setup();
+  // The mock's getPositionAsync stashes the cb; resolve it manually.
+  apiPlayer.getPositionAsync = (cb) => cb(987);
+  const got = await core.currentTimeAsync();
+  assert.equal(got, 987);
+});
+
+test("getBufferedRanges proxies api.player.getBufferedRanges", () => {
+  const { apiPlayer, core } = setup();
+  apiPlayer._bufferedRanges = [{ start: 0, end: 10 }];
+  const got = core.getBufferedRanges();
+  assert.equal(got.length, 1);
+  assert.equal(got[0].start, 0);
+});
+
+test("seekable reflects whether _duration is set", () => {
+  const { core } = setup();
+  assert.equal(core.seekable(), false);
+  core._duration = 12345;
+  assert.equal(core.seekable(), true);
+});
+
+test("duration returns _duration or null", () => {
+  const { core } = setup();
+  assert.equal(core.duration(), null);
+  core._duration = 5000;
+  assert.equal(core.duration(), 5000);
+});
+
+test("connectSignals wires handlers; signals deliver", () => {
+  const { apiPlayer, core } = setup();
+  let playingCalled = 0;
+  core.handlers.onPlaying = () => { playingCalled++; };
+  core.handlers.onTimeUpdate = () => {};
+  core.handlers.onSeeking = () => {};
+  core.handlers.onEnded = () => {};
+  core.handlers.onPause = () => {};
+  core.handlers.onDuration = () => {};
+  core.handlers.onError = () => {};
+  core.connectSignals();
+  apiPlayer.playing.emit();
+  apiPlayer.playing.emit();
+  assert.equal(playingCalled, 2);
+
+  core.disconnectSignals();
+  apiPlayer.playing.emit();
+  assert.equal(playingCalled, 2);
+});
+
+test("connectSignals is idempotent", () => {
+  const { apiPlayer, core } = setup();
+  for (const k of Object.keys(core.handlers)) core.handlers[k] = () => {};
+  core.connectSignals();
+  core.connectSignals();
+  assert.equal(apiPlayer.playing.handlers.length, 1);
+});
+
+test("startTimeUpdateTimer is a no-op when already running; stop clears it", () => {
+  const { core } = setup();
+  core.startTimeUpdateTimer();
+  const first = core._timeUpdateTimer;
+  core.startTimeUpdateTimer();
+  assert.equal(core._timeUpdateTimer, first);
+  core.stopTimeUpdateTimer();
+  assert.equal(core._timeUpdateTimer, null);
+});
+
+test("getSupportedPlaybackRates returns ascending name/id pairs", () => {
+  const { core } = setup();
+  const rates = core.getSupportedPlaybackRates();
+  assert.equal(rates[0].id, 0.5);
+  assert.equal(rates[0].name, "0.5x");
+  assert.ok(rates.every(r => typeof r.id === "number" && typeof r.name === "string"));
+});
+
+test("saveVolume(0) does NOT persist (truthy guard)", () => {
+  const { appSettings, core } = setup();
+  appSettings._store.delete("volume");
+  core.saveVolume(0);
+  assert.equal(appSettings.get("volume"), undefined);
+  core.saveVolume(0.7);
+  assert.equal(appSettings.get("volume"), 0.7);
+});

--- a/tests/web/mpv_video_player_test.js
+++ b/tests/web/mpv_video_player_test.js
@@ -1,0 +1,201 @@
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { loadScript } from "./helpers/load.js";
+import {
+  makeWindow,
+  makeApiPlayer,
+  makeJmpBus,
+  makeEvents,
+  makeAppSettings,
+  lastSend,
+  sendsOf,
+} from "./helpers/mocks.js";
+
+function setup({ aspectRatio } = {}) {
+  const apiPlayer = makeApiPlayer();
+  const jmp = makeJmpBus();
+  const events = makeEvents();
+  const appSettings = makeAppSettings({ aspectRatio });
+  const win = makeWindow({ apiPlayer, jmp });
+  loadScript("mpv-player-core.js", win);
+  loadScript("mpv-video-player.js", win);
+  const Video = win._mpvVideoPlayer;
+  const video = new Video({
+    events,
+    loading: { show: () => {}, hide: () => {} },
+    appRouter: { showVideoOsd: () => {} },
+    globalize: { translate: (k) => k },
+    appHost: {},
+    appSettings,
+    confirm: () => {},
+    dashboard: undefined,
+  });
+  return { win, apiPlayer, jmp, events, appSettings, video, Video };
+}
+
+test("plugin metadata fields are set", () => {
+  const { video } = setup();
+  assert.equal(video.name, "MPV Video Player");
+  assert.equal(video.type, "mediaplayer");
+  assert.equal(video.id, "mpvvideoplayer");
+  assert.equal(video.priority, -1);
+  assert.equal(video.isLocalPlayer, true);
+});
+
+test("constructor sets window._mpvVideoPlayerInstance to itself", () => {
+  const { win, video } = setup();
+  assert.equal(win._mpvVideoPlayerInstance, video);
+});
+
+test("canPlayMediaType only matches video", () => {
+  const { video } = setup();
+  assert.equal(video.canPlayMediaType("Video"), true);
+  assert.equal(video.canPlayMediaType("audio"), false);
+});
+
+test("supports advertises PlaybackRate and SetAspectRatio", () => {
+  const { video } = setup();
+  assert.equal(video.supports("PlaybackRate"), true);
+  assert.equal(video.supports("SetAspectRatio"), true);
+  assert.equal(video.supports("AirPlay"), false);
+});
+
+test("getAspectRatio prefers appSettings.aspectRatio() function", () => {
+  const { video } = setup({ aspectRatio: "cover" });
+  assert.equal(video.getAspectRatio(), "cover");
+});
+
+test("getAspectRatio falls back to _currentAspectRatio (v10.10.7)", () => {
+  const { video } = setup();
+  assert.equal(video.getAspectRatio(), "auto");
+  video._currentAspectRatio = "fill";
+  assert.equal(video.getAspectRatio(), "fill");
+});
+
+test("setAspectRatio writes through appSettings.aspectRatio() and emits player.setAspectRatio", () => {
+  const { jmp, appSettings, video } = setup({ aspectRatio: "auto" });
+  video.setAspectRatio("cover");
+  assert.equal(appSettings.aspectRatio(), "cover");
+  assert.deepEqual(lastSend(jmp, "player.setAspectRatio"), { mode: "cover" });
+});
+
+test("setAspectRatio falls back to _currentAspectRatio in v10.10.7 mode", () => {
+  const { jmp, video } = setup();
+  video.setAspectRatio("fill");
+  assert.equal(video._currentAspectRatio, "fill");
+  assert.deepEqual(lastSend(jmp, "player.setAspectRatio"), { mode: "fill" });
+});
+
+test("setCurrentSrc emits player.setAspectRatio then player.load with full mediaSource", () => {
+  const { apiPlayer, jmp, video } = setup({ aspectRatio: "auto" });
+  const p = video.setCurrentSrc({
+    url: "http://stream/x.mkv",
+    playerStartPositionTicks: 0,
+    item: { Id: "vid" },
+    mediaSource: { MediaStreams: [], DefaultAudioStreamIndex: -1, DefaultSubtitleStreamIndex: -1 },
+  });
+  // Resolve immediately so the test isn't pending.
+  apiPlayer.playing.emit();
+  return p.then(() => {
+    assert.deepEqual(lastSend(jmp, "player.setAspectRatio"), { mode: "auto" });
+    const load = lastSend(jmp, "player.load");
+    assert.equal(load.url, "http://stream/x.mkv");
+    assert.equal(load.startMs, 0);
+    assert.equal(load.defaultAudioIdx, -1);
+    assert.equal(load.defaultSubIdx, -1);
+    assert.ok(load.mediaSource);
+  });
+});
+
+test("setCurrentSrc passes raw Jellyfin default audio index (no relative translation)", () => {
+  const { apiPlayer, jmp, video } = setup({ aspectRatio: "auto" });
+  const p = video.setCurrentSrc({
+    url: "u",
+    item: {},
+    mediaSource: {
+      MediaStreams: [],
+      DefaultAudioStreamIndex: 3,
+      DefaultSubtitleStreamIndex: -1,
+    },
+  });
+  apiPlayer.playing.emit();
+  return p.then(() => {
+    assert.equal(lastSend(jmp, "player.load").defaultAudioIdx, 3);
+  });
+});
+
+test("setSubtitleStreamIndex(null) sends jellyfinIndex: null", () => {
+  const { jmp, video } = setup();
+  video.setSubtitleStreamIndex(null);
+  assert.deepEqual(lastSend(jmp, "player.selectSubtitle"), { jellyfinIndex: null });
+});
+
+test("setSubtitleStreamIndex(-1) sends jellyfinIndex: null", () => {
+  const { jmp, video } = setup();
+  video.setSubtitleStreamIndex(-1);
+  assert.deepEqual(lastSend(jmp, "player.selectSubtitle"), { jellyfinIndex: null });
+});
+
+test("setSubtitleStreamIndex passes Jellyfin index unchanged (resolver in C++)", () => {
+  const { jmp, video } = setup();
+  video.setSubtitleStreamIndex(4);
+  assert.deepEqual(lastSend(jmp, "player.selectSubtitle"), { jellyfinIndex: 4 });
+});
+
+test("resetSubtitleOffset emits player.setSubtitleOffset(0)", () => {
+  const { jmp, video } = setup();
+  video.resetSubtitleOffset();
+  assert.deepEqual(lastSend(jmp, "player.setSubtitleOffset"), { seconds: 0 });
+});
+
+test("setSubtitleOffset sends seconds (no scaling)", () => {
+  const { jmp, video } = setup();
+  video.setSubtitleOffset(1.234);
+  assert.deepEqual(lastSend(jmp, "player.setSubtitleOffset"), { seconds: 1.234 });
+});
+
+test("setAudioStreamIndex(null) sends jellyfinIndex: null", () => {
+  const { jmp, video } = setup();
+  video.setAudioStreamIndex(null);
+  assert.deepEqual(lastSend(jmp, "player.selectAudio"), { jellyfinIndex: null });
+});
+
+test("setAudioStreamIndex passes Jellyfin index unchanged", () => {
+  const { jmp, video } = setup();
+  video.setAudioStreamIndex(2);
+  assert.deepEqual(lastSend(jmp, "player.selectAudio"), { jellyfinIndex: 2 });
+});
+
+test("onPlaying handler triggers player.setVideoRectangle", () => {
+  const { jmp, video } = setup();
+  video._videoDialog = null;
+  video._currentPlayOptions = { fullscreen: false };
+  video._core.handlers.onPlaying();
+  assert.deepEqual(lastSend(jmp, "player.setVideoRectangle"), { x: 0, y: 0, w: 0, h: 0 });
+});
+
+test("setPlaybackRate emits player.setRate and input.rateChanged", () => {
+  const { jmp, video } = setup();
+  video.setPlaybackRate(2);
+  assert.deepEqual(lastSend(jmp, "player.setRate"), { rate: 2 });
+  assert.deepEqual(lastSend(jmp, "input.rateChanged"), { rate: 2 });
+});
+
+test("toggleFullscreen sends fullscreen.toggle", () => {
+  const { jmp, video } = setup();
+  video.toggleFullscreen();
+  assert.equal(sendsOf(jmp, "fullscreen.toggle").length, 1);
+});
+
+test("getStats returns categories array", async () => {
+  const { video } = setup();
+  const stats = await video.getStats();
+  assert.equal(Array.isArray(stats.categories), true);
+});
+
+test("static getSupportedFeatures includes PlaybackRate and SetAspectRatio", () => {
+  const { Video } = setup();
+  const features = Video.getSupportedFeatures();
+  assert.ok(features.includes("PlaybackRate"));
+  assert.ok(features.includes("SetAspectRatio"));
+});


### PR DESCRIPTION
Replaces the per-method renderer↔browser RPC plumbing with a single namespaced message bus, and moves mpv-specific track logic out of JS and into C++.