### PR TITLE
macOS legacy bundle: rewrite all non-system absolute dylib paths

### DIFF
--- a/cmake/CompleteBundleMac.cmake.in
+++ b/cmake/CompleteBundleMac.cmake.in
@@ -84,7 +84,11 @@ function(resolve_dependency dep_path out_var)
         list(GET cellar_candidates 0 result)
       endif()
     endif()
-  elseif(dep_path MATCHES "^(/opt/homebrew|/usr/local)")
+  elseif(dep_path MATCHES "^/")
+    # Any absolute path that exists on disk — covers Homebrew prefixes
+    # and custom build prefixes (e.g. $HOME/jellyfin-deps used by the
+    # legacy workflow). System paths are already filtered out by
+    # fix_lib_dependencies before we get here.
     if(EXISTS "${dep_path}")
       set(result "${dep_path}")
     endif()
@@ -111,9 +115,15 @@ function(fix_lib_dependencies lib framework_libs_var)
   foreach(line ${otool_lines})
     string(STRIP "${line}" line)
 
-    # Check if dependency needs fixing
+    # Check if dependency needs fixing.
+    # Any non-system absolute path (e.g. Homebrew, $HOME/jellyfin-deps used
+    # by the legacy workflow) gets bundled. The exclusion list is small
+    # and stable: /usr/lib for libc et al, /System for OS frameworks,
+    # /Library for third-party system-wide installs that should stay
+    # external (e.g. Sparkle).
     set(needs_fix FALSE)
-    if(line MATCHES "^(@rpath|@loader_path|/opt/homebrew|/usr/local)")
+    if(line MATCHES "^(@rpath|@loader_path)" OR
+       (line MATCHES "^/" AND NOT line MATCHES "^(/usr/lib/|/System/|/Library/)"))
       set(needs_fix TRUE)
     endif()
 


### PR DESCRIPTION
Hotfix for a regression I introduced in eb025ed ("Cache ffmpeg and libplacebo builds"). That commit moved the build prefix from `/usr/local/jellyfin-deps` to `$HOME/jellyfin-deps` to avoid `actions/cache` permission problems when restoring under `/usr/local`. The bundler in `cmake/CompleteBundleMac.cmake.in` recognised dylib references via a small allowlist of prefixes (`@rpath`, `@loader_path`, `/opt/homebrew`, `/usr/local`) in two places: `fix_lib_dependencies` and `resolve_dependency`. Anything under `/Users/runner/...` matched neither, so libmpv's references to libavcodec/libplacebo/etc were left as absolute paths into the runner's home and the shipped DMG crashed at launch on the user's machine with `Library not loaded: '/Users/.../libplacebo.360.dylib'`.

The fix replaces both allowlists with a stable exclusion list — `/usr/lib`, `/System`, `/Library` are kept external; anything else absolute (or `@rpath`/`@loader_path`) gets bundled. Future build-prefix changes won't silently break bundling again.

Verified on macOS 12.7.6 Intel: DMG launches and runs; `otool -L` on the bundled libmpv shows ffmpeg/libplacebo refs now resolve to `@executable_path/../Frameworks/`.
