### PR TITLE
Clean up version string handling

### DIFF
--- a/cmake/GenerateVersion.cmake
+++ b/cmake/GenerateVersion.cmake
@@ -59,16 +59,16 @@ if(NOT "${APP_VERSION}" STREQUAL "${CACHED_VERSION}" OR
     file(WRITE "${EPOCH_CACHE}" "${SOURCE_EPOCH}")
     file(WRITE "${CEF_CACHE}" "${APP_CEF_VERSION}")
     if(HAS_GIT_HASH)
-        set(APP_VERSION_STRING "${APP_VERSION}+${APP_GIT_HASH}")
+        set(APP_VERSION_FULL "${APP_VERSION}+${APP_GIT_HASH}")
     else()
-        set(APP_VERSION_STRING "${APP_VERSION}")
+        set(APP_VERSION_FULL "${APP_VERSION}")
     endif()
     file(WRITE "${VERSION_FILE}"
 "#pragma once
 
 #define APP_VERSION \"${APP_VERSION}\"
-#define APP_VERSION_STRING \"${APP_VERSION_STRING}\"
-#define APP_USER_AGENT \"JellyfinDesktop/${APP_VERSION_STRING}\"
+#define APP_VERSION_FULL \"${APP_VERSION_FULL}\"
+#define APP_USER_AGENT \"JellyfinDesktop/${APP_VERSION_FULL}\"
 #define APP_CEF_VERSION \"${APP_CEF_VERSION}\"
 ")
     message(STATUS "version.h updated: ${APP_VERSION}+${APP_GIT_HASH} cef=${APP_CEF_VERSION}")

--- a/cmake/GenerateVersion.cmake
+++ b/cmake/GenerateVersion.cmake
@@ -1,13 +1,16 @@
 # Generate version.h at build time
 # Called via: cmake -P GenerateVersion.cmake
+#
+# APP_VERSION_FULL rules:
+# - No git available (e.g. tarball build): APP_VERSION as-is.
+# - HEAD clean and exactly tagged "v${APP_VERSION}" (release build): APP_VERSION as-is.
+# - Otherwise: "${APP_VERSION}+${short-sha}", with "-dirty" appended when working tree has changes.
+#
+# Only rewrites version.h when its contents would actually change, to avoid
+# triggering rebuilds of every TU that includes it.
 
 set(VERSION_FILE "${BINARY_DIR}/src/version.h")
-set(VERSION_CACHE "${BINARY_DIR}/src/.version_cache")
-set(HASH_CACHE "${BINARY_DIR}/src/.git_hash_cache")
-set(EPOCH_CACHE "${BINARY_DIR}/src/.epoch_cache")
-set(CEF_CACHE "${BINARY_DIR}/src/.cef_version_cache")
 
-# Read current values
 file(READ "${SOURCE_DIR}/VERSION" APP_VERSION)
 string(STRIP "${APP_VERSION}" APP_VERSION)
 
@@ -15,55 +18,39 @@ file(READ "${SOURCE_DIR}/CEF_VERSION" APP_CEF_VERSION)
 string(STRIP "${APP_CEF_VERSION}" APP_CEF_VERSION)
 
 execute_process(
-    COMMAND git describe --always --dirty
+    COMMAND git rev-parse --short HEAD
     WORKING_DIRECTORY "${SOURCE_DIR}"
-    OUTPUT_VARIABLE APP_GIT_HASH
+    OUTPUT_VARIABLE APP_GIT_SHA
     OUTPUT_STRIP_TRAILING_WHITESPACE
     ERROR_QUIET
     RESULT_VARIABLE GIT_RESULT
 )
-if(NOT GIT_RESULT EQUAL 0 OR APP_GIT_HASH STREQUAL "")
-    set(APP_GIT_HASH "")
-    set(HAS_GIT_HASH 0)
+if(NOT GIT_RESULT EQUAL 0 OR APP_GIT_SHA STREQUAL "")
+    set(APP_VERSION_FULL "${APP_VERSION}")
 else()
-    set(HAS_GIT_HASH 1)
-endif()
-
-set(SOURCE_EPOCH "$ENV{SOURCE_DATE_EPOCH}")
-
-# Read cached values
-set(CACHED_VERSION "")
-set(CACHED_HASH "")
-set(CACHED_EPOCH "")
-set(CACHED_CEF "")
-if(EXISTS "${VERSION_CACHE}")
-    file(READ "${VERSION_CACHE}" CACHED_VERSION)
-endif()
-if(EXISTS "${HASH_CACHE}")
-    file(READ "${HASH_CACHE}" CACHED_HASH)
-endif()
-if(EXISTS "${EPOCH_CACHE}")
-    file(READ "${EPOCH_CACHE}" CACHED_EPOCH)
-endif()
-if(EXISTS "${CEF_CACHE}")
-    file(READ "${CEF_CACHE}" CACHED_CEF)
-endif()
-
-# Update if changed
-if(NOT "${APP_VERSION}" STREQUAL "${CACHED_VERSION}" OR
-   NOT "${APP_GIT_HASH}" STREQUAL "${CACHED_HASH}" OR
-   NOT "${SOURCE_EPOCH}" STREQUAL "${CACHED_EPOCH}" OR
-   NOT "${APP_CEF_VERSION}" STREQUAL "${CACHED_CEF}")
-    file(WRITE "${VERSION_CACHE}" "${APP_VERSION}")
-    file(WRITE "${HASH_CACHE}" "${APP_GIT_HASH}")
-    file(WRITE "${EPOCH_CACHE}" "${SOURCE_EPOCH}")
-    file(WRITE "${CEF_CACHE}" "${APP_CEF_VERSION}")
-    if(HAS_GIT_HASH)
-        set(APP_VERSION_FULL "${APP_VERSION}+${APP_GIT_HASH}")
-    else()
+    execute_process(
+        COMMAND git diff --quiet HEAD
+        WORKING_DIRECTORY "${SOURCE_DIR}"
+        RESULT_VARIABLE DIRTY_RESULT
+    )
+    execute_process(
+        COMMAND git describe --exact-match --tags HEAD
+        WORKING_DIRECTORY "${SOURCE_DIR}"
+        OUTPUT_VARIABLE APP_GIT_TAG
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+        RESULT_VARIABLE TAG_RESULT
+    )
+    if(DIRTY_RESULT EQUAL 0 AND TAG_RESULT EQUAL 0 AND APP_GIT_TAG STREQUAL "v${APP_VERSION}")
         set(APP_VERSION_FULL "${APP_VERSION}")
+    elseif(DIRTY_RESULT EQUAL 0)
+        set(APP_VERSION_FULL "${APP_VERSION}+${APP_GIT_SHA}")
+    else()
+        set(APP_VERSION_FULL "${APP_VERSION}+${APP_GIT_SHA}-dirty")
     endif()
-    file(WRITE "${VERSION_FILE}"
+endif()
+
+set(NEW_CONTENT
 "#pragma once
 
 #define APP_VERSION \"${APP_VERSION}\"
@@ -71,5 +58,13 @@ if(NOT "${APP_VERSION}" STREQUAL "${CACHED_VERSION}" OR
 #define APP_USER_AGENT \"JellyfinDesktop/${APP_VERSION_FULL}\"
 #define APP_CEF_VERSION \"${APP_CEF_VERSION}\"
 ")
-    message(STATUS "version.h updated: ${APP_VERSION}+${APP_GIT_HASH} cef=${APP_CEF_VERSION}")
+
+set(OLD_CONTENT "")
+if(EXISTS "${VERSION_FILE}")
+    file(READ "${VERSION_FILE}" OLD_CONTENT)
+endif()
+
+if(NOT "${NEW_CONTENT}" STREQUAL "${OLD_CONTENT}")
+    file(WRITE "${VERSION_FILE}" "${NEW_CONTENT}")
+    message(STATUS "version.h updated: ${APP_VERSION_FULL} cef=${APP_CEF_VERSION}")
 endif()

--- a/src/cef/cef_app.cpp
+++ b/src/cef/cef_app.cpp
@@ -409,7 +409,7 @@ void App::OnContextCreated(CefRefPtr<CefBrowser> browser,
     };
     replace_first("__SERVER_URL__", Settings::instance().serverUrl());
     replace_first("__SETTINGS_JSON__", Settings::instance().cliSettingsJson());
-    replace_first("__APP_VERSION__", APP_VERSION_STRING);
+    replace_first("__APP_VERSION__", APP_VERSION);
     if (profile->HasKey("device_profile_json"))
         replace_first("__DEVICE_PROFILE_JSON__",
                       profile->GetString("device_profile_json").ToString());

--- a/src/cef/resource_handler.cpp
+++ b/src/cef/resource_handler.cpp
@@ -71,7 +71,7 @@ CefRefPtr<CefResourceHandler> EmbeddedSchemeHandlerFactory::Create(
         // hand-rolled JSON). Log paths are omitted when file logging is
         // disabled — the panel renders only the rows present in the data.
         auto dict = CefDictionaryValue::Create();
-        dict->SetString("app", APP_VERSION_STRING);
+        dict->SetString("app", APP_VERSION_FULL);
         dict->SetString("cef", APP_CEF_VERSION);
         dict->SetString("configDir", absPath(paths::getConfigDir()));
         const std::string& log_path = activeLogPath();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -410,7 +410,7 @@ int main(int argc, char* argv[]) {
                    kDefaultLogLevelName, kHwdecDefault);
             return 0;
         } else if (strcmp(argv[i], "-v") == 0 || strcmp(argv[i], "--version") == 0) {
-            printf("jellyfin-desktop %s\n\nCEF %s\n\n", APP_VERSION_STRING, CEF_VERSION);
+            printf("jellyfin-desktop %s\n\nCEF %s\n\n", APP_VERSION_FULL, CEF_VERSION);
             mpv_handle* h = mpv_create();
             if (h && mpv_initialize(h) >= 0) {
                 for (const char* prop : {"mpv-version", "ffmpeg-version"}) {
@@ -490,7 +490,7 @@ int main(int argc, char* argv[]) {
     }
     initLogging(log_path.c_str(), log_level);
 
-    LOG_INFO(LOG_MAIN, "jellyfin-desktop " APP_VERSION_STRING);
+    LOG_INFO(LOG_MAIN, "jellyfin-desktop " APP_VERSION_FULL);
     LOG_INFO(LOG_MAIN, "CEF {}", CEF_VERSION);
     if (!log_path.empty()) LOG_INFO(LOG_MAIN, "Log file: {}", log_path.c_str());
 
@@ -730,7 +730,7 @@ int main(int argc, char* argv[]) {
     {
         auto caps = mpv_capabilities::Query(g_mpv.Get());
         jellyfin_device_profile::SetCachedJson(jellyfin_device_profile::Build(
-            caps, "Jellyfin Desktop", APP_VERSION_STRING,
+            caps, "Jellyfin Desktop", APP_VERSION_FULL,
             Settings::instance().forceTranscoding()));
     }
 


### PR DESCRIPTION
- Report bare version to jellyfin-web so the server stops flipping the stored value
- Smarter sha rules and self-checking regen in `GenerateVersion.cmake`