### PR TITLE
Toggle titlebar theming

### DIFF
--- a/src/browser/overlay_browser.cpp
+++ b/src/browser/overlay_browser.cpp
@@ -114,6 +114,7 @@ static void applySettingValue(const std::string& section, const std::string& key
     else if (key == "audioPassthrough") s.setAudioPassthrough(value);
     else if (key == "audioExclusive") s.setAudioExclusive(value == "true");
     else if (key == "audioChannels") s.setAudioChannels(value);
+    else if (key == "titlebarThemeColor") s.setTitlebarThemeColor(value == "true");
     else if (key == "logLevel") s.setLogLevel(value);
     else LOG_WARN(LOG_CEF, "Unknown setting key: {}.{}", section.c_str(), key.c_str());
     s.saveAsync();

--- a/src/browser/web_browser.cpp
+++ b/src/browser/web_browser.cpp
@@ -62,6 +62,7 @@ static void applySettingValue(const std::string& section, const std::string& key
     else if (key == "audioPassthrough") s.setAudioPassthrough(value);
     else if (key == "audioExclusive") s.setAudioExclusive(value == "true");
     else if (key == "audioChannels") s.setAudioChannels(value);
+    else if (key == "titlebarThemeColor") s.setTitlebarThemeColor(value == "true");
     else if (key == "logLevel") s.setLogLevel(value);
     else LOG_WARN(LOG_CEF, "Unknown setting key: {}.{}", section.c_str(), key.c_str());
     s.saveAsync();

--- a/src/platform/wayland.cpp
+++ b/src/platform/wayland.cpp
@@ -1117,9 +1117,8 @@ static bool wl_init(mpv_handle* mpv) {
         g_platform.shared_texture_supported = false;
     }
 
-    // KDE titlebar color — matches the loading screen background
+    // KDE titlebar color — use system theme color until changed by wl_set_titlebar_color(...)
     wl_init_kde_palette();
-    wl_set_titlebar_color(kBgColor.r, kBgColor.g, kBgColor.b);
 
     // Start input thread (input layer owns it)
     input::wayland::start_input_thread();

--- a/src/titlebar_color.h
+++ b/src/titlebar_color.h
@@ -9,7 +9,10 @@
 class TitlebarColor {
 public:
     TitlebarColor(Platform& platform, bool enabled)
-        : platform_(platform), enabled_(enabled) {}
+        : platform_(platform), enabled_(enabled) {
+            if(enabled)
+                platform_.set_titlebar_color(kBgColor.r, kBgColor.g, kBgColor.b);
+        }
 
     void onThemeColor(const std::string& color) {
         std::fprintf(stderr, "TitlebarColor::onThemeColor enabled=%d unlocked=%d color=%s\n",

--- a/src/web/native-shim.js
+++ b/src/web/native-shim.js
@@ -99,6 +99,7 @@
             },
             advanced: {
                 transparentTitlebar: _savedSettings.transparentTitlebar !== false,
+                titlebarThemeColor: _savedSettings.titlebarThemeColor !== false,
                 logLevel: _savedSettings.logLevel || ''
             }
         },
@@ -136,6 +137,15 @@
             key: 'transparentTitlebar',
             displayName: 'Transparent Titlebar',
             help: 'Overlay traffic light buttons on the window content instead of a separate titlebar. Requires restart.'
+        });
+    }
+
+    // Linux-only: titlebar theme color toggle
+    if (navigator.platform.startsWith('Linux')) {
+        jmpInfo.settingsDescriptions.advanced.unshift({
+            key: 'titlebarThemeColor',
+            displayName: 'Titlebar Theme Color',
+            help: 'Set titlebar color to match Jellyfin theme'
         });
     }
 


### PR DESCRIPTION
Added option to disable titlebar color theming on wayland. When disabled it uses current system theme.

Related issue: #76 

Settings:
<img width="379" height="102" alt="image" src="https://github.com/user-attachments/assets/e0b7b5ef-cdfa-428d-8160-8e7bba9617b4" />

Examples:
<img width="1288" height="186" alt="image" src="https://github.com/user-attachments/assets/69532f88-6129-4b59-81ff-b138766d994c" />
<img width="1288" height="186" alt="image" src="https://github.com/user-attachments/assets/075319f3-53a7-4fd7-ae8f-0b578163a15a" />
<img width="1288" height="186" alt="image" src="https://github.com/user-attachments/assets/4f42e1dc-4a63-46fd-8590-4b08e8a54f9b" />



