### PR TITLE
Fix display-sleep inhibit leaking past playback

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -228,6 +228,14 @@ static void cef_consumer_thread() {
             if (!g_web_browser) continue;
             switch (ev.type) {
             case MpvEventType::PAUSE:
+                // mpv's `pause` property is observable in idle state too,
+                // where pause=false does not imply playback is running.
+                // Without this guard, a stale pause=false event after
+                // END_FILE_* would flip state back to Playing and re-arm
+                // the display-sleep inhibit. The next FILE_LOADED brings
+                // state out of Stopped via the explicit assignment there.
+                if (g_playback_state.load(std::memory_order_relaxed)
+                    == PlaybackState::Stopped) break;
                 g_playback_state = ev.flag ? PlaybackState::Paused : PlaybackState::Playing;
                 update_idle_inhibit();
                 g_web_browser->execJs(ev.flag ? "window._nativeEmit('paused')" : "window._nativeEmit('playing')");
@@ -273,6 +281,11 @@ static void cef_consumer_thread() {
                 // pause=false, after the track-switch reinits land. Don't
                 // emit 'playing' here — JS must not see "playing" until
                 // mpv is actually unpaused with the right tracks selected.
+                // Bring state out of Stopped so the upcoming PAUSE events
+                // (pause=true from loadfile, then pause=false from
+                // ApplyPendingTrackSelectionAndPlay) are not blocked by
+                // the PAUSE handler's idle-state guard.
+                g_playback_state = PlaybackState::Paused;
                 g_mpv.ApplyPendingTrackSelectionAndPlay();
                 break;
             case MpvEventType::END_FILE_EOF:


### PR DESCRIPTION
After a video finished or was stopped, the display would never sleep again until the app was quit, even though the user was back on the browse screen and no playback was active.

Root cause: the PAUSE event handler in `src/main.cpp` derived `g_playback_state` solely from mpv's `pause` property:

```cpp
case MpvEventType::PAUSE:
    g_playback_state = ev.flag ? Paused : Playing;
    update_idle_inhibit();
```

mpv's `pause` property is observable in idle state too, where its value carries no playback semantics. After `END_FILE_*` correctly transitioned state to `Stopped` and released the `IOPMAssertionPreventUserIdleDisplaySleep`, a stale `pause=false` event from mpv (e.g. from `stop` resetting `pause` to its `--pause` default) flipped state back to `Playing`, and `update_idle_inhibit()` re-armed the display assertion — for as long as the app was open.

Fix: PAUSE events are only meaningful between `FILE_LOADED` and `END_FILE_*`. The handler now ignores them while `Stopped`, and `FILE_LOADED` explicitly sets `Paused` so the upcoming pause/unpause sequence (`pause=yes` from loadfile → `pause=false` from `ApplyPendingTrackSelectionAndPlay`) transitions correctly.

Verified on macOS 12.7.6 Intel: after stopping playback the display goes to sleep as expected, and the inhibit re-arms correctly on the next playback.
