### PR TITLE
macos: implement edit context menu

### DIFF
--- a/src/input/input_macos.mm
+++ b/src/input/input_macos.mm
@@ -7,6 +7,8 @@
 #import <Cocoa/Cocoa.h>
 #include <mach/mach_time.h>
 
+#include "include/cef_browser.h"
+#include "include/cef_frame.h"
 #include "include/internal/cef_types.h"
 
 #include <atomic>
@@ -456,6 +458,54 @@ static void fill_key_event_from_nsevent(input::KeyEvent& e, NSEvent* event) {
     LOG_INFO(LOG_PLATFORM, "[INPUT] resignFirstResponder");
     input::dispatch_keyboard_focus(false);
     return [super resignFirstResponder];
+}
+
+// --- Edit commands ---
+//
+// Without an Edit menu, AppKit never sends copy:/paste:/etc. through the
+// responder chain, so Cmd+C/V/X/Z/A silently do nothing.
+// Forward each action to the active CEF browser's focused frame.
+
+- (IBAction)undo:(id)sender {
+    (void)sender;
+    auto browser = input::active_browser();
+    if (!browser) return;
+    if (auto frame = browser->GetFocusedFrame()) frame->Undo();
+}
+
+- (IBAction)redo:(id)sender {
+    (void)sender;
+    auto browser = input::active_browser();
+    if (!browser) return;
+    if (auto frame = browser->GetFocusedFrame()) frame->Redo();
+}
+
+- (IBAction)cut:(id)sender {
+    (void)sender;
+    auto browser = input::active_browser();
+    if (!browser) return;
+    if (auto frame = browser->GetFocusedFrame()) frame->Cut();
+}
+
+- (IBAction)copy:(id)sender {
+    (void)sender;
+    auto browser = input::active_browser();
+    if (!browser) return;
+    if (auto frame = browser->GetFocusedFrame()) frame->Copy();
+}
+
+- (IBAction)paste:(id)sender {
+    (void)sender;
+    auto browser = input::active_browser();
+    if (!browser) return;
+    if (auto frame = browser->GetFocusedFrame()) frame->Paste();
+}
+
+- (IBAction)selectAll:(id)sender {
+    (void)sender;
+    auto browser = input::active_browser();
+    if (!browser) return;
+    if (auto frame = browser->GetFocusedFrame()) frame->SelectAll();
 }
 
 @end

--- a/src/platform/macos.mm
+++ b/src/platform/macos.mm
@@ -912,7 +912,7 @@ static void macos_early_init() {
 
     [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
 
-    // Menu bar: About, separator, Quit
+    // Menu bar: App (About, Quit) + Edit (standard editing shortcuts)
     g_app_menu_target = [[JellyfinAppMenuTarget alloc] init];
 
     NSMenu* menubar = [[NSMenu alloc] init];
@@ -931,6 +931,33 @@ static void macos_early_init() {
                                                 action:@selector(terminate:)
                                          keyEquivalent:@"q"]];
     [appMenuItem setSubmenu:appMenu];
+
+    // Edit menu
+    NSMenuItem* editMenuItem = [[NSMenuItem alloc] init];
+    [menubar addItem:editMenuItem];
+    NSMenu* editMenu = [[NSMenu alloc] initWithTitle:@"Edit"];
+    [editMenu addItem:[[NSMenuItem alloc] initWithTitle:@"Undo"
+                                                 action:@selector(undo:)
+                                          keyEquivalent:@"z"]];
+    [editMenu addItem:[[NSMenuItem alloc] initWithTitle:@"Redo"
+                                                 action:@selector(redo:)
+                                          keyEquivalent:@"Z"]];
+    [editMenu addItem:[NSMenuItem separatorItem]];
+    [editMenu addItem:[[NSMenuItem alloc] initWithTitle:@"Cut"
+                                                 action:@selector(cut:)
+                                          keyEquivalent:@"x"]];
+    [editMenu addItem:[[NSMenuItem alloc] initWithTitle:@"Copy"
+                                                 action:@selector(copy:)
+                                          keyEquivalent:@"c"]];
+    [editMenu addItem:[[NSMenuItem alloc] initWithTitle:@"Paste"
+                                                 action:@selector(paste:)
+                                          keyEquivalent:@"v"]];
+    [editMenu addItem:[NSMenuItem separatorItem]];
+    [editMenu addItem:[[NSMenuItem alloc] initWithTitle:@"Select All"
+                                                 action:@selector(selectAll:)
+                                          keyEquivalent:@"a"]];
+    [editMenuItem setSubmenu:editMenu];
+
     [NSApp setMainMenu:menubar];
 
     [NSApp finishLaunching];


### PR DESCRIPTION
We need a standard edit context menu under macOS so that we can route those operations to the active CEF frame that actually does the copy/paste operations.

Fixes #292