### PR TITLE
macos: render About in the active macOS browser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -495,6 +495,7 @@ set(JS_SHIMS
     ${CMAKE_SOURCE_DIR}/src/web/mpv-audio-player.js
     ${CMAKE_SOURCE_DIR}/src/web/input-plugin.js
     ${CMAKE_SOURCE_DIR}/src/web/client-settings.js
+    ${CMAKE_SOURCE_DIR}/src/web/about.js
     ${CMAKE_SOURCE_DIR}/src/web/context-menu.js
 )
 set(EMBEDDED_JS_HEADER ${CMAKE_BINARY_DIR}/generated/embedded_js.h)

--- a/src/browser/about_browser.cpp
+++ b/src/browser/about_browser.cpp
@@ -1,7 +1,10 @@
 #include "about_browser.h"
 #include "app_menu.h"
 #include "browsers.h"
+#include "overlay_browser.h"
+#include "web_browser.h"
 #include "../common.h"
+#include "../cef/resource_handler.h"
 #include "../mpv/event.h"
 #include "logging.h"
 #include "../input/dispatch.h"
@@ -44,6 +47,7 @@ int safe_lh() {
     int ph = safe_ph();
     return static_cast<int>(std::lround(ph / s));
 }
+
 }
 
 CefRefPtr<CefDictionaryValue> AboutBrowser::injectionProfile() {
@@ -93,6 +97,21 @@ AboutBrowser::AboutBrowser()
 }
 
 void AboutBrowser::open() {
+#ifdef __APPLE__
+    CefRefPtr<CefBrowser> target = input::active_browser();
+    if (!target && g_overlay_browser) target = g_overlay_browser->browser();
+    if (!target && g_web_browser) target = g_web_browser->browser();
+    CefRefPtr<CefFrame> frame = target ? target->GetMainFrame() : nullptr;
+    if (!frame) {
+        LOG_WARN(LOG_CEF, "AboutBrowser::open: no live browser available on macOS");
+        return;
+    }
+    input::set_active_browser(target);
+    frame->ExecuteJavaScript(
+        "if(window._nativeShowAbout) window._nativeShowAbout(" + buildAboutDataJson() + ");",
+        frame->GetURL(), 0);
+    return;
+#else
     if (g_about_browser) {
         LOG_INFO(LOG_CEF, "AboutBrowser::open: already open, ignoring");
         return;
@@ -105,11 +124,7 @@ void AboutBrowser::open() {
     CefWindowInfo wi;
     wi.SetAsWindowless(0);
     wi.shared_texture_enabled = g_platform.shared_texture_supported;
-#ifdef __APPLE__
-    wi.external_begin_frame_enabled = true;
-#else
     wi.external_begin_frame_enabled = false;
-#endif
     CefBrowserSettings bs;
     bs.background_color = 0;
     bs.windowless_frame_rate = g_display_hz.load(std::memory_order_relaxed);
@@ -117,6 +132,7 @@ void AboutBrowser::open() {
     CefBrowserHost::CreateBrowser(wi, g_about_browser->client_,
                                   "app://resources/about.html", bs,
                                   injectionProfile(), nullptr);
+#endif
 }
 
 bool AboutBrowser::handleMessage(const std::string& name,

--- a/src/browser/about_browser.h
+++ b/src/browser/about_browser.h
@@ -8,11 +8,13 @@
 // is a no-op if a panel is already up; otherwise it allocates the singleton,
 // creates the CEF browser at app://resources/about.html, and hands it input.
 //
-// On dismiss (aboutDismiss IPC), the instance restores input to whatever
-// browser had it before, hides the platform subsurface, and closes the CEF
-// browser. OnBeforeClose nulls g_about_browser and posts a deferred
-// self-delete on the CEF UI thread so the instance is freed after the
-// callback returns rather than mid-invocation.
+// On macOS, AboutBrowser::open() injects the panel into the currently active
+// browser instead of creating a separate CEF browser.
+//
+// On dismiss (aboutDismiss IPC), the standalone path restores input to the
+// previous browser, hides the platform subsurface, and closes the About
+// browser. OnBeforeClose nulls g_about_browser and posts a deferred self-delete
+// on the CEF UI thread so the instance is freed after the callback returns.
 class AboutBrowser {
 public:
     static void open();

--- a/src/browser/overlay_browser.cpp
+++ b/src/browser/overlay_browser.cpp
@@ -131,9 +131,15 @@ CefRefPtr<CefDictionaryValue> OverlayBrowser::injectionProfile() {
         "saveServerUrl", "navigateMain", "dismissOverlay",
         "checkServerConnectivity", "cancelServerConnectivity",
         "overlayFadeComplete",
+#ifdef __APPLE__
+        "aboutOpenPath", "aboutDismiss",
+#endif
         "menuItemSelected", "menuDismissed",
     };
     static const char* const kScripts[] = {
+#ifdef __APPLE__
+        "about.js",
+#endif
         "context-menu.js",
     };
     CefRefPtr<CefListValue> fns = CefListValue::Create();
@@ -205,6 +211,18 @@ bool OverlayBrowser::handleMessage(const std::string& name,
         std::string url = args->GetString(0).ToString();
         Settings::instance().setServerUrl(url);
         Settings::instance().saveAsync();
+#ifdef __APPLE__
+    } else if (name == "aboutOpenPath") {
+        std::string path = args->GetString(0).ToString();
+        if (path.empty()) {
+            LOG_WARN(LOG_CEF, "aboutOpenPath: empty path, ignoring");
+            return true;
+        }
+        if (g_platform.open_external_url)
+            g_platform.open_external_url("file://" + path);
+    } else if (name == "aboutDismiss") {
+        return true;
+#endif
     } else if (name == "setSettingValue") {
         std::string section = args->GetString(0).ToString();
         std::string key = args->GetString(1).ToString();

--- a/src/browser/web_browser.cpp
+++ b/src/browser/web_browser.cpp
@@ -90,6 +90,9 @@ CefRefPtr<CefDictionaryValue> WebBrowser::injectionProfile() {
         "notifyRateChange",
         "appExit", "setSettingValue", "themeColor",
         "setOsdVisible", "setCursorVisible", "toggleFullscreen",
+#ifdef __APPLE__
+        "aboutOpenPath", "aboutDismiss",
+#endif
         "menuItemSelected", "menuDismissed",
     };
     static const char* const kScripts[] = {
@@ -99,6 +102,9 @@ CefRefPtr<CefDictionaryValue> WebBrowser::injectionProfile() {
         "mpv-audio-player.js",
         "input-plugin.js",
         "client-settings.js",
+#ifdef __APPLE__
+        "about.js",
+#endif
         "context-menu.js",
     };
 
@@ -135,6 +141,21 @@ WebBrowser::WebBrowser(RenderTarget target, int w, int h, int pw, int ph)
 bool WebBrowser::handleMessage(const std::string& name,
                                CefRefPtr<CefListValue> args,
                                CefRefPtr<CefBrowser> browser) {
+#ifdef __APPLE__
+    if (name == "aboutOpenPath") {
+        std::string path = args->GetString(0).ToString();
+        if (path.empty()) {
+            LOG_WARN(LOG_CEF, "aboutOpenPath: empty path, ignoring");
+            return true;
+        }
+        if (g_platform.open_external_url)
+            g_platform.open_external_url("file://" + path);
+        return true;
+    }
+    if (name == "aboutDismiss")
+        return true;
+#endif
+
     if (!g_mpv.IsValid()) return false;
 
     if (name == "playerLoad") {

--- a/src/cef/resource_handler.cpp
+++ b/src/cef/resource_handler.cpp
@@ -21,6 +21,29 @@ static std::string absPath(const std::string& p) {
     return abs.string();
 }
 
+std::string buildAboutDataJson() {
+    auto dict = CefDictionaryValue::Create();
+    dict->SetString("app", APP_VERSION_STRING);
+    dict->SetString("cef", APP_CEF_VERSION);
+    dict->SetString("configDir", absPath(paths::getConfigDir()));
+
+    auto logo = embedded_resources.find("resources/logo.png");
+    if (logo != embedded_resources.end()) {
+        dict->SetString(
+            "logoDataUrl",
+            "data:image/png;base64," +
+                CefBase64Encode(logo->second.data, logo->second.size).ToString());
+    }
+
+    const std::string& log_path = activeLogPath();
+    if (!log_path.empty())
+        dict->SetString("logFile", absPath(log_path));
+
+    auto val = CefValue::Create();
+    val->SetDictionary(dict);
+    return CefWriteJSON(val, JSON_WRITER_DEFAULT).ToString();
+}
+
 // Generated at startup from kBgColor; served as app://resources/theme.css.
 static char g_theme_css[64];
 static size_t g_theme_css_len = 0;
@@ -70,18 +93,7 @@ CefRefPtr<CefResourceHandler> EmbeddedSchemeHandlerFactory::Create(
         // Assemble the data blob with CefWriteJSON (per CLAUDE.md: no
         // hand-rolled JSON). Log paths are omitted when file logging is
         // disabled — the panel renders only the rows present in the data.
-        auto dict = CefDictionaryValue::Create();
-        dict->SetString("app", APP_VERSION_STRING);
-        dict->SetString("cef", APP_CEF_VERSION);
-        dict->SetString("configDir", absPath(paths::getConfigDir()));
-        const std::string& log_path = activeLogPath();
-        if (!log_path.empty())
-            dict->SetString("logFile", absPath(log_path));
-        auto val = CefValue::Create();
-        val->SetDictionary(dict);
-        CefString json = CefWriteJSON(val, JSON_WRITER_DEFAULT);
-
-        std::string prefix = "var _aboutData = " + json.ToString() + ";\n";
+        std::string prefix = "var _aboutData = " + buildAboutDataJson() + ";\n";
         std::string payload;
         payload.reserve(prefix.size() + it->second.size);
         payload.append(prefix);

--- a/src/cef/resource_handler.h
+++ b/src/cef/resource_handler.h
@@ -5,6 +5,10 @@
 #include "include/cef_resource_handler.h"
 #include "embedded_resources.h"
 
+// Shared About payload used by both the standalone about.html resource and the
+// macOS in-page About panel injected into an existing browser.
+std::string buildAboutDataJson();
+
 class EmbeddedSchemeHandlerFactory : public CefSchemeHandlerFactory {
 public:
     CefRefPtr<CefResourceHandler> Create(

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -300,10 +300,12 @@ static void cef_consumer_thread() {
                     g_overlay_browser->resize(ev.lw, ev.lh, ev.pw, ev.ph);
                     g_platform.overlay_resize(ev.lw, ev.lh, ev.pw, ev.ph);
                 }
+#ifndef __APPLE__
                 if (g_about_browser && g_about_browser->browser()) {
                     g_about_browser->resize(ev.lw, ev.lh, ev.pw, ev.ph);
                     g_platform.about_resize(ev.lw, ev.lh, ev.pw, ev.ph);
                 }
+#endif
                 break;
             case MpvEventType::BUFFERED_RANGES: {
                 auto list = CefListValue::Create();
@@ -326,8 +328,10 @@ static void cef_consumer_thread() {
                     g_web_browser->browser()->GetHost()->SetWindowlessFrameRate(hz);
                 if (g_overlay_browser && g_overlay_browser->browser())
                     g_overlay_browser->browser()->GetHost()->SetWindowlessFrameRate(hz);
+#ifndef __APPLE__
                 if (g_about_browser && g_about_browser->browser())
                     g_about_browser->browser()->GetHost()->SetWindowlessFrameRate(hz);
+#endif
                 break;
             }
             case MpvEventType::SHUTDOWN:
@@ -896,7 +900,11 @@ int main(int argc, char* argv[]) {
     // driven — CFRunLoopRunInMode wakes on any source firing.
     while (!g_web_browser->isClosed() ||
            (g_overlay_browser && !g_overlay_browser->isClosed()) ||
+#ifndef __APPLE__
            (g_about_browser && !g_about_browser->isClosed())) {
+#else
+           false) {
+#endif
         CFRunLoopRunInMode(kCFRunLoopDefaultMode, 60.0, true);
     }
 
@@ -977,9 +985,11 @@ int main(int argc, char* argv[]) {
     // CEF shutdown: all browsers must be closed first (guaranteed by waitForClose above)
     delete g_web_browser; g_web_browser = nullptr;
     delete g_overlay_browser; g_overlay_browser = nullptr;
+#ifndef __APPLE__
     // g_about_browser is normally self-deleted via its BeforeCloseCallback.
     // If shutdown races the callback (unlikely), we take responsibility here.
     if (g_about_browser) { delete g_about_browser; g_about_browser = nullptr; }
+#endif
     CefRuntime::Shutdown();
 
     // Platform cleanup (joins input thread, destroys subsurfaces)

--- a/src/platform/macos.mm
+++ b/src/platform/macos.mm
@@ -108,13 +108,6 @@ struct LayerState {
 static LayerState g_main{};
 static LayerState g_overlay{};
 static bool g_overlay_visible = false;
-static LayerState g_about{};
-static bool g_about_visible = false;
-// Deferred-reveal flag: set by macos_set_about_visible(true), consumed by
-// macos_about_present once CEF delivers a frame. Avoids a window of empty
-// transparent layer between unhide and first real paint — the view stays
-// hidden until we actually have something to show.
-static bool g_about_pending_reveal = false;
 
 // Input NSView (owned by input::macos)
 static NSView* g_input_view = nil;
@@ -312,10 +305,6 @@ static void create_content_layer(NSView* contentView, CGRect frame, CGFloat scal
         CefRefPtr<CefBrowser> b = g_overlay_browser->browser();
         if (b) b->GetHost()->SendExternalBeginFrame();
     }
-    if (g_about_browser) {
-        CefRefPtr<CefBrowser> b = g_about_browser->browser();
-        if (b) b->GetHost()->SendExternalBeginFrame();
-    }
 }
 @end
 
@@ -440,7 +429,6 @@ static bool macos_init(mpv_handle* mpv) {
 
     create_content_layer(contentView, frame, scale, g_main.view, g_main.layer, nil);
     create_content_layer(contentView, frame, scale, g_overlay.view, g_overlay.layer, g_main.view);
-    create_content_layer(contentView, frame, scale, g_about.view, g_about.layer, g_overlay.view);
     // Both CEF content views start hidden so nothing from their fresh
     // (empty) CALayer sublayers can leak stale window-server snapshot
     // content before CEF has actually painted. The user sees mpv's
@@ -450,12 +438,11 @@ static bool macos_init(mpv_handle* mpv) {
     // together); macos_present unhides g_main in player mode.
     [g_main.view setHidden:YES];
     [g_overlay.view setHidden:YES];
-    [g_about.view setHidden:YES];
 
     g_input_view = input::macos::create_input_view();
     g_input_view.frame = contentView.bounds;
     g_input_view.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
-    [contentView addSubview:g_input_view positioned:NSWindowAbove relativeTo:g_about.view];
+    [contentView addSubview:g_input_view positioned:NSWindowAbove relativeTo:g_overlay.view];
 
     // NSWindow drops mouseMoved: events on the floor unless this is set.
     // Without it, our input view's hover/cursor tracking never fires.
@@ -539,36 +526,13 @@ static void macos_overlay_present_software(const CefRenderHandler::RectList&, co
 static void macos_resize(int, int, int, int) {}
 static void macos_overlay_resize(int, int, int, int) {}
 
-static void macos_about_present(const CefAcceleratedPaintInfo& info) {
-    present_iosurface(g_about, info);
-    if (g_about_pending_reveal) {
-        g_about_pending_reveal = false;
-        [g_about.view setHidden:NO];
-    }
-}
+static void macos_about_present(const CefAcceleratedPaintInfo&) {}
 
 static void macos_about_present_software(const CefRenderHandler::RectList&, const void*, int, int) {}
 
 static void macos_about_resize(int, int, int, int) {}
 
-static void macos_set_about_visible(bool visible) {
-    g_about_visible = visible;
-    if (visible) {
-        // Keep the layer hidden until macos_about_present confirms a real
-        // frame — avoids flashing an empty transparent layer.
-        g_about_pending_reveal = true;
-    } else {
-        g_about_pending_reveal = false;
-        [g_about.view setHidden:YES];
-    }
-
-    if (visible) {
-        auto main = g_web_browser ? g_web_browser->browser() : nullptr;
-        auto ovl  = g_overlay_browser ? g_overlay_browser->browser() : nullptr;
-        if (main) main->GetHost()->SetFocus(false);
-        if (ovl)  ovl->GetHost()->SetFocus(false);
-    }
-}
+static void macos_set_about_visible(bool) {}
 
 // =====================================================================
 // Native NSMenu popup (replaces CEF's HTML popup widget for <select>)

--- a/src/web/about.js
+++ b/src/web/about.js
@@ -2,104 +2,139 @@
 // `window._aboutData` is prepended to this file by the browser-side resource
 // handler (src/cef/resource_handler.cpp) — do NOT depend on any IPC to
 // arrive before first paint.
+// When injected from native code on macOS, `window._nativeShowAbout(data)` is
+// called externally instead.
 (function () {
-    var data = window._aboutData || {};
+    function render(data) {
+        if (!document.body) return false;
+        if (window._nativeAboutDismiss) return true;
 
-    var host = document.createElement('div');
-    host.id = '_jabout';
-    host.style.cssText =
-        'position:fixed;left:0;top:0;width:100vw;height:100vh;' +
-        'z-index:2147483647';
-    var shadow = host.attachShadow({ mode: 'closed' });
+        data = data || {};
 
-    var style = document.createElement('style');
-    style.textContent =
-        '*{margin:0;padding:0;box-sizing:border-box}' +
-        '.bg{position:fixed;inset:0;background:rgba(0,0,0,.5)}' +
-        '.box{position:fixed;left:50%;top:50%;transform:translate(-50%,-50%);' +
-          'background:#2b2b2b;border:1px solid #555;border-radius:8px;' +
-          'padding:20px 24px 18px;min-width:420px;max-width:80vw;' +
-          'font:13px/1.4 sans-serif;color:#e0e0e0;' +
-          'box-shadow:0 4px 24px rgba(0,0,0,.6)}' +
-        '.head{display:flex;justify-content:center;margin-bottom:16px}' +
-        '.logo{max-width:240px;height:auto}' +
-        '.x{position:absolute;top:8px;right:10px;cursor:pointer;' +
-          'padding:2px 8px;border-radius:4px;font-size:18px;line-height:1;' +
-          'color:#aaa;user-select:none}' +
-        '.x:hover{background:#3d3d3d;color:#e0e0e0}' +
-        '.row{display:flex;margin-top:8px}' +
-        '.row .k{flex:0 0 140px;color:#888}' +
-        '.row .v{flex:1 1 auto;word-break:break-all}' +
-        '.path{cursor:pointer;color:#8ab4f8;text-decoration:underline}' +
-        '.path:hover{color:#b3cdff}';
-    shadow.appendChild(style);
+        var host = document.createElement('div');
+        host.id = '_jabout';
+        host.style.cssText =
+            'position:fixed;left:0;top:0;width:100vw;height:100vh;' +
+            'z-index:2147483647';
+        var shadow = host.attachShadow({ mode: 'closed' });
 
-    var bg = document.createElement('div');
-    bg.className = 'bg';
-    shadow.appendChild(bg);
+        var style = document.createElement('style');
+        style.textContent =
+            '*{margin:0;padding:0;box-sizing:border-box}' +
+            '.bg{position:fixed;inset:0;background:rgba(0,0,0,.5)}' +
+            '.box{position:fixed;left:50%;top:50%;transform:translate(-50%,-50%);' +
+              'background:#2b2b2b;border:1px solid #555;border-radius:8px;' +
+              'padding:20px 24px 18px;min-width:420px;max-width:80vw;' +
+              'font:13px/1.4 sans-serif;color:#e0e0e0;' +
+              'box-shadow:0 4px 24px rgba(0,0,0,.6)}' +
+            '.head{display:flex;justify-content:center;align-items:center;margin-bottom:16px}' +
+            '.logo{max-width:240px;height:auto}' +
+            '.title{font:600 28px/1.2 sans-serif;color:#ffffff}' +
+            '.x{position:absolute;top:8px;right:10px;cursor:pointer;' +
+              'padding:2px 8px;border-radius:4px;font-size:18px;line-height:1;' +
+              'color:#aaa;user-select:none}' +
+            '.x:hover{background:#3d3d3d;color:#e0e0e0}' +
+            '.row{display:flex;margin-top:8px}' +
+            '.row .k{flex:0 0 140px;color:#888}' +
+            '.row .v{flex:1 1 auto;word-break:break-all}' +
+            '.path{cursor:pointer;color:#8ab4f8;text-decoration:underline}' +
+            '.path:hover{color:#b3cdff}';
+        shadow.appendChild(style);
 
-    var box = document.createElement('div');
-    box.className = 'box';
-    shadow.appendChild(box);
+        var bg = document.createElement('div');
+        bg.className = 'bg';
+        shadow.appendChild(bg);
 
-    var head = document.createElement('div');
-    head.className = 'head';
-    var logo = document.createElement('img');
-    logo.className = 'logo';
-    logo.src = 'logo.png';
-    logo.alt = 'Jellyfin';
-    var xBtn = document.createElement('div');
-    xBtn.className = 'x';
-    xBtn.textContent = '\u00D7';
-    head.appendChild(logo);
-    head.appendChild(xBtn);
-    box.appendChild(head);
+        var box = document.createElement('div');
+        box.className = 'box';
+        shadow.appendChild(box);
 
-    function addRow(label, value, isPath) {
-        var row = document.createElement('div');
-        row.className = 'row';
-        var k = document.createElement('div');
-        k.className = 'k';
-        k.textContent = label;
-        var v = document.createElement('div');
-        v.className = 'v';
-        if (isPath && value) {
-            v.className += ' path';
-            v.textContent = value;
-            v.addEventListener('click', function () {
-                if (window.jmpNative) jmpNative.aboutOpenPath(value);
-            });
+        var head = document.createElement('div');
+        head.className = 'head';
+        var logo = document.createElement('img');
+        logo.className = 'logo';
+        logo.alt = 'Jellyfin';
+        var title = document.createElement('div');
+        title.className = 'title';
+        title.textContent = 'Jellyfin Desktop';
+        if (data.logoDataUrl) {
+            title.style.display = 'none';
+            logo.src = data.logoDataUrl;
+            logo.addEventListener('error', function () {
+                logo.remove();
+                title.style.display = '';
+            }, { once: true });
         } else {
-            v.textContent = value || '';
+            title.style.display = '';
+            logo.style.display = 'none';
         }
-        row.appendChild(k);
-        row.appendChild(v);
-        box.appendChild(row);
+        var xBtn = document.createElement('div');
+        xBtn.className = 'x';
+        xBtn.textContent = '\u00D7';
+        head.appendChild(logo);
+        head.appendChild(title);
+        head.appendChild(xBtn);
+        box.appendChild(head);
+
+        function addRow(label, value, isPath) {
+            var row = document.createElement('div');
+            row.className = 'row';
+            var k = document.createElement('div');
+            k.className = 'k';
+            k.textContent = label;
+            var v = document.createElement('div');
+            v.className = 'v';
+            if (isPath && value) {
+                v.className += ' path';
+                v.textContent = value;
+                v.addEventListener('click', function () {
+                    if (window.jmpNative) jmpNative.aboutOpenPath(value);
+                });
+            } else {
+                v.textContent = value || '';
+            }
+            row.appendChild(k);
+            row.appendChild(v);
+            box.appendChild(row);
+        }
+
+        addRow('App version', data.app, false);
+        addRow('CEF version', data.cef, false);
+        if (data.configDir) addRow('Config directory', data.configDir, true);
+        if (data.logFile) addRow('Current log file', data.logFile, true);
+
+        var dismissed = false;
+        function dismiss() {
+            if (dismissed) return;
+            dismissed = true;
+            window.removeEventListener('keydown', onKeyDown, true);
+            window._nativeAboutDismiss = null;
+            host.remove();
+            if (window.jmpNative) jmpNative.aboutDismiss();
+        }
+
+        function onKeyDown(e) {
+            if (e.key === 'Escape') { e.preventDefault(); dismiss(); }
+        }
+
+        xBtn.addEventListener('click', dismiss);
+        bg.addEventListener('mousedown', function (e) { e.preventDefault(); dismiss(); });
+        // Stop backdrop click-through from firing when clicking inside the box.
+        box.addEventListener('mousedown', function (e) { e.stopPropagation(); });
+        window.addEventListener('keydown', onKeyDown, true);
+
+        document.body.appendChild(host);
+        window._nativeAboutDismiss = dismiss;
+        return true;
     }
 
-    addRow('App version', data.app, false);
-    addRow('CEF version', data.cef, false);
-    if (data.configDir) addRow('Config directory', data.configDir, true);
-    if (data.logFile) addRow('Current log file', data.logFile, true);
+    window._nativeShowAbout = function (data) {
+        if (render(data)) return;
+        window.addEventListener('DOMContentLoaded', function onReady() {
+            window.removeEventListener('DOMContentLoaded', onReady, false);
+            render(data);
+        }, false);
+    };
 
-    var dismissed = false;
-    function dismiss() {
-        if (dismissed) return;
-        dismissed = true;
-        window.removeEventListener('keydown', onKeyDown, true);
-        host.remove();
-        if (window.jmpNative) jmpNative.aboutDismiss();
-    }
-
-    function onKeyDown(e) {
-        if (e.key === 'Escape') { e.preventDefault(); dismiss(); }
-    }
-
-    xBtn.addEventListener('click', dismiss);
-    bg.addEventListener('mousedown', function (e) { e.preventDefault(); dismiss(); });
-    // Stop backdrop click-through from firing when clicking inside the box.
-    box.addEventListener('mousedown', function (e) { e.stopPropagation(); });
-    window.addEventListener('keydown', onKeyDown, true);
-
-    document.body.appendChild(host);
+    if (window._aboutData) window._nativeShowAbout(window._aboutData);
 })();


### PR DESCRIPTION
This is a workaround for macOS's unreliable OSR browser rendering. The cross-browser rendering could fail after the about browser opened and display nothing.
The only workaround seems to be directly render with the active browser.

Fixes #291

I have to admit that this might over-complicated, but most behavior is bared on macOS and we already have similar workaround (single process CEF) for the platform.