### PR TITLE
appimage: drop redundant 'linux' from filename

### DIFF
--- a/dev/appimage/Dockerfile
+++ b/dev/appimage/Dockerfile
@@ -201,4 +201,4 @@ RUN mkdir -p /output && \
     --runtime-file /opt/tools/runtime-x86_64 \
     /AppDir /output/JellyfinDesktop-x86_64.AppImage
 
-CMD ["sh", "-c", "cp /output/JellyfinDesktop-x86_64.AppImage /host-output/JellyfinDesktop-${VERSION}-linux-x86_64.AppImage"]
+CMD ["sh", "-c", "cp /output/JellyfinDesktop-x86_64.AppImage /host-output/JellyfinDesktop-${VERSION}-x86_64.AppImage"]

--- a/dev/appimage/build.sh
+++ b/dev/appimage/build.sh
@@ -30,4 +30,4 @@ ${CONTAINER_CMD} run --rm \
     jellyfin-desktop-appimage
 
 echo ""
-echo "AppImage: ${OUTPUT_DIR}/JellyfinDesktop-${VERSION}-linux-x86_64.AppImage"
+echo "AppImage: ${OUTPUT_DIR}/JellyfinDesktop-${VERSION}-x86_64.AppImage"


### PR DESCRIPTION
https://github.com/jellyfin/jellyfin-desktop/issues/355