### PR TITLE
fix(macos): use dns-safe macOS name

### DIFF
--- a/src/platform/macos.mm
+++ b/src/platform/macos.mm
@@ -29,11 +29,13 @@
 #include <mach/mach_time.h>
 #include <objc/runtime.h>
 
-// gethostname() on macOS returns a network-derived BSD hostname (e.g.
-// "dhcp-1-2-3-4.lan"); SCDynamicStoreCopyComputerName returns the stable
-// user-set name from System Settings → General → About → Name.
+// SCDynamicStoreCopyComputerName returns the freeform "Computer Name" from
+// System Settings — which can contain emoji, smart quotes, CJK, and other
+// non-ASCII that breaks the HTTP header.
+// SCDynamicStoreCopyLocalHostName returns the Bonjour hostname: always DNS-safe ASCII (letters, digits,
+// hyphens), derived from the Computer Name by macOS itself.
 std::string macosComputerName() {
-    CFStringRef name = SCDynamicStoreCopyComputerName(nullptr, nullptr);
+    CFStringRef name = SCDynamicStoreCopyLocalHostName(nullptr);
     if (!name) return {};
     CFIndex len = CFStringGetLength(name);
     CFIndex max = CFStringGetMaximumSizeForEncoding(len, kCFStringEncodingUTF8) + 1;


### PR DESCRIPTION
SCDynamicStoreCopyComputerName could return any utf-8 string that is not a valid http header. SCDynamicStoreCopyLocalHostName is a safer alternative, but it also has it limitations. For non-latin user, the default name usualy includes the user name in non-latin characters and the normalized dns name could be a not recognizable name, as key characters are discarded. But at least it gurantees to return a safe string.

The complexity to make this fancier does not worth it IMO.

Fixes #328