### PR TITLE
Logging cleanup and miscellaneous fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ if(APPLE)
     find_library(IOSURFACE_FRAMEWORK IOSurface REQUIRED)
     find_library(IOKIT_FRAMEWORK IOKit REQUIRED)
     find_library(MEDIAPLAYER_FRAMEWORK MediaPlayer REQUIRED)
+    find_library(SYSTEMCONFIGURATION_FRAMEWORK SystemConfiguration REQUIRED)
 
     set(PLATFORM_SOURCES
         src/platform/macos.mm
@@ -141,6 +142,7 @@ if(APPLE)
         ${IOSURFACE_FRAMEWORK}
         ${IOKIT_FRAMEWORK}
         ${MEDIAPLAYER_FRAMEWORK}
+        ${SYSTEMCONFIGURATION_FRAMEWORK}
     )
 elseif(WIN32)
     configure_file(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -552,6 +552,7 @@ if(WIN32)
     set(COMMON_SOURCES
         src/main.cpp
         src/logging.cpp
+        src/log_redact.cpp
         src/single_instance.cpp
         src/mpv/event.cpp
         src/mpv/capabilities.cpp
@@ -576,6 +577,7 @@ else()
     set(COMMON_SOURCES
         src/main.cpp
         src/logging.cpp
+        src/log_redact.cpp
         src/mpv/event.cpp
         src/mpv/capabilities.cpp
         src/jellyfin/device_profile.cpp

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Available recipes:
     flatpak           # Build Flatpak bundle (outputs to dist/)
     list              # List available recipes
     mpv *args         # Run the standalone mpv CLI built from the submodule (forwards args)
-    run *args         # Run the app with trace logging (logs to build/run.log)
+    run *args         # Run the app with debug logging (logs to build/run.log)
     test              # Run unit tests
     update-deps *args # Update vendored/fetched deps (CEF, doctest, quill); pass --check to verify only
 ```

--- a/cmake/GenerateVersion.cmake
+++ b/cmake/GenerateVersion.cmake
@@ -68,6 +68,7 @@ if(NOT "${APP_VERSION}" STREQUAL "${CACHED_VERSION}" OR
 
 #define APP_VERSION \"${APP_VERSION}\"
 #define APP_VERSION_STRING \"${APP_VERSION_STRING}\"
+#define APP_USER_AGENT \"JellyfinDesktop/${APP_VERSION_STRING}\"
 #define APP_CEF_VERSION \"${APP_CEF_VERSION}\"
 ")
     message(STATUS "version.h updated: ${APP_VERSION}+${APP_GIT_HASH} cef=${APP_CEF_VERSION}")

--- a/dev/macos/macos.just
+++ b/dev/macos/macos.just
@@ -20,7 +20,7 @@ test: build
 
 [macos]
 run *args: build
-    ./dev/macos/run.sh --log-level=trace --log-file=build/run.log {{args}}
+    ./dev/macos/run.sh --log-level=debug --log-file=build/run.log {{args}}
 
 # Run the standalone mpv CLI built from the submodule (forwards args)
 [macos]

--- a/dev/windows/windows.just
+++ b/dev/windows/windows.just
@@ -14,7 +14,7 @@ test: build
 
 [windows]
 run *args: build
-    build\jellyfin-desktop.exe --log-level=trace --log-file=build\run.log {{args}}
+    build\jellyfin-desktop.exe --log-level=debug --log-file=build\run.log {{args}}
 
 # Run the standalone mpv CLI built from the submodule (forwards args)
 [windows]

--- a/justfile
+++ b/justfile
@@ -31,10 +31,10 @@ deps:
 test: build
     ctest --test-dir build --output-on-failure
 
-# Run the app with trace logging (logs to build/run.log)
+# Run the app with debug logging (logs to build/run.log)
 [linux]
 run *args: build
-    build/jellyfin-desktop --log-level=trace --log-file=build/run.log {{args}}
+    build/jellyfin-desktop --log-level=debug --log-file=build/run.log {{args}}
 
 # Update vendored/fetched deps (CEF, doctest, quill); pass --check to verify only
 update-deps *args:

--- a/src/browser/about_browser.cpp
+++ b/src/browser/about_browser.cpp
@@ -94,7 +94,7 @@ AboutBrowser::AboutBrowser()
 
 void AboutBrowser::open() {
     if (g_about_browser) {
-        LOG_INFO(LOG_CEF, "AboutBrowser::open: already open, ignoring");
+        LOG_DEBUG(LOG_CEF, "AboutBrowser::open: already open, ignoring");
         return;
     }
     LOG_INFO(LOG_CEF, "AboutBrowser::open");

--- a/src/browser/overlay_browser.cpp
+++ b/src/browser/overlay_browser.cpp
@@ -116,6 +116,7 @@ static void applySettingValue(const std::string& section, const std::string& key
     else if (key == "audioChannels") s.setAudioChannels(value);
     else if (key == "titlebarThemeColor") s.setTitlebarThemeColor(value == "true");
     else if (key == "logLevel") s.setLogLevel(value);
+    else if (key == "deviceName") s.setDeviceName(value);
     else LOG_WARN(LOG_CEF, "Unknown setting key: {}.{}", section.c_str(), key.c_str());
     s.saveAsync();
 }

--- a/src/browser/web_browser.cpp
+++ b/src/browser/web_browser.cpp
@@ -66,6 +66,7 @@ static void applySettingValue(const std::string& section, const std::string& key
     else if (key == "titlebarThemeColor") s.setTitlebarThemeColor(value == "true");
     else if (key == "logLevel") s.setLogLevel(value);
     else if (key == "forceTranscoding") s.setForceTranscoding(value == "true");
+    else if (key == "deviceName") s.setDeviceName(value);
     else LOG_WARN(LOG_CEF, "Unknown setting key: {}.{}", section.c_str(), key.c_str());
     s.saveAsync();
 }

--- a/src/browser/web_browser.cpp
+++ b/src/browser/web_browser.cpp
@@ -253,7 +253,7 @@ bool WebBrowser::handleMessage(const std::string& name,
     } else if (name == "appExit") {
         initiate_shutdown();
     } else if (name == "openConfigDir") {
-        LOG_INFO(LOG_CEF, "Openning mpv home directory");
+        LOG_INFO(LOG_CEF, "Opening mpv home directory");
         paths::openMpvHome();
     } else {
         return false;

--- a/src/cef/cef_app.cpp
+++ b/src/cef/cef_app.cpp
@@ -629,7 +629,7 @@ constexpr double kCefMaxTimeSliceMs = 10.0;
 
 static void pump_drain(const char* trigger) {
     if (g_pump_shutdown.load(std::memory_order_acquire)) {
-        LOG_INFO(LOG_CEF, "[PUMP] drain({}) skipped (shutdown)", trigger);
+        LOG_DEBUG(LOG_CEF, "[PUMP] drain({}) skipped (shutdown)", trigger);
         return;
     }
 
@@ -691,7 +691,7 @@ void App::InitPump() {
 
 void App::OnScheduleMessagePumpWork(int64_t delay_ms) {
     if (g_pump_shutdown.load(std::memory_order_acquire)) {
-        LOG_INFO(LOG_CEF, "[PUMP] OnSched({}) SKIP(shutdown) tid={}",
+        LOG_DEBUG(LOG_CEF, "[PUMP] OnSched({}) SKIP(shutdown) tid={}",
                  (long long)delay_ms, (unsigned long long)tid_u64());
         return;
     }

--- a/src/cef/cef_app.cpp
+++ b/src/cef/cef_app.cpp
@@ -409,6 +409,7 @@ void App::OnContextCreated(CefRefPtr<CefBrowser> browser,
     };
     replace_first("__SERVER_URL__", Settings::instance().serverUrl());
     replace_first("__SETTINGS_JSON__", Settings::instance().cliSettingsJson());
+    replace_first("__APP_VERSION__", APP_VERSION_STRING);
     if (profile->HasKey("device_profile_json"))
         replace_first("__DEVICE_PROFILE_JSON__",
                       profile->GetString("device_profile_json").ToString());

--- a/src/cef/cef_app.cpp
+++ b/src/cef/cef_app.cpp
@@ -4,6 +4,7 @@
 #include "../paths/paths.h"
 #include "embedded_js.h"
 #include "logging.h"
+#include "version.h"
 #include "include/cef_app.h"
 #include "include/cef_browser.h"
 #include "include/cef_command_line.h"
@@ -204,6 +205,7 @@ bool Initialize() {
 #endif
     settings.no_sandbox = true;
     CefString(&settings.locale).FromASCII("en-US");
+    CefString(&settings.user_agent).FromASCII(APP_USER_AGENT);
 
 #ifdef __APPLE__
     char exe_buf[4096];

--- a/src/cef/cef_client.cpp
+++ b/src/cef/cef_client.cpp
@@ -129,7 +129,7 @@ bool CefLayer::GetScreenInfo(CefRefPtr<CefBrowser>, CefScreenInfo& info) {
 }
 
 void CefLayer::resize(int w, int h, int physical_w, int physical_h) {
-    LOG_INFO(LOG_CEF, "CefLayer::resize logical={}x{} physical={}x{} browser={}",
+    LOG_TRACE(LOG_CEF, "CefLayer::resize logical={}x{} physical={}x{} browser={}",
              w, h, physical_w, physical_h, static_cast<void*>(browser_.get()));
     width_ = w;
     height_ = h;
@@ -229,7 +229,7 @@ void CefLayer::OnAcceleratedPaint(CefRefPtr<CefBrowser>, PaintElementType type,
 }
 
 void CefLayer::OnAfterCreated(CefRefPtr<CefBrowser> browser) {
-    LOG_INFO(LOG_CEF, "CefLayer::OnAfterCreated browser={} id={}",
+    LOG_DEBUG(LOG_CEF, "CefLayer::OnAfterCreated browser={} id={}",
              static_cast<void*>(browser.get()), browser ? browser->GetIdentifier() : -1);
     browser_ = browser;
     closed_ = false;

--- a/src/cef/cef_client.cpp
+++ b/src/cef/cef_client.cpp
@@ -384,12 +384,15 @@ bool CefLayer::OnConsoleMessage(CefRefPtr<CefBrowser>, cef_log_severity_t level,
                                 int line) {
     std::string msg = message.ToString();
     std::string src = source.ToString();
+    // CEF: VERBOSE/DEBUG share a value. DEFAULT (0) → treat as INFO.
     if (level >= LOGSEVERITY_ERROR)
         LOG_ERROR(LOG_JS, "{} ({}:{})", msg.c_str(), src.c_str(), line);
     else if (level == LOGSEVERITY_WARNING)
         LOG_WARN(LOG_JS, "{} ({}:{})", msg.c_str(), src.c_str(), line);
-    else
+    else if (level == LOGSEVERITY_INFO || level == LOGSEVERITY_DEFAULT)
         LOG_INFO(LOG_JS, "{} ({}:{})", msg.c_str(), src.c_str(), line);
+    else  // VERBOSE/DEBUG
+        LOG_DEBUG(LOG_JS, "{} ({}:{})", msg.c_str(), src.c_str(), line);
     return true;
 }
 

--- a/src/input/dispatch.cpp
+++ b/src/input/dispatch.cpp
@@ -45,7 +45,7 @@ void set_active_browser(CefRefPtr<CefBrowser> browser) {
         prev = g_active;
         g_active = browser;
     }
-    LOG_INFO(LOG_PLATFORM, "[INPUT] set_active_browser prev={} new={}",
+    LOG_DEBUG(LOG_PLATFORM, "[INPUT] set_active_browser prev={} new={}",
              static_cast<void*>(prev.get()), static_cast<void*>(browser.get()));
     if (prev)    prev->GetHost()->SetFocus(false);
     if (browser) browser->GetHost()->SetFocus(true);

--- a/src/input/input_macos.mm
+++ b/src/input/input_macos.mm
@@ -490,6 +490,7 @@ static void flush_scroll_accumulator() {
 // --- Keyboard events ---
 - (void)keyDown:(NSEvent*)event {
     unsigned short kc = [event keyCode];
+    LOG_TRACE(LOG_PLATFORM, "[INPUT] keyDown kc={}", (int)kc);
 
     input::KeyEvent e{};
     fill_key_event_from_nsevent(e, event);
@@ -515,6 +516,7 @@ static void flush_scroll_accumulator() {
 }
 
 - (void)keyUp:(NSEvent*)event {
+    LOG_TRACE(LOG_PLATFORM, "[INPUT] keyUp kc={}", (int)[event keyCode]);
     input::KeyEvent e{};
     fill_key_event_from_nsevent(e, event);
     e.action = input::KeyAction::Up;
@@ -523,6 +525,8 @@ static void flush_scroll_accumulator() {
 
 - (void)flagsChanged:(NSEvent*)event {
     unsigned short kc = [event keyCode];
+    LOG_TRACE(LOG_PLATFORM, "[INPUT] flagsChanged kc={} flags=0x{:x}",
+              (int)kc, (uint64_t)[event modifierFlags]);
     NSEventModifierFlags flag = 0;
     switch (kc) {
         case 56: case 60: flag = NSEventModifierFlagShift; break;

--- a/src/input/input_macos.mm
+++ b/src/input/input_macos.mm
@@ -319,7 +319,7 @@ static void fill_key_event_from_nsevent(input::KeyEvent& e, NSEvent* event) {
         owner:self
         userInfo:nil];
     [self addTrackingArea:_trackingArea];
-    LOG_INFO(LOG_PLATFORM, "[INPUT] updateTrackingAreas bounds={:.0f}x{:.0f}",
+    LOG_TRACE(LOG_PLATFORM, "[INPUT] updateTrackingAreas bounds={:.0f}x{:.0f}",
              self.bounds.size.width, self.bounds.size.height);
 }
 
@@ -547,13 +547,13 @@ static void flush_scroll_accumulator() {
 
 // --- Focus ---
 - (BOOL)becomeFirstResponder {
-    LOG_INFO(LOG_PLATFORM, "[INPUT] becomeFirstResponder");
+    LOG_DEBUG(LOG_PLATFORM, "[INPUT] becomeFirstResponder");
     input::dispatch_keyboard_focus(true);
     return [super becomeFirstResponder];
 }
 
 - (BOOL)resignFirstResponder {
-    LOG_INFO(LOG_PLATFORM, "[INPUT] resignFirstResponder");
+    LOG_DEBUG(LOG_PLATFORM, "[INPUT] resignFirstResponder");
     input::dispatch_keyboard_focus(false);
     return [super resignFirstResponder];
 }

--- a/src/input/input_wayland.cpp
+++ b/src/input/input_wayland.cpp
@@ -130,7 +130,9 @@ void ptr_button(void*, wl_pointer*, uint32_t, uint32_t, uint32_t button, uint32_
     case BTN_LEFT:   btn = MouseButton::Left;   flag = EVENTFLAG_LEFT_MOUSE_BUTTON;   break;
     case BTN_RIGHT:  btn = MouseButton::Right;  flag = EVENTFLAG_RIGHT_MOUSE_BUTTON;  break;
     case BTN_MIDDLE: btn = MouseButton::Middle; flag = EVENTFLAG_MIDDLE_MOUSE_BUTTON; break;
-    default: return;
+    default:
+        LOG_TRACE(LOG_PLATFORM, "[INPUT] ptr_button unhandled code=0x{:x}", button);
+        return;
     }
     if (pressed) g.mouse_button_modifiers |= flag;
     else         g.mouse_button_modifiers &= ~flag;
@@ -237,6 +239,14 @@ void kb_key(void*, wl_keyboard*, uint32_t, uint32_t, uint32_t key, uint32_t stat
     uint32_t kc = key + 8;
     xkb_keysym_t sym = xkb_state_key_get_one_sym(g.xkb_st, kc);
     const bool pressed = (state == WL_KEYBOARD_KEY_STATE_PRESSED);
+    LOG_TRACE(LOG_PLATFORM, "[INPUT] kb_key code={} sym=0x{:x} pressed={}",
+              key, (uint32_t)sym, pressed);
+
+    // Browser/IR-remote history navigation keys (e.g. XF86Back on MCE remotes).
+    if (sym == XKB_KEY_XF86Back || sym == XKB_KEY_XF86Forward) {
+        if (pressed) input::dispatch_history_nav(sym == XKB_KEY_XF86Forward);
+        return;
+    }
 
     KeyEvent e{};
     e.code             = keysym_to_keycode(sym);

--- a/src/input/input_windows.cpp
+++ b/src/input/input_windows.cpp
@@ -231,6 +231,26 @@ LRESULT CALLBACK input_wndproc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
         return TRUE;  // must return TRUE for WM_XBUTTON* per MSDN
     }
 
+    // MCE IR remote / multimedia keys deliver Back/Forward as WM_APPCOMMAND
+    // rather than VK_BROWSER_BACK keystrokes. Handle here so the remote's Back
+    // button navigates browser history.
+    case WM_APPCOMMAND: {
+        const WORD cmd = GET_APPCOMMAND_LPARAM(lp);
+        LOG_TRACE(LOG_PLATFORM, "[INPUT] wm_appcommand cmd={}", cmd);
+        switch (cmd) {
+        case APPCOMMAND_BROWSER_BACKWARD:
+            dispatch_history_nav(false);
+            return TRUE;
+        case APPCOMMAND_BROWSER_FORWARD:
+            dispatch_history_nav(true);
+            return TRUE;
+        default:
+            LOG_TRACE(LOG_PLATFORM, "[INPUT] wm_appcommand unhandled cmd={}", cmd);
+            break;
+        }
+        break;  // let DefWindowProc bubble unhandled commands to parent
+    }
+
     case WM_MOUSEWHEEL: {
         POINT pt = { GET_X_LPARAM(lp), GET_Y_LPARAM(lp) };
         ScreenToClient(hwnd, &pt);
@@ -261,6 +281,15 @@ LRESULT CALLBACK input_wndproc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
             PostMessage(g.mpv_hwnd, WM_CLOSE, 0, 0);
             return 0;
         }
+        LOG_TRACE(LOG_PLATFORM, "[INPUT] wm_key msg=0x{:x} vk=0x{:x} down={}",
+                  msg, (int)wp, msg == WM_KEYDOWN || msg == WM_SYSKEYDOWN);
+        // Browser navigation keys from keyboards/IR drivers that emit keystrokes
+        // rather than WM_APPCOMMAND.
+        if (wp == VK_BROWSER_BACK || wp == VK_BROWSER_FORWARD) {
+            if (msg == WM_KEYDOWN || msg == WM_SYSKEYDOWN)
+                dispatch_history_nav(wp == VK_BROWSER_FORWARD);
+            return 0;
+        }
         KeyEvent e{};
         e.code             = vk_to_keycode(static_cast<int>(wp));
         e.windows_key_code = static_cast<int>(wp);
@@ -274,6 +303,7 @@ LRESULT CALLBACK input_wndproc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
     }
 
     case WM_CHAR: case WM_SYSCHAR: {
+        LOG_TRACE(LOG_PLATFORM, "[INPUT] wm_char msg=0x{:x} cp=0x{:x}", msg, (uint32_t)wp);
         dispatch_char(static_cast<uint32_t>(wp),
                       keyboard_modifiers(wp, lp),
                       static_cast<int>(lp),

--- a/src/input/input_x11.cpp
+++ b/src/input/input_x11.cpp
@@ -135,6 +135,16 @@ void handle_key(xcb_key_press_event_t* ev, bool pressed) {
     if (!g.xkb_st) return;
     xkb_keycode_t kc = ev->detail;
     xkb_keysym_t sym = xkb_state_key_get_one_sym(g.xkb_st, kc);
+    LOG_TRACE(LOG_PLATFORM, "[INPUT] xcb_key code={} sym=0x{:x} pressed={}",
+              (int)kc - 8, (uint32_t)sym, pressed);
+
+    // Browser/IR-remote history navigation keys (e.g. XF86Back on MCE remotes).
+    if (sym == XKB_KEY_XF86Back || sym == XKB_KEY_XF86Forward) {
+        if (pressed) input::dispatch_history_nav(sym == XKB_KEY_XF86Forward);
+        xkb_state_update_key(g.xkb_st, kc,
+            pressed ? XKB_KEY_DOWN : XKB_KEY_UP);
+        return;
+    }
 
     KeyEvent e{};
     e.code             = keysym_to_keycode(sym);
@@ -201,7 +211,9 @@ void handle_button(xcb_button_press_event_t* ev, bool pressed) {
     case 1: btn = MouseButton::Left;   flag = EVENTFLAG_LEFT_MOUSE_BUTTON;   break;
     case 2: btn = MouseButton::Middle; flag = EVENTFLAG_MIDDLE_MOUSE_BUTTON; break;
     case 3: btn = MouseButton::Right;  flag = EVENTFLAG_RIGHT_MOUSE_BUTTON;  break;
-    default: return;
+    default:
+        LOG_TRACE(LOG_PLATFORM, "[INPUT] xcb_button unhandled code={}", button);
+        return;
     }
 
     if (pressed) g.mouse_button_modifiers |= flag;
@@ -367,6 +379,9 @@ void input_thread_func() {
                 // WM_DELETE_WINDOW on our overlay windows (WM targets
                 // the focused window, which may be our overlay)
                 initiate_shutdown();
+                break;
+            default:
+                LOG_TRACE(LOG_PLATFORM, "[INPUT] xcb_event unhandled type={}", (int)type);
                 break;
             }
             free(ev);

--- a/src/log_redact.cpp
+++ b/src/log_redact.cpp
@@ -1,0 +1,75 @@
+#include "log_redact.h"
+
+#include <array>
+#include <string>
+#include <string_view>
+
+namespace log_redact {
+
+namespace {
+
+// A redaction rule: when `needle` is found in a log line, the run of
+// characters following it (up to but excluding the first character in
+// `terminators`, or end-of-string) is overwritten with 'x'.
+struct PatternRule {
+    std::string_view needle;
+    std::string_view terminators;
+};
+
+// Terminators for URL-param / header forms. Tokens end at the next URL
+// delimiter or whitespace.
+constexpr std::string_view kUrlTerminators = "&\"' \t\r\n;<>";
+// JSON form: the token ends at the closing quote.
+constexpr std::string_view kJsonTerminators = "\"";
+
+constexpr std::array<PatternRule, 6> kRules = {{
+    {"api_key=",                kUrlTerminators},
+    {"X-MediaBrowser-Token%3D", kUrlTerminators},
+    {"X-MediaBrowser-Token=",   kUrlTerminators},
+    {"ApiKey=",                 kUrlTerminators},
+    {"AccessToken=",            kUrlTerminators},
+    {"AccessToken\":\"",        kJsonTerminators},
+}};
+
+std::size_t findTokenEnd(const std::string& msg, std::size_t from,
+                         std::string_view terminators) {
+    auto end = msg.find_first_of(terminators, from);
+    return end == std::string::npos ? msg.size() : end;
+}
+
+void elideTokens(std::string& msg, const PatternRule& rule) {
+    std::size_t start = 0;
+    while ((start = msg.find(rule.needle, start)) != std::string::npos) {
+        std::size_t token_start = start + rule.needle.size();
+        std::size_t token_end = findTokenEnd(msg, token_start, rule.terminators);
+        for (std::size_t i = token_start; i < token_end; ++i) {
+            msg[i] = 'x';
+        }
+        // Advance past the (now-redacted) token; if it was empty, advance past
+        // the needle so we don't loop on the same position.
+        start = token_end > token_start ? token_end : token_start;
+    }
+}
+
+}  // namespace
+
+bool containsSecret(std::string_view msg) {
+    for (const auto& rule : kRules) {
+        auto pos = msg.find(rule.needle);
+        if (pos == std::string_view::npos) continue;
+        std::size_t token_start = pos + rule.needle.size();
+        if (token_start < msg.size() &&
+            rule.terminators.find(msg[token_start]) == std::string_view::npos) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void censor(std::string& msg) {
+    for (const auto& rule : kRules) {
+        elideTokens(msg, rule);
+    }
+}
+
+}  // namespace log_redact

--- a/src/log_redact.h
+++ b/src/log_redact.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+
+// Token redaction for log output. Detects known query-param / JSON / header
+// patterns that precede a Jellyfin access token and overwrites the token
+// value with 'x' characters, preserving URL/JSON shape.
+//
+// Standalone module with no logging or third-party dependencies so it can be
+// unit-tested in isolation.
+namespace log_redact {
+
+// Returns true if `msg` contains any redactable pattern with a non-empty
+// token value following. Cheap pre-check so callers can skip the string copy
+// on the common case of no secrets.
+bool containsSecret(std::string_view msg);
+
+// Overwrites token characters that follow known patterns with 'x' in place.
+// Length-preserving — `msg.size()` is unchanged.
+void censor(std::string& msg);
+
+}  // namespace log_redact

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -71,8 +71,7 @@ using RotatingFileSinkNoNewlines = NewlineStripSink<quill::RotatingFileSink>;
 namespace {
 
 constexpr const char* kCategoryNames[LOG_CATEGORY_COUNT] = {
-    "Main", "mpv",   "CEF",   "GL",    "Media",   "Overlay",  "Menu", "UI",
-    "Window", "Platform", "Compositor", "Resource", "Test", "JS", "Video",
+    "Main", "mpv", "CEF", "Media", "Platform", "JS", "Resource",
 };
 
 // ---- stderr capture ------------------------------------------------------
@@ -200,22 +199,23 @@ void shutdownStderrCapture() {
 
 }  // namespace
 
-static quill::LogLevel toQuillLevel(int parsed) {
-    switch (parsed) {
-        case 0: return quill::LogLevel::TraceL1;  // verbose
-        case 1: return quill::LogLevel::Debug;
-        case 2: return quill::LogLevel::Info;
-        case 3: return quill::LogLevel::Warning;
-        case 4: return quill::LogLevel::Error;
-        default: return quill::LogLevel::TraceL3;  // allow everything
+static quill::LogLevel toQuillLevel(LogLevel level) {
+    switch (level) {
+        case LogLevel::Trace: return quill::LogLevel::TraceL1;
+        case LogLevel::Debug: return quill::LogLevel::Debug;
+        case LogLevel::Info:  return quill::LogLevel::Info;
+        case LogLevel::Warn:  return quill::LogLevel::Warning;
+        case LogLevel::Error: return quill::LogLevel::Error;
+        case LogLevel::Default: break;
     }
+    return quill::LogLevel::TraceL3;  // allow everything
 }
 
 const std::string& activeLogPath() {
     return g_active_log_path;
 }
 
-void initLogging(const char* path, int min_level) {
+void initLogging(const char* path, LogLevel min_level) {
     g_active_log_path = (path && path[0]) ? path : "";
 
     quill::Backend::start();

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -1,5 +1,6 @@
 #include "logging.h"
 
+#include "log_redact.h"
 #include "quill/Backend.h"
 #include "quill/Frontend.h"
 #include "quill/sinks/ConsoleSink.h"
@@ -30,12 +31,14 @@ quill::Logger* g_loggers[LOG_CATEGORY_COUNT] = {};
 
 static std::string g_active_log_path;
 
-// Sink mixin that replaces embedded newlines in the rendered log_statement
-// before handing it to the real sink. Runs on Quill's backend worker thread,
-// so the call site stays free of string mangling. Newlines come mainly from
-// multi-line JS console messages (stack traces) piped through OnConsoleMessage.
+// Sink mixin that post-processes the rendered log_statement before handing it
+// to the real sink. Two transforms:
+//   1. Replace embedded newlines (mainly multi-line JS stack traces) with
+//      spaces so each log entry stays on one line.
+//   2. Redact auth tokens / API keys via log_redact::censor.
+// Runs on Quill's backend worker thread so call sites stay free of mangling.
 template <class Base>
-class NewlineStripSink : public Base {
+class SanitizingSink : public Base {
 public:
     using Base::Base;
     void write_log(quill::MacroMetadata const* md, uint64_t ts,
@@ -46,18 +49,29 @@ public:
                    std::vector<std::pair<std::string, std::string>> const* named_args,
                    std::string_view log_message, std::string_view log_statement) override {
         // Last char is the pattern suffix '\n' which Quill added — keep it.
-        // Only strip newlines that were embedded in the message itself.
+        // Only consider transforms over the body.
         auto body_end = log_statement.size();
         if (body_end > 0 && log_statement[body_end - 1] == '\n') --body_end;
-        if (log_statement.substr(0, body_end).find_first_of("\r\n") == std::string_view::npos) {
+        std::string_view body = log_statement.substr(0, body_end);
+
+        bool has_newline = body.find_first_of("\r\n") != std::string_view::npos;
+        bool has_secret = log_redact::containsSecret(body);
+
+        if (!has_newline && !has_secret) {
             Base::write_log(md, ts, thread_id, thread_name, process_id, logger_name,
                             level, level_desc, level_code, named_args,
                             log_message, log_statement);
             return;
         }
+
         std::string cleaned(log_statement);
-        for (size_t i = 0; i < body_end; ++i) {
-            if (cleaned[i] == '\r' || cleaned[i] == '\n') cleaned[i] = ' ';
+        if (has_newline) {
+            for (size_t i = 0; i < body_end; ++i) {
+                if (cleaned[i] == '\r' || cleaned[i] == '\n') cleaned[i] = ' ';
+            }
+        }
+        if (has_secret) {
+            log_redact::censor(cleaned);
         }
         Base::write_log(md, ts, thread_id, thread_name, process_id, logger_name,
                         level, level_desc, level_code, named_args,
@@ -65,8 +79,8 @@ public:
     }
 };
 
-using ConsoleSinkNoNewlines = NewlineStripSink<quill::ConsoleSink>;
-using RotatingFileSinkNoNewlines = NewlineStripSink<quill::RotatingFileSink>;
+using ConsoleSinkSanitizing = SanitizingSink<quill::ConsoleSink>;
+using RotatingFileSinkSanitizing = SanitizingSink<quill::RotatingFileSink>;
 
 namespace {
 
@@ -226,7 +240,7 @@ void initLogging(const char* path, LogLevel min_level) {
     quill::ConsoleSinkConfig console_config;
     console_config.set_override_pattern_formatter_options(quill::PatternFormatterOptions{
         "[%(logger)] %(message)", "", quill::Timezone::LocalTime});
-    sinks.push_back(quill::Frontend::create_or_get_sink<ConsoleSinkNoNewlines>(
+    sinks.push_back(quill::Frontend::create_or_get_sink<ConsoleSinkSanitizing>(
         "console_sink", console_config));
 
     // File: ISO timestamp, padded level, then "[Category] message".
@@ -242,7 +256,7 @@ void initLogging(const char* path, LogLevel min_level) {
             "%(time) %(log_level:<7) [%(logger)] %(message)",
             "%Y-%m-%dT%H:%M:%S",
             quill::Timezone::LocalTime});
-        sinks.push_back(quill::Frontend::create_or_get_sink<RotatingFileSinkNoNewlines>(path, file_config));
+        sinks.push_back(quill::Frontend::create_or_get_sink<RotatingFileSinkSanitizing>(path, file_config));
     }
 
     quill::LogLevel level = toQuillLevel(min_level);

--- a/src/logging.h
+++ b/src/logging.h
@@ -8,21 +8,13 @@
 #include "include/internal/cef_types.h"
 
 enum LogCategory {
-    LOG_MAIN       = 0,
-    LOG_MPV        = 1,
-    LOG_CEF        = 2,
-    LOG_GL         = 3,
-    LOG_MEDIA      = 4,
-    LOG_OVERLAY    = 5,
-    LOG_MENU       = 6,
-    LOG_UI         = 7,
-    LOG_WINDOW     = 8,
-    LOG_PLATFORM   = 9,
-    LOG_COMPOSITOR = 10,
-    LOG_RESOURCE   = 11,
-    LOG_TEST       = 12,
-    LOG_JS         = 13,
-    LOG_VIDEO      = 14,
+    LOG_MAIN,
+    LOG_MPV,
+    LOG_CEF,
+    LOG_MEDIA,
+    LOG_PLATFORM,
+    LOG_JS,
+    LOG_RESOURCE,
     LOG_CATEGORY_COUNT,
 };
 
@@ -34,34 +26,43 @@ extern quill::Logger* g_loggers[LOG_CATEGORY_COUNT];
 #define LOG_DEBUG(cat, ...)   QUILL_LOG_DEBUG(g_loggers[cat],   __VA_ARGS__)
 #define LOG_TRACE(cat, ...)   QUILL_LOG_TRACE_L1(g_loggers[cat], __VA_ARGS__)
 
-inline int parseLogLevel(const char* level) {
-    if (strcmp(level, "trace") == 0) return 0;
-    if (strcmp(level, "debug") == 0)   return 1;
-    if (strcmp(level, "info") == 0)    return 2;
-    if (strcmp(level, "warn") == 0)    return 3;
-    if (strcmp(level, "error") == 0)   return 4;
-    return -1;
+enum class LogLevel {
+    Default,  // backend default (everything)
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+};
+
+// Returns LogLevel::Default for unknown strings.
+inline LogLevel parseLogLevel(const char* level) {
+    if (strcmp(level, "trace") == 0) return LogLevel::Trace;
+    if (strcmp(level, "debug") == 0) return LogLevel::Debug;
+    if (strcmp(level, "info")  == 0) return LogLevel::Info;
+    if (strcmp(level, "warn")  == 0) return LogLevel::Warn;
+    if (strcmp(level, "error") == 0) return LogLevel::Error;
+    return LogLevel::Default;
 }
 
-// Map our 0..4 log level (see parseLogLevel) to CEF's severity enum.
-inline cef_log_severity_t toCefSeverity(int parsed) {
-    switch (parsed) {
-        case 0: case 1: return LOGSEVERITY_VERBOSE;
-        case 2:         return LOGSEVERITY_INFO;
-        case 3:         return LOGSEVERITY_WARNING;
-        case 4:         return LOGSEVERITY_ERROR;
-        default:        return LOGSEVERITY_DEFAULT;
+inline cef_log_severity_t toCefSeverity(LogLevel level) {
+    switch (level) {
+        case LogLevel::Trace:
+        case LogLevel::Debug: return LOGSEVERITY_VERBOSE;
+        case LogLevel::Info:  return LOGSEVERITY_INFO;
+        case LogLevel::Warn:  return LOGSEVERITY_WARNING;
+        case LogLevel::Error: return LOGSEVERITY_ERROR;
+        case LogLevel::Default: break;
     }
+    return LOGSEVERITY_DEFAULT;
 }
 
 // Install the log file at `path` (rotated on startup + at 10 MB, 3 backups)
 // and redirect this process's stderr through the logger so writes from
 // CEF/Chromium (and subprocesses that inherit our stderr) land in the log.
 // Empty/null path disables file logging; stderr is still captured.
-// `min_level` is the value returned by parseLogLevel: 0=verbose .. 4=error;
-// pass -1 to keep the default (everything).
 // Call once before spawning any subprocess.
-void initLogging(const char* path, int min_level);
+void initLogging(const char* path, LogLevel min_level);
 
 // Flush and stop the backend, drain the stderr capture, close files.
 void shutdownLogging();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -562,6 +562,8 @@ int main(int argc, char* argv[]) {
     // failure mode for nothing.
     g_mpv.SetOptionString("ytdl", "no");
 
+    g_mpv.SetOptionString("user-agent", APP_USER_AGENT);
+
     g_mpv.SetHwdec(hwdec_str);
     g_mpv.SetOptionString("background-color", kBgColor.hex);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -121,10 +121,13 @@ static void log_mpv_message(const mpv_event_log_message* msg) {
         LOG_WARN(LOG_MPV, "{}: {}", msg->prefix, msg->text); break;
     case MPV_LOG_LEVEL_INFO:
         LOG_INFO(LOG_MPV, "{}: {}", msg->prefix, msg->text); break;
-    case MPV_LOG_LEVEL_TRACE:
-        LOG_TRACE(LOG_MPV, "{}: {}", msg->prefix, msg->text); break;
-    default: // V, DEBUG
+    case MPV_LOG_LEVEL_V:
         LOG_DEBUG(LOG_MPV, "{}: {}", msg->prefix, msg->text); break;
+    case MPV_LOG_LEVEL_DEBUG:
+        LOG_TRACE(LOG_MPV, "{}: {}", msg->prefix, msg->text); break;
+    default: // unexpected (e.g. TRACE — we cap subscription at debug) or new mpv level
+        LOG_WARN(LOG_MPV, "[unhandled mpv level {}] {}: {}",
+                 (int)msg->log_level, msg->prefix, msg->text); break;
     }
 }
 
@@ -469,10 +472,10 @@ int main(int argc, char* argv[]) {
         log_path = paths::getLogPath();
 #endif
     }
-    int log_level = -1;
+    LogLevel log_level = LogLevel::Default;
     if (log_level_str && log_level_str[0]) {
         log_level = parseLogLevel(log_level_str);
-        if (log_level < 0) {
+        if (log_level == LogLevel::Default) {
             fprintf(stderr, "Invalid log level: '%s' (expected trace|debug|info|warn|error)\n",
                     log_level_str);
             return 1;
@@ -640,7 +643,7 @@ int main(int argc, char* argv[]) {
         g_mpv.TerminateDestroy();
         return 1;
     }
-    g_mpv.RequestLogMessages("info");
+    g_mpv.SetLogLevel(log_level);
 
     // input-default-bindings=no removes all builtin bindings including
     // CLOSE_WIN → quit.  Re-bind it so the WM close button works.

--- a/src/mpv/handle.h
+++ b/src/mpv/handle.h
@@ -394,8 +394,21 @@ public:
         mpv_set_wakeup_callback(handle_, cb, data);
     }
 
-    void RequestLogMessages(const char* level) {
-        mpv_request_log_messages(handle_, level);
+    // Subscribe mpv at the most verbose level our log filter would actually
+    // surface, so mpv doesn't waste IPC on messages we'd discard.
+    // We cap mpv at "debug" — mpv's "trace" is extreme and not worth the IPC.
+    // mpv's "v" maps to our Debug; mpv's "debug" maps to our Trace.
+    void SetLogLevel(LogLevel level) {
+        const char* mpv_level = "debug";
+        switch (level) {
+            case LogLevel::Debug: mpv_level = "v";     break;
+            case LogLevel::Info:  mpv_level = "info";  break;
+            case LogLevel::Warn:  mpv_level = "warn";  break;
+            case LogLevel::Error: mpv_level = "error"; break;
+            case LogLevel::Trace:
+            case LogLevel::Default: break; // subscribe to "debug" (cap)
+        }
+        mpv_request_log_messages(handle_, mpv_level);
     }
 
     mpv_event* WaitEvent(double timeout) {

--- a/src/platform/macos.mm
+++ b/src/platform/macos.mm
@@ -25,8 +25,24 @@
 #import <QuartzCore/QuartzCore.h>
 #import <IOSurface/IOSurface.h>
 #include <IOKit/pwr_mgt/IOPMLib.h>
+#include <SystemConfiguration/SystemConfiguration.h>
 #include <mach/mach_time.h>
 #include <objc/runtime.h>
+
+// gethostname() on macOS returns a network-derived BSD hostname (e.g.
+// "dhcp-1-2-3-4.lan"); SCDynamicStoreCopyComputerName returns the stable
+// user-set name from System Settings → General → About → Name.
+std::string macosComputerName() {
+    CFStringRef name = SCDynamicStoreCopyComputerName(nullptr, nullptr);
+    if (!name) return {};
+    CFIndex len = CFStringGetLength(name);
+    CFIndex max = CFStringGetMaximumSizeForEncoding(len, kCFStringEncodingUTF8) + 1;
+    std::string out(max, '\0');
+    CFStringGetCString(name, out.data(), max, kCFStringEncodingUTF8);
+    out.resize(strlen(out.c_str()));
+    CFRelease(name);
+    return out;
+}
 
 // =====================================================================
 // Forward declarations

--- a/src/platform/macos.mm
+++ b/src/platform/macos.mm
@@ -492,7 +492,7 @@ static bool macos_init(mpv_handle* mpv) {
                      queue:nil
                 usingBlock:^(NSNotification* /*note*/) {
         NSRect b = [[g_window contentView] bounds];
-        LOG_INFO(LOG_PLATFORM, "[WINDOW] NSWindowDidResizeNotification contentView={:.0f}x{:.0f}",
+        LOG_TRACE(LOG_PLATFORM, "[WINDOW] NSWindowDidResizeNotification contentView={:.0f}x{:.0f}",
                  b.size.width, b.size.height);
     }];
 

--- a/src/platform/wayland.cpp
+++ b/src/platform/wayland.cpp
@@ -860,7 +860,7 @@ static bool probe_shared_texture_support(const std::string& ozone_platform,
     // --- Load GBM ---
     void* gbm_lib = dlopen("libgbm.so.1", RTLD_LAZY | RTLD_LOCAL);
     if (!gbm_lib) {
-        LOG_INFO(LOG_PLATFORM, "dmabuf probe: libgbm not available, assuming supported");
+        LOG_WARN(LOG_PLATFORM, "dmabuf probe: libgbm not available, assuming supported");
         cleanup_gl(); cleanup();
         return true;
     }
@@ -1113,7 +1113,7 @@ static bool wl_init(mpv_handle* mpv) {
     if (egl_dpy != EGL_NO_DISPLAY) eglInitialize(egl_dpy, nullptr, nullptr);
 
     if (!probe_shared_texture_support(g_platform.cef_ozone_platform, egl_dpy)) {
-        LOG_INFO(LOG_PLATFORM, "Shared textures not supported; using software CEF rendering");
+        LOG_WARN(LOG_PLATFORM, "Shared textures not supported; using software CEF rendering");
         g_platform.shared_texture_supported = false;
     }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -6,6 +6,15 @@
 #include <sstream>
 #include <thread>
 
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
+// Server's Devices.DeviceName column is varchar(64); clamp here to match.
+static constexpr size_t kDeviceNameMax = 64;
+
 Settings& Settings::instance() {
     static Settings instance;
     return instance;
@@ -72,6 +81,8 @@ bool Settings::load() {
     transparent_titlebar_ = jsonBool(root, "transparentTitlebar", true);
     log_level_ = jsonStr(root, "logLevel");
     force_transcoding_ = jsonBool(root, "forceTranscoding", false);
+    device_name_ = jsonStr(root, "deviceName");
+    if (device_name_.size() > kDeviceNameMax) device_name_.resize(kDeviceNameMax);
 
     cJSON_Delete(root);
     return true;
@@ -108,6 +119,7 @@ static std::string buildSettingsJson(const Settings& s, bool pretty) {
     if (!s.transparentTitlebar()) cJSON_AddBoolToObject(root, "transparentTitlebar", false);
     if (!s.logLevel().empty()) cJSON_AddStringToObject(root, "logLevel", s.logLevel().c_str());
     if (s.forceTranscoding()) cJSON_AddBoolToObject(root, "forceTranscoding", true);
+    if (!s.deviceName().empty()) cJSON_AddStringToObject(root, "deviceName", s.deviceName().c_str());
 
     char* str = pretty ? cJSON_Print(root) : cJSON_PrintUnformatted(root);
     std::string result(str);
@@ -150,6 +162,8 @@ std::string Settings::cliSettingsJson() const {
     if (!transparent_titlebar_) cJSON_AddBoolToObject(root, "transparentTitlebar", false);
     if (!log_level_.empty()) cJSON_AddStringToObject(root, "logLevel", log_level_.c_str());
     cJSON_AddBoolToObject(root, "forceTranscoding", force_transcoding_);
+    if (!device_name_.empty()) cJSON_AddStringToObject(root, "deviceName", device_name_.c_str());
+    cJSON_AddStringToObject(root, "deviceNameDefault", platformDeviceName().c_str());
 
     cJSON* opts = cJSON_AddArrayToObject(root, "hwdecOptions");
     for (const auto& o : hwdecOptions())
@@ -160,4 +174,55 @@ std::string Settings::cliSettingsJson() const {
     cJSON_free(str);
     cJSON_Delete(root);
     return result;
+}
+
+#ifdef __APPLE__
+std::string macosComputerName();  // src/platform/macos.mm
+#endif
+
+std::string Settings::platformDeviceName() {
+#ifdef _WIN32
+    wchar_t buf[MAX_COMPUTERNAME_LENGTH + 1] = {};
+    DWORD len = sizeof(buf) / sizeof(buf[0]);
+    GetComputerNameW(buf, &len);
+    int utf8_len = WideCharToMultiByte(CP_UTF8, 0, buf, len, nullptr, 0, nullptr, nullptr);
+    std::string out(utf8_len, '\0');
+    WideCharToMultiByte(CP_UTF8, 0, buf, len, out.data(), utf8_len, nullptr, nullptr);
+#elif defined(__APPLE__)
+    std::string out = macosComputerName();
+#else
+    char buf[256] = {};
+    gethostname(buf, sizeof(buf) - 1);
+    std::string out(buf);
+#endif
+    if (out.size() > kDeviceNameMax) out.resize(kDeviceNameMax);
+    return out;
+}
+
+void Settings::setDeviceName(const std::string& v) {
+    // Server's auth header parser preserves whitespace verbatim, so " foo "
+    // would round-trip into the Devices table.
+    std::string trimmed;
+    trimmed.reserve(v.size());
+    bool in_space = true;
+    for (char c : v) {
+        bool ws = c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == '\v' || c == '\f';
+        if (ws) {
+            if (!in_space) trimmed.push_back(' ');
+            in_space = true;
+        } else {
+            trimmed.push_back(c);
+            in_space = false;
+        }
+    }
+    if (!trimmed.empty() && trimmed.back() == ' ') trimmed.pop_back();
+    if (trimmed.size() > kDeviceNameMax) trimmed.resize(kDeviceNameMax);
+    // Don't persist the platform default — leave the override empty so
+    // hostname changes propagate automatically on the next launch.
+    if (trimmed == platformDeviceName()) trimmed.clear();
+    device_name_ = std::move(trimmed);
+}
+
+std::string Settings::effectiveDeviceName() const {
+    return device_name_.empty() ? platformDeviceName() : device_name_;
 }

--- a/src/settings.h
+++ b/src/settings.h
@@ -65,11 +65,23 @@ public:
     bool forceTranscoding() const { return force_transcoding_; }
     void setForceTranscoding(bool v) { force_transcoding_ = v; }
 
+    // Device name override. Empty = use platform default (hostname).
+    const std::string& deviceName() const { return device_name_; }
+    void setDeviceName(const std::string& v);
+
+    // System hostname, truncated to the server's 64-char DeviceName limit.
+    // Used when no explicit override is set.
+    static std::string platformDeviceName();
+
+    // Stored override if non-empty, otherwise platformDeviceName().
+    std::string effectiveDeviceName() const;
+
     // JSON string of CLI-equivalent settings (for injection into JS)
     std::string cliSettingsJson() const;
 
-private:
     Settings() = default;
+
+private:
     std::string getConfigPath();
 
     std::string server_url_;
@@ -85,6 +97,7 @@ private:
     bool transparent_titlebar_ = true;
     std::string log_level_;
     bool force_transcoding_ = false;
+    std::string device_name_;
 
     std::mutex save_mutex_;  // Prevent concurrent saves
 };

--- a/src/web/client-settings.js
+++ b/src/web/client-settings.js
@@ -242,17 +242,24 @@
                         helpText.textContent = setting.help;
                         container.appendChild(helpText);
                     }
-                } else if (setting.inputType === 'textarea') {
+                } else if (setting.inputType === 'text' || setting.inputType === 'textarea') {
+                    const isTextarea = setting.inputType === 'textarea';
                     container.className = 'inputContainer';
                     const labelText = document.createElement('label');
                     labelText.className = 'inputLabel';
                     labelText.textContent = setting.displayName;
                     container.appendChild(labelText);
-                    const control = document.createElement('textarea');
+                    const control = document.createElement(isTextarea ? 'textarea' : 'input');
                     control.className = 'emby-input';
-                    control.style.resize = 'none';
                     control.value = values[setting.key] || '';
-                    control.rows = 2;
+                    if (isTextarea) {
+                        control.style.resize = 'none';
+                        control.rows = 2;
+                    } else {
+                        control.type = 'text';
+                        if (setting.placeholder) control.placeholder = setting.placeholder;
+                        if (setting.maxLength) control.maxLength = setting.maxLength;
+                    }
                     control.addEventListener('change', () => {
                         jmpInfo.settings[section][setting.key] = control.value;
                         window.api.settings.setValue(section, setting.key, control.value);

--- a/src/web/client-settings.js
+++ b/src/web/client-settings.js
@@ -319,7 +319,7 @@
             btn.type = 'button';
             btn.addEventListener('click', () => {
                 if (window.jmpNative && window.jmpNative.openConfigDir) {
-                    console.log('[SETTINGS] called openConfigDir');
+                    console.debug('[SETTINGS] called openConfigDir');
                     window.jmpNative.openConfigDir();
                 }
             });

--- a/src/web/connectivityHelper.js
+++ b/src/web/connectivityHelper.js
@@ -6,7 +6,7 @@ window.jmpCheckServerConnectivity = (() => {
 
     // Called by native code when result is ready
     window._onServerConnectivityResult = (url, success, resolvedUrl) => {
-        console.log('Connectivity result:', url, success, resolvedUrl);
+        console.debug('Connectivity result:', url, success, resolvedUrl);
         if (pendingUrl === url) {
             if (success) {
                 pendingResolve(resolvedUrl);
@@ -35,7 +35,7 @@ window.jmpCheckServerConnectivity = (() => {
             pendingReject = reject;
             pendingUrl = url;
 
-            console.log('Checking connectivity:', url);
+            console.debug('Checking connectivity:', url);
             window.jmpNative.checkServerConnectivity(url);
         });
     };

--- a/src/web/input-plugin.js
+++ b/src/web/input-plugin.js
@@ -11,7 +11,7 @@
             this.pendingArtworkUrl = null;
             this.attachedPlayer = null;
 
-            console.log('[Media] inputPlugin constructed with playbackManager:', !!playbackManager);
+            console.debug('[Media] inputPlugin constructed with playbackManager:', !!playbackManager);
 
             if (playbackManager && window.Events) {
                 this.setupEvents(playbackManager);
@@ -32,7 +32,7 @@
                 RunTimeTicks: item.RunTimeTicks || 0,
                 Id: item.Id || ''
             };
-            console.log('[Media] notifyMetadata:', meta.Name);
+            console.debug('[Media] notifyMetadata:', meta.Name);
             window.jmpNative.notifyMetadata(JSON.stringify(meta));
             this.fetchAlbumArt(item);
         }
@@ -83,12 +83,12 @@
 
             const imageUrl = this.getImageUrl(item, baseUrl);
             if (!imageUrl) {
-                console.log('[Media] No album art URL found');
+                console.debug('[Media] No album art URL found');
                 return;
             }
 
             if (imageUrl === this.pendingArtworkUrl) {
-                console.log('[Media] Album art already pending for:', imageUrl);
+                console.debug('[Media] Album art already pending for:', imageUrl);
                 return;
             }
 
@@ -96,7 +96,7 @@
             this.artworkAbortController = new AbortController();
             const signal = this.artworkAbortController.signal;
 
-            console.log('[Media] Fetching album art:', imageUrl);
+            console.debug('[Media] Fetching album art:', imageUrl);
 
             fetch(imageUrl, { signal })
                 .then(response => {
@@ -108,7 +108,7 @@
                     reader.onloadend = () => {
                         if (signal.aborted) return;
                         const dataUri = reader.result;
-                        console.log('[Media] Album art fetched, sending data URI');
+                        console.debug('[Media] Album art fetched, sending data URI');
                         window.jmpNative.notifyArtwork(dataUri);
                         this.pendingArtworkUrl = null;
                     };
@@ -116,9 +116,9 @@
                 })
                 .catch(err => {
                     if (err.name === 'AbortError') {
-                        console.log('[Media] Album art fetch aborted');
+                        console.debug('[Media] Album art fetch aborted');
                     } else {
-                        console.log('[Media] Album art fetch failed:', err.message);
+                        console.warn('[Media] Album art fetch failed:', err.message);
                     }
                     this.pendingArtworkUrl = null;
                 });
@@ -162,7 +162,7 @@
             const drift = actual - expected;
 
             if (Math.abs(drift) > 2000) {
-                console.log('[Media] Position drift detected: expected=' + Math.floor(expected) + ' actual=' + Math.floor(actual) + ' drift=' + Math.floor(drift));
+                console.debug('[Media] Position drift detected: expected=' + Math.floor(expected) + ' actual=' + Math.floor(actual) + ' drift=' + Math.floor(drift));
                 if (drift > 0) {
                     window.jmpNative.notifySeek(Math.floor(actual));
                 } else {
@@ -190,7 +190,7 @@
 
                 if (!playlist || !Array.isArray(playlist) || playlist.length === 0 ||
                     currentIndex === undefined || currentIndex === null || currentIndex < 0) {
-                    console.log('[Media] updateQueueState: queue invalid (idx=' + currentIndex + ' len=' + (playlist?.length || 0) + '), keeping last state');
+                    console.warn('[Media] updateQueueState: queue invalid (idx=' + currentIndex + ' len=' + (playlist?.length || 0) + '), keeping last state');
                     return;
                 }
 
@@ -200,7 +200,7 @@
                 const isMusic = state?.NowPlayingItem?.MediaType === 'Audio';
                 const canPrev = isMusic ? true : (currentIndex > 0);
 
-                console.log('[Media] updateQueueState: idx=' + currentIndex + ' len=' + playlist.length + ' canNext=' + canNext + ' canPrev=' + canPrev);
+                console.debug('[Media] updateQueueState: idx=' + currentIndex + ' len=' + playlist.length + ' canNext=' + canNext + ' canPrev=' + canPrev);
                 window.jmpNative.notifyQueueChange(canNext, canPrev);
             } catch (e) {
                 console.error('[Media] updateQueueState error:', e);
@@ -208,11 +208,11 @@
         }
 
         setupEvents(pm) {
-            console.log('[Media] Setting up playbackManager events');
+            console.debug('[Media] Setting up playbackManager events');
             const self = this;
 
             window.Events.on(pm, 'playbackstart', (e, player) => {
-                console.log('[Media] playbackstart event, player:', !!player);
+                console.debug('[Media] playbackstart event, player:', !!player);
 
                 const state = pm.getPlayerState ? pm.getPlayerState() : null;
 
@@ -220,7 +220,7 @@
                     self.notifyMetadata(state.NowPlayingItem);
                 }
 
-                console.log('[Media] Sending Playing state from playbackstart');
+                console.debug('[Media] Sending Playing state from playbackstart');
                 if (window.jmpNative) window.jmpNative.notifyPlaybackState('Playing');
                 self.startPositionUpdates();
                 self.updateQueueState();
@@ -235,7 +235,7 @@
                     self.attachedPlayer = player;
 
                     window.Events.on(player, 'playing', () => {
-                        console.log('[Media] player.playing event');
+                        console.debug('[Media] player.playing event');
                         if (window.jmpNative) window.jmpNative.notifyPlaybackState('Playing');
                         self.updateQueueState();
 
@@ -250,7 +250,7 @@
                     });
 
                     window.Events.on(player, 'pause', () => {
-                        console.log('[Media] player.pause event');
+                        console.debug('[Media] player.pause event');
                         if (window.jmpNative) {
                             window.jmpNative.notifyPlaybackState('Paused');
                             const pos = pm.currentTime ? pm.currentTime() : 0;
@@ -262,7 +262,7 @@
 
                     window.Events.on(player, 'ratechange', () => {
                         const rate = player.getPlaybackRate ? player.getPlaybackRate() : 1.0;
-                        console.log('[Media] player.ratechange event, rate:', rate);
+                        console.debug('[Media] player.ratechange event, rate:', rate);
                         if (window.jmpNative) {
                             window.jmpNative.notifyRateChange(rate);
                             const pos = pm.currentTime ? pm.currentTime() : 0;
@@ -281,18 +281,18 @@
 
             window.Events.on(pm, 'playbackstop', (e, stopInfo) => {
                 try {
-                    console.log('[Media] playbackstop event, stopInfo:', JSON.stringify(stopInfo));
+                    console.debug('[Media] playbackstop event, stopInfo:', JSON.stringify(stopInfo));
                 } catch (err) {
-                    console.log('[Media] playbackstop event, stopInfo: [unserializable]');
+                    console.debug('[Media] playbackstop event, stopInfo: [unserializable]');
                 }
                 self.stopPositionUpdates();
 
                 const isNavigating = !!(stopInfo && stopInfo.nextMediaType);
                 if (!isNavigating) {
-                    console.log('[Media] Playback truly stopped, clearing state');
+                    console.debug('[Media] Playback truly stopped, clearing state');
                     if (window.jmpNative) window.jmpNative.notifyPlaybackState('Stopped');
                 } else {
-                    console.log('[Media] Navigating to next item, keeping metadata');
+                    console.debug('[Media] Navigating to next item, keeping metadata');
                 }
                 self.updateQueueState();
             });
@@ -313,40 +313,40 @@
             };
 
             window.api.input.hostInput.connect((actions) => {
-                console.log('[Media] hostInput received:', actions);
+                console.debug('[Media] hostInput received:', actions);
                 actions.forEach(action => {
                     const mappedAction = remap[action] || action;
-                    console.log('[Media] Sending to inputManager:', mappedAction);
+                    console.debug('[Media] Sending to inputManager:', mappedAction);
                     if (self.inputManager && typeof self.inputManager.handleCommand === 'function') {
                         self.inputManager.handleCommand(mappedAction, {});
                     } else {
-                        console.log('[Media] inputManager.handleCommand not available, inputManager:', !!self.inputManager);
+                        console.warn('[Media] inputManager.handleCommand not available, inputManager:', !!self.inputManager);
                     }
                 });
             });
 
             window.api.input.positionSeek.connect((positionMs) => {
-                console.log('[Media] positionSeek received:', positionMs);
+                console.debug('[Media] positionSeek received:', positionMs);
                 const currentPlayer = pm.getCurrentPlayer ? pm.getCurrentPlayer() : pm._currentPlayer;
                 if (currentPlayer) {
                     const duration = pm.duration ? pm.duration() : 0;
                     if (duration > 0) {
                         const percent = (positionMs * 10000) / duration * 100;
-                        console.log('[Media] Seeking to', percent.toFixed(2), '% (', positionMs, 'ms of', duration, 'ticks)');
+                        console.debug('[Media] Seeking to', percent.toFixed(2), '% (', positionMs, 'ms of', duration, 'ticks)');
                         pm.seekPercent(percent, currentPlayer);
                     }
                 }
             });
 
             window.api.input.rateChanged.connect((rate) => {
-                console.log('[Media] rateChanged received:', rate);
+                console.debug('[Media] rateChanged received:', rate);
                 const currentPlayer = pm.getCurrentPlayer ? pm.getCurrentPlayer() : pm._currentPlayer;
                 if (currentPlayer && typeof currentPlayer.setPlaybackRate === 'function') {
                     currentPlayer.setPlaybackRate(rate);
                 }
             });
 
-            console.log('[Media] Events setup complete');
+            console.debug('[Media] Events setup complete');
         }
 
         destroy() {
@@ -370,5 +370,5 @@
     }
 
     window._inputPlugin = inputPlugin;
-    console.log('[Media] inputPlugin class installed');
+    console.debug('[Media] inputPlugin class installed');
 })();

--- a/src/web/mpv-audio-player.js
+++ b/src/web/mpv-audio-player.js
@@ -106,5 +106,5 @@
     }
 
     window._mpvAudioPlayer = mpvAudioPlayer;
-    console.log('[Media] mpvAudioPlayer plugin installed');
+    console.debug('[Media] mpvAudioPlayer plugin installed');
 })();

--- a/src/web/mpv-player-base.js
+++ b/src/web/mpv-player-base.js
@@ -101,7 +101,7 @@
             return new Promise((resolve) => {
                 const val = options.url;
                 this._currentSrc = val;
-                console.log(`[Media] [${this.logTag}] Playing:`, val);
+                console.debug(`[Media] [${this.logTag}] Playing:`, val);
 
                 const ms = Math.round((options.playerStartPositionTicks || 0) / 10000);
                 this._currentPlayOptions = options;
@@ -127,7 +127,7 @@
                 this.events.trigger(this, 'unpause');
             }
             this.events.trigger(this, 'playing');
-            console.log(`[Media] [${this.logTag}] playing event triggered`);
+            console.debug(`[Media] [${this.logTag}] playing event triggered`);
         }
 
         // Playback control

--- a/src/web/mpv-video-player.js
+++ b/src/web/mpv-video-player.js
@@ -94,14 +94,14 @@
         }
 
         async play(options) {
-            console.log(`[Media] [${this.logTag}] play() called with options:`, options);
+            console.debug(`[Media] [${this.logTag}] play() called with options:`, options);
             this._started = false;
             this._timeUpdated = false;
             this._currentTime = null;
             this._endedPending = false;
             if (options.fullscreen) this.loading.show();  // fills entire web content area, not the actual screen
             await this.createMediaElement(options);
-            console.log(`[Media] [${this.logTag}] createMediaElement done, calling setCurrentSrc`);
+            console.debug(`[Media] [${this.logTag}] createMediaElement done, calling setCurrentSrc`);
             const result = await this.setCurrentSrc(options);
 
             // needed when only audio is single external
@@ -342,5 +342,5 @@
     }
 
     window._mpvVideoPlayer = mpvVideoPlayer;
-    console.log('[Media] mpvVideoPlayer class installed');
+    console.debug('[Media] mpvVideoPlayer class installed');
 })();

--- a/src/web/native-shim.js
+++ b/src/web/native-shim.js
@@ -78,7 +78,7 @@
     // window.jmpInfo - settings and device info
     window.jmpInfo = {
         version: '__APP_VERSION__',
-        deviceName: 'Jellyfin Desktop',
+        deviceName: _savedSettings.deviceName || _savedSettings.deviceNameDefault,
         mode: 'desktop',
         userAgent: navigator.userAgent,
         scriptPath: '',
@@ -104,7 +104,8 @@
             advanced: {
                 transparentTitlebar: _savedSettings.transparentTitlebar !== false,
                 titlebarThemeColor: _savedSettings.titlebarThemeColor !== false,
-                logLevel: _savedSettings.logLevel || ''
+                logLevel: _savedSettings.logLevel || '',
+                deviceName: _savedSettings.deviceName || ''
             }
         },
         settingsDescriptions: {
@@ -125,6 +126,7 @@
                 { key: 'forceTranscoding', displayName: 'Force Transcoding', help: 'Always request a transcoded stream from the server, even when direct play would work.' }
             ],
             advanced: [
+                { key: 'deviceName', displayName: 'Device Name', help: 'Identifies this machine to the server. Leave blank to use the system hostname.', inputType: 'text', maxLength: 64, placeholder: _savedSettings.deviceNameDefault },
                 { key: 'logLevel', displayName: 'Log Level', help: 'Set the application log verbosity level.', options: [
                     { value: '', title: 'Default (Info)' },
                     { value: 'verbose', title: 'Verbose' },

--- a/src/web/native-shim.js
+++ b/src/web/native-shim.js
@@ -77,7 +77,7 @@
 
     // window.jmpInfo - settings and device info
     window.jmpInfo = {
-        version: '1.0.0',
+        version: '__APP_VERSION__',
         deviceName: 'Jellyfin Desktop',
         mode: 'desktop',
         userAgent: navigator.userAgent,

--- a/src/web/native-shim.js
+++ b/src/web/native-shim.js
@@ -1,5 +1,5 @@
 (function() {
-    console.log('[Media] Installing native shim...');
+    console.debug('[Media] Installing native shim...');
 
     // Fullscreen state tracking via HTML5 Fullscreen API
     window._isFullscreen = false;
@@ -62,12 +62,12 @@
         };
         signal.connect = (cb) => {
             callbacks.push(cb);
-            console.log('[Media] [Signal] ' + name + ' connected, now has', callbacks.length, 'listeners');
+            console.debug('[Media] [Signal] ' + name + ' connected, now has', callbacks.length, 'listeners');
         };
         signal.disconnect = (cb) => {
             const idx = callbacks.indexOf(cb);
             if (idx >= 0) callbacks.splice(idx, 1);
-            console.log('[Media] [Signal] ' + name + ' disconnected, now has', callbacks.length, 'listeners');
+            console.debug('[Media] [Signal] ' + name + ' disconnected, now has', callbacks.length, 'listeners');
         };
         return signal;
     }
@@ -189,7 +189,7 @@
 
             // Methods
             load(url, options, streamdata, audioStream, subtitleStream, externalAudioUrl, externalSubUrl, callback) {
-                console.log('[Media] player.load:', url);
+                console.debug('[Media] player.load:', url);
                 window._jmpVideoActive = streamdata?.type === 'video';
                 if (callback) {
                     // Wait for playing signal before calling callback
@@ -212,63 +212,63 @@
                 }
             },
             stop() {
-                console.log('[Media] player.stop');
+                console.debug('[Media] player.stop');
                 restoreThemeColor();
                 if (window.jmpNative) window.jmpNative.playerStop();
             },
             pause() {
-                console.log('[Media] player.pause');
+                console.debug('[Media] player.pause');
                 if (window.jmpNative) window.jmpNative.playerPause();
                 playerState.paused = true;
             },
             play() {
-                console.log('[Media] player.play');
+                console.debug('[Media] player.play');
                 if (window.jmpNative) window.jmpNative.playerPlay();
                 playerState.paused = false;
             },
             seekTo(ms) {
-                console.log('[Media] player.seekTo:', ms);
+                console.debug('[Media] player.seekTo:', ms);
                 if (window.jmpNative) window.jmpNative.playerSeek(ms);
             },
             setVolume(vol) {
-                console.log('[Media] player.setVolume:', vol);
+                console.debug('[Media] player.setVolume:', vol);
                 playerState.volume = vol;
                 if (window.jmpNative) window.jmpNative.playerSetVolume(vol);
             },
             setMuted(muted) {
-                console.log('[Media] player.setMuted:', muted);
+                console.debug('[Media] player.setMuted:', muted);
                 playerState.muted = muted;
                 if (window.jmpNative) window.jmpNative.playerSetMuted(muted);
             },
             setPlaybackRate(rate) {
-                console.log('[Media] player.setPlaybackRate:', rate);
+                console.debug('[Media] player.setPlaybackRate:', rate);
                 if (window.jmpNative) window.jmpNative.playerSetSpeed(rate);
             },
             setSubtitleStream(index) {
-                console.log('[Media] player.setSubtitleStream:', index);
+                console.debug('[Media] player.setSubtitleStream:', index);
                 if (window.jmpNative) window.jmpNative.playerSetSubtitle(index);
             },
             addSubtitleStream(url) {
-                console.log('[Media] player.addSubtitleStream:', url);
+                console.debug('[Media] player.addSubtitleStream:', url);
                 if (window.jmpNative) window.jmpNative.playerAddSubtitle(url);
             },
             setAudioStream(index) {
-                console.log('[Media] player.setAudioStream:', index);
+                console.debug('[Media] player.setAudioStream:', index);
                 if (window.jmpNative) window.jmpNative.playerSetAudio(index);
             },
             addAudioStream(url) {
-                console.log('[Media] player.addAudioStream:', url);
+                console.debug('[Media] player.addAudioStream:', url);
                 if (window.jmpNative) window.jmpNative.playerAddAudio(url);
             },
             setSubtitleDelay(ms) {
-                console.log('[Media] player.setSubtitleDelay:', ms);
+                console.debug('[Media] player.setSubtitleDelay:', ms);
             },
             setAudioDelay(ms) {
-                console.log('[Media] player.setAudioDelay:', ms);
+                console.debug('[Media] player.setAudioDelay:', ms);
                 if (window.jmpNative) window.jmpNative.playerSetAudioDelay(ms / 1000.0);
             },
             setAspectMode(mode) {
-                console.log('[Media] player.setAspectMode:', mode);
+                console.debug('[Media] player.setAspectMode:', mode);
                 if (window.jmpNative) window.jmpNative.playerSetAspectMode(mode);
             },
             setVideoRectangle(x, y, w, h) {
@@ -326,9 +326,9 @@
 
     // Expose signal emitter for native code
     window._nativeEmit = function(signal, ...args) {
-        console.log('[Media] _nativeEmit called with signal:', signal, 'args:', args);
+        console.debug('[Media] _nativeEmit called with signal:', signal, 'args:', args);
         if (window.api && window.api.player && window.api.player[signal]) {
-            console.log('[Media] Firing signal:', signal);
+            console.debug('[Media] Firing signal:', signal);
             window.api.player[signal](...args);
         } else {
             console.error('[Media] Signal not found:', signal, 'api exists:', !!window.api);
@@ -351,15 +351,15 @@
     };
     // Native emitters for media session control commands
     window._nativeHostInput = function(actions) {
-        console.log('[Media] _nativeHostInput:', actions);
+        console.debug('[Media] _nativeHostInput:', actions);
         window.api.input.hostInput(actions);
     };
     window._nativeSetRate = function(rate) {
-        console.log('[Media] _nativeSetRate:', rate);
+        console.debug('[Media] _nativeSetRate:', rate);
         window.api.input.rateChanged(rate);
     };
     window._nativeSeek = function(positionMs) {
-        console.log('[Media] _nativeSeek:', positionMs);
+        console.debug('[Media] _nativeSeek:', positionMs);
         window.api.input.positionSeek(positionMs);
     };
 
@@ -512,5 +512,5 @@
         }
     });
 
-    console.log('[Media] Native shim installed');
+    console.debug('[Media] Native shim installed');
 })();

--- a/src/web/overlay.html
+++ b/src/web/overlay.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>Jellyfin</title>
+    <link rel="stylesheet" href="theme.css">
     <link rel="stylesheet" href="overlay.css">
 </head>
 <body>

--- a/src/web/overlay.js
+++ b/src/web/overlay.js
@@ -25,7 +25,7 @@ function cancellableDelay(ms, label) {
     return new Promise((resolve, reject) => {
         const t = setTimeout(() => { cancelWait = null; resolve(); }, ms);
         cancelWait = () => {
-            console.log('Cancelling ' + label + ' timer', t);
+            console.debug('Cancelling ' + label + ' timer', t);
             clearTimeout(t);
             cancelWait = null;
             reject(new Error('cancelled'));
@@ -35,11 +35,11 @@ function cancellableDelay(ms, label) {
 
 async function tryConnect(server, spinnerStartTime = Date.now()) {
     try {
-        console.log("Checking connectivity to:", server);
+        console.debug("Checking connectivity to:", server);
 
         const resolvedUrl = await window.jmpCheckServerConnectivity(server);
         console.log("Server connectivity check passed");
-        console.log("Resolved URL:", resolvedUrl);
+        console.debug("Resolved URL:", resolvedUrl);
 
         if (!isConnecting) return false;
 
@@ -75,7 +75,7 @@ async function tryConnect(server, spinnerStartTime = Date.now()) {
         return true;
     } catch (e) {
         if (/cancel/i.test(e && e.message)) {
-            console.log("Connection cancelled");
+            console.debug("Connection cancelled");
         } else {
             console.error("Server connectivity check failed:", e);
         }
@@ -166,7 +166,7 @@ const startConnecting = async () => {
 const cancelConnection = () => {
     if (!isConnecting) return;
 
-    console.log("Cancelling connection");
+    console.debug("Cancelling connection");
     // Native resets main on cancelServerConnectivity.
     mainLoaded = false;
     isConnecting = false;
@@ -216,10 +216,10 @@ document.addEventListener('keydown', (e) => {
     console.log('Auto-connect: starting');
 
     const savedServer = await savedServerUrlReady;
-    console.log('Auto-connect: savedServer =', savedServer);
+    console.debug('Auto-connect: savedServer =', savedServer);
 
     if (savedServer) {
-        console.log('Auto-connect: checking saved server', savedServer);
+        console.debug('Auto-connect: checking saved server', savedServer);
 
         // main.cpp pre-loads the saved URL into the main browser in parallel
         // with overlay startup, so don't issue a redundant navigateMain.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,3 +10,28 @@ target_include_directories(jellyfin_api_test PRIVATE
 )
 
 add_test(NAME jellyfin_api_test COMMAND jellyfin_api_test)
+
+set(_settings_test_paths
+    ${CMAKE_SOURCE_DIR}/src/paths/paths.cpp
+)
+if(APPLE)
+    list(APPEND _settings_test_paths ${CMAKE_SOURCE_DIR}/src/paths/macos.cpp)
+elseif(WIN32)
+    list(APPEND _settings_test_paths ${CMAKE_SOURCE_DIR}/src/paths/windows.cpp)
+else()
+    list(APPEND _settings_test_paths ${CMAKE_SOURCE_DIR}/src/paths/linux.cpp)
+endif()
+
+add_executable(settings_test
+    settings_test.cpp
+    ${CMAKE_SOURCE_DIR}/src/settings.cpp
+    ${CMAKE_SOURCE_DIR}/src/cjson/cJSON.c
+    ${_settings_test_paths}
+)
+
+target_include_directories(settings_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/third_party/doctest/include
+)
+
+add_test(NAME settings_test COMMAND settings_test)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,3 +35,15 @@ target_include_directories(settings_test PRIVATE
 )
 
 add_test(NAME settings_test COMMAND settings_test)
+
+add_executable(log_redact_test
+    log_redact_test.cpp
+    ${CMAKE_SOURCE_DIR}/src/log_redact.cpp
+)
+
+target_include_directories(log_redact_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/third_party/doctest/include
+)
+
+add_test(NAME log_redact_test COMMAND log_redact_test)

--- a/tests/log_redact_test.cpp
+++ b/tests/log_redact_test.cpp
@@ -1,0 +1,147 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+
+#include "log_redact.h"
+
+#include <string>
+
+using log_redact::censor;
+using log_redact::containsSecret;
+
+namespace {
+
+// 32-char hex token, like Jellyfin emits.
+constexpr const char* kToken = "7e7a0b378bc4440e85016c880ba4cfa7";
+constexpr const char* kRedacted = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+
+std::string redacted(std::string s) {
+    censor(s);
+    return s;
+}
+
+}  // namespace
+
+TEST_CASE("censor leaves messages without sensitive patterns alone") {
+    CHECK(redacted("") == "");
+    CHECK(redacted("nothing to see here") == "nothing to see here");
+    CHECK(redacted("token=abc still safe") == "token=abc still safe");
+}
+
+TEST_CASE("censor preserves message length (overwrites in place)") {
+    std::string s = std::string("ApiKey=") + kToken + "&Tag=z";
+    auto before = s.size();
+    censor(s);
+    CHECK(s.size() == before);
+}
+
+TEST_CASE("censor redacts api_key= query param") {
+    std::string url = std::string("https://host/socket?api_key=") + kToken + "&deviceId=abc";
+    censor(url);
+    CHECK(url == std::string("https://host/socket?api_key=") + kRedacted + "&deviceId=abc");
+}
+
+TEST_CASE("censor redacts ApiKey= camelcase variant") {
+    std::string url = std::string("/stream.mkv?Static=true&ApiKey=") + kToken + "&Tag=xyz";
+    censor(url);
+    CHECK(url == std::string("/stream.mkv?Static=true&ApiKey=") + kRedacted + "&Tag=xyz");
+}
+
+TEST_CASE("censor redacts AccessToken JSON value") {
+    std::string json =
+        std::string("{\"UserId\":\"abc\",\"AccessToken\":\"") + kToken + "\",\"Other\":1}";
+    censor(json);
+    CHECK(json == std::string("{\"UserId\":\"abc\",\"AccessToken\":\"") + kRedacted +
+                      "\",\"Other\":1}");
+}
+
+TEST_CASE("censor redacts AccessToken= form") {
+    std::string s = std::string("AccessToken=") + kToken + " trailing";
+    censor(s);
+    CHECK(s == std::string("AccessToken=") + kRedacted + " trailing");
+}
+
+TEST_CASE("censor redacts X-MediaBrowser-Token header forms") {
+    std::string plain = std::string("X-MediaBrowser-Token=") + kToken + ";";
+    censor(plain);
+    CHECK(plain == std::string("X-MediaBrowser-Token=") + kRedacted + ";");
+
+    std::string encoded = std::string("X-MediaBrowser-Token%3D") + kToken + "&";
+    censor(encoded);
+    CHECK(encoded == std::string("X-MediaBrowser-Token%3D") + kRedacted + "&");
+}
+
+TEST_CASE("censor redacts every occurrence of the same pattern") {
+    std::string s = std::string("first ApiKey=") + kToken + " second ApiKey=" + kToken;
+    censor(s);
+    CHECK(s == std::string("first ApiKey=") + kRedacted + " second ApiKey=" + kRedacted);
+}
+
+TEST_CASE("censor handles multiple distinct patterns in one message") {
+    std::string s = std::string("api_key=") + kToken + " and AccessToken=" + kToken;
+    censor(s);
+    CHECK(s == std::string("api_key=") + kRedacted + " and AccessToken=" + kRedacted);
+}
+
+TEST_CASE("censor redacts to end-of-string when no terminator follows") {
+    std::string s = std::string("trailing ApiKey=") + kToken;
+    censor(s);
+    CHECK(s == std::string("trailing ApiKey=") + kRedacted);
+}
+
+TEST_CASE("censor redacts short token values to their actual length") {
+    std::string s = "ApiKey=abc&next=1";
+    censor(s);
+    CHECK(s == "ApiKey=xxx&next=1");
+}
+
+TEST_CASE("censor leaves pattern with no token unchanged") {
+    std::string s = "ApiKey=&Tag=xyz";
+    std::string copy = s;
+    censor(copy);
+    CHECK(copy == s);
+
+    std::string at_eof = "trailing ApiKey=";
+    std::string at_eof_copy = at_eof;
+    censor(at_eof_copy);
+    CHECK(at_eof_copy == at_eof);
+}
+
+TEST_CASE("censor matches case-sensitively (api_key vs API_KEY)") {
+    std::string s = std::string("API_KEY=") + kToken;
+    std::string copy = s;
+    censor(copy);
+    CHECK(copy == s);  // pattern is lowercase api_key= only
+}
+
+TEST_CASE("containsSecret returns true only when a token follows") {
+    CHECK(containsSecret(std::string("ApiKey=") + kToken));
+    CHECK(containsSecret("ApiKey=x"));  // even a single char counts
+
+    CHECK_FALSE(containsSecret(""));
+    CHECK_FALSE(containsSecret("nothing relevant"));
+    CHECK_FALSE(containsSecret("ApiKey=&next=1"));  // pattern present, terminator immediately after
+    CHECK_FALSE(containsSecret("ApiKey="));         // pattern at EOF, no value
+    CHECK_FALSE(containsSecret("apikey lowercase mention only"));
+}
+
+TEST_CASE("containsSecret detects each pattern variant") {
+    CHECK(containsSecret(std::string("api_key=") + kToken));
+    CHECK(containsSecret(std::string("ApiKey=") + kToken));
+    CHECK(containsSecret(std::string("AccessToken=") + kToken));
+    CHECK(containsSecret(std::string("AccessToken\":\"") + kToken));
+    CHECK(containsSecret(std::string("X-MediaBrowser-Token=") + kToken));
+    CHECK(containsSecret(std::string("X-MediaBrowser-Token%3D") + kToken));
+}
+
+TEST_CASE("censor preserves rest of multi-pattern realistic playback URL") {
+    std::string url =
+        "https://localhost:8096/Videos/abc/stream.mkv?Static=true"
+        "&deviceId=opaque&ApiKey=";
+    url += kToken;
+    url += "&Tag=298f007d1192550985fc1e5960bbb3d7";
+    censor(url);
+    CHECK(url ==
+          std::string("https://localhost:8096/Videos/abc/stream.mkv?Static=true"
+                      "&deviceId=opaque&ApiKey=") +
+              kRedacted + "&Tag=298f007d1192550985fc1e5960bbb3d7");
+}

--- a/tests/settings_test.cpp
+++ b/tests/settings_test.cpp
@@ -1,0 +1,90 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+
+#include "settings.h"
+
+#include <string>
+
+#ifdef __APPLE__
+// Stub for src/platform/macos.mm symbol so tests don't link the platform layer.
+std::string macosComputerName() { return "test-host"; }
+#endif
+
+TEST_CASE("setDeviceName trims leading and trailing whitespace") {
+    Settings s;
+    s.setDeviceName("  foo  ");
+    CHECK(s.deviceName() == "foo");
+
+    s.setDeviceName("\t\nfoo\r\n");
+    CHECK(s.deviceName() == "foo");
+}
+
+TEST_CASE("setDeviceName collapses internal whitespace runs to a single space") {
+    Settings s;
+    s.setDeviceName("foo  bar");
+    CHECK(s.deviceName() == "foo bar");
+
+    s.setDeviceName("foo\t\tbar");
+    CHECK(s.deviceName() == "foo bar");
+
+    s.setDeviceName("foo \t\nbar   baz");
+    CHECK(s.deviceName() == "foo bar baz");
+}
+
+TEST_CASE("setDeviceName treats whitespace-only input as empty") {
+    Settings s;
+    s.setDeviceName("   \t\n  ");
+    CHECK(s.deviceName().empty());
+}
+
+TEST_CASE("setDeviceName preserves single internal spaces") {
+    Settings s;
+    s.setDeviceName("Andrew's MacBook Pro");
+    CHECK(s.deviceName() == "Andrew's MacBook Pro");
+}
+
+TEST_CASE("setDeviceName clamps to 64 chars (server's DeviceName column limit)") {
+    Settings s;
+    std::string long_name(100, 'x');
+    s.setDeviceName(long_name);
+    CHECK(s.deviceName().size() == 64);
+    CHECK(s.deviceName() == std::string(64, 'x'));
+}
+
+TEST_CASE("setDeviceName clamps after whitespace normalization") {
+    Settings s;
+    std::string padded = "  " + std::string(70, 'x') + "  ";
+    s.setDeviceName(padded);
+    CHECK(s.deviceName().size() == 64);
+}
+
+TEST_CASE("setDeviceName clears override when value equals platform default") {
+    Settings s;
+    s.setDeviceName("custom");
+    REQUIRE(s.deviceName() == "custom");
+
+    s.setDeviceName(Settings::platformDeviceName());
+    CHECK(s.deviceName().empty());
+}
+
+TEST_CASE("setDeviceName clears override when whitespace-padded default is supplied") {
+    Settings s;
+    s.setDeviceName("custom");
+    REQUIRE(s.deviceName() == "custom");
+
+    s.setDeviceName("  " + Settings::platformDeviceName() + "  ");
+    CHECK(s.deviceName().empty());
+}
+
+TEST_CASE("effectiveDeviceName falls back to platform default when override empty") {
+    Settings s;
+    CHECK(s.deviceName().empty());
+    CHECK(s.effectiveDeviceName() == Settings::platformDeviceName());
+
+    s.setDeviceName("custom");
+    CHECK(s.effectiveDeviceName() == "custom");
+}
+
+TEST_CASE("platformDeviceName respects the 64-char server limit") {
+    CHECK(Settings::platformDeviceName().size() <= 64);
+}


### PR DESCRIPTION
- Set a consistent User-Agent header for all requests to the server (eg. `JellyfinDesktop/3.0.0-dev+c77fce9-dirty`)
- Properly set the the Jellyfin device name (default is the host name; can be customized in settings)
- Mask access tokens in logs
- Re-level log items