### PR TITLE
Fix: Use emby-select in Client Settings

### DIFF
--- a/src/web/client-settings.js
+++ b/src/web/client-settings.js
@@ -117,12 +117,9 @@
 
                 if (setting.options) {
                     container.className = 'selectContainer';
-                    const labelText = document.createElement('label');
-                    labelText.className = 'inputLabel';
-                    labelText.textContent = setting.displayName;
-                    container.appendChild(labelText);
                     const control = document.createElement('select');
-                    control.className = 'emby-select-withcolor emby-select';
+                    control.setAttribute('is', 'emby-select');
+                    control.className = 'emby-select-withcolor';
                     control.setAttribute('label', setting.displayName);
                     for (const option of setting.options) {
                         const val = typeof option === 'string' ? option : option.value;


### PR DESCRIPTION
Added the missing dropdown arrows in User Settings under Client Settings.

Before: 
<img width="827" height="690" alt="image" src="https://github.com/user-attachments/assets/b8f17de1-dad0-4695-a578-8f873d4c8be0" />


After: 
<img width="836" height="703" alt="image" src="https://github.com/user-attachments/assets/faf4a289-5e0e-4b53-b12a-032d2fd02700" />
