### PR TITLE
fix(arm64): support native Linux aarch64 builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -443,15 +443,7 @@ endif()
 # mpv configuration
 option(BUILD_MPV_CLI "Also build the standalone mpv CLI binary from the submodule (for rendering comparisons; requires building mpv from submodule, not EXTERNAL_MPV_DIR)" OFF)
 
-# Auto-detect external mpv from /opt if it exists
-set(_DEFAULT_EXTERNAL_MPV_DIR "")
-if(EXISTS "/opt/jellyfin-desktop/libmpv/lib/libmpv.so")
-    set(_DEFAULT_EXTERNAL_MPV_DIR "/opt/jellyfin-desktop/libmpv")
-elseif(APPLE AND EXISTS "/opt/jellyfin-desktop/libmpv/lib/libmpv.dylib")
-    set(_DEFAULT_EXTERNAL_MPV_DIR "/opt/jellyfin-desktop/libmpv")
-endif()
-
-set(EXTERNAL_MPV_DIR "${_DEFAULT_EXTERNAL_MPV_DIR}" CACHE PATH "Path to external mpv installation (must contain include/ and lib/)")
+set(EXTERNAL_MPV_DIR "" CACHE PATH "Path to external mpv installation (must contain include/ and lib/); leave empty to build from third_party/mpv submodule")
 
 if(EXTERNAL_MPV_DIR)
     message(STATUS "Using external mpv from: ${EXTERNAL_MPV_DIR}")
@@ -490,7 +482,7 @@ else()
     if(NOT EXISTS "${MPV_BUILD_DIR}/build.ninja")
         message(STATUS "Configuring mpv with meson (cplayer=${_MPV_CPLAYER})...")
         execute_process(
-            COMMAND meson setup build --default-library=shared -Dlibmpv=true -Dcplayer=${_MPV_CPLAYER}
+            COMMAND meson setup build --default-library=shared -Dlibmpv=true -Dcplayer=${_MPV_CPLAYER} -Dpipewire=disabled
             WORKING_DIRECTORY ${MPV_SOURCE_DIR}
             RESULT_VARIABLE MPV_SETUP_RESULT
         )
@@ -885,6 +877,9 @@ else()
     install(DIRECTORY "${CEF_RESOURCE_DIR}/locales" DESTINATION .)
     if(EXTERNAL_MPV_DIR)
         install(FILES "${EXTERNAL_MPV_DIR}/lib/libmpv.so" DESTINATION .)
+    else()
+        install(FILES "${MPV_BUILD_DIR}/libmpv.so.2" DESTINATION .)
+        install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink libmpv.so.2 \"\${CMAKE_INSTALL_PREFIX}/libmpv.so\")")
     endif()
 endif()
 

--- a/README.md
+++ b/README.md
@@ -31,14 +31,30 @@ This project uses [just](https://github.com/casey/just) as a command runner.
 
 ```
 Available recipes:
-    appimage          # Build AppImage (outputs to dist/)
-    build             # Configure (if needed) + build the main app
-    clean             # Remove build artifacts (keeps CEF SDK download)
-    deps              # Ensure submodules and CEF are present
-    flatpak           # Build Flatpak bundle (outputs to dist/)
-    list              # List available recipes
-    mpv *args         # Run the standalone mpv CLI built from the submodule (forwards args)
-    run *args         # Run the app with debug logging (logs to build/run.log)
-    test              # Run unit tests
-    update-deps *args # Update vendored/fetched deps (CEF, doctest, quill); pass --check to verify only
+    appimage               # Build AppImage (outputs to dist/)
+    build                  # Configure (if needed) + build the main app
+    clean                  # Remove build artifacts (keeps CEF SDK download)
+    deps                   # Ensure submodules and CEF are present
+    flatpak                # Build Flatpak bundle (outputs to dist/)
+    install-deps-fedora    # Install build dependencies on Fedora/RHEL
+    list                   # List available recipes
+    mpv *args              # Run the standalone mpv CLI built from the submodule (forwards args)
+    run *args              # Run the app with debug logging (logs to build/run.log)
+    test                   # Run unit tests
+    update-deps *args      # Update vendored/fetched deps (CEF, doctest, quill); pass --check to verify only
 ```
+
+### Building from source on Linux
+
+`just build` handles everything: submodule init, CEF download, mpv build, and the app itself. It builds mpv from the bundled submodule (a fork that exposes Wayland surface handles required for the overlay architecture).
+
+**Arch Linux** — install the [AUR package](https://aur.archlinux.org/packages/jellyfin-desktop-git) or use the packages listed in `dev/appimage/Dockerfile`.
+
+**Fedora / RHEL** — install dependencies first (requires [RPM Fusion free](https://rpmfusion.org/Configuration) for `ffmpeg-devel`):
+
+```sh
+just install-deps-fedora
+just build
+```
+
+> **ARM64 / Asahi Linux note:** `just build` works natively on `aarch64` — no cross-compilation needed. The pre-built AppImage and Flatpak are x86_64 only, so building from source is the supported path on ARM64.

--- a/cmake/FindCEF.cmake
+++ b/cmake/FindCEF.cmake
@@ -133,7 +133,7 @@ elseif(CEF_ROOT AND EXISTS "${CEF_ROOT}/include/cef_version.h")
         if(CMAKE_GENERATOR)
             list(APPEND _CEF_CMAKE_ARGS -G "${CMAKE_GENERATOR}")
         endif()
-        if(WIN32 AND CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64")
+        if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
             list(APPEND _CEF_CMAKE_ARGS -DPROJECT_ARCH=arm64)
         endif()
         execute_process(

--- a/dev/linux/install-deps-fedora.sh
+++ b/dev/linux/install-deps-fedora.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env sh
+# Install build dependencies for jellyfin-desktop on Fedora/RHEL.
+# Requires rpmfusion-free for ffmpeg-devel (or substitute libavcodec-free-devel).
+set -eu
+
+# Enable RPM Fusion free if not already enabled (needed for ffmpeg-devel)
+if ! rpm -q rpmfusion-free-release >/dev/null 2>&1; then
+    echo "RPM Fusion free not enabled. Install it first:"
+    echo "  sudo dnf install https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-\$(rpm -E %fedora).noarch.rpm"
+    echo "Or substitute ffmpeg-devel with libavcodec-free-devel from the main Fedora repo."
+    exit 1
+fi
+
+sudo dnf install -y \
+    cmake \
+    ninja-build \
+    gcc \
+    gcc-c++ \
+    git \
+    meson \
+    just \
+    python3 \
+    python3-pip \
+    \
+    ffmpeg-devel \
+    \
+    wayland-devel \
+    wayland-protocols-devel \
+    plasma-wayland-protocols \
+    libxkbcommon-devel \
+    libxkbcommon-x11-devel \
+    xcb-util-devel \
+    xcb-util-cursor-devel \
+    xcb-util-image-devel \
+    xcb-util-keysyms-devel \
+    xcb-util-wm-devel \
+    libX11-devel \
+    libXpresent-devel \
+    libXScrnSaver-devel \
+    libXv-devel \
+    systemd-devel \
+    libdrm-devel \
+    mesa-libEGL-devel \
+    mesa-libgbm-devel \
+    \
+    alsa-lib-devel \
+    libass-devel \
+    libplacebo-devel \
+    rubberband-devel \
+    uchardet-devel \
+    zimg-devel \
+    libva-devel \
+    libvdpau-devel \
+    libshaderc-devel \
+    vulkan-headers \
+    vulkan-loader-devel \
+    compat-lua-devel \
+    mujs-devel \
+    libjpeg-turbo-devel \
+    libdvdnav-devel \
+    libcdio-paranoia-devel \
+    libbluray-devel \
+    libdisplay-info-devel \
+    libunwind-devel \
+    openal-soft-devel \
+    pulseaudio-libs-devel \
+    libsamplerate-devel \
+    openssl-devel \
+    libarchive-devel

--- a/dev/linux/linux.just
+++ b/dev/linux/linux.just
@@ -1,5 +1,10 @@
 # Linux-specific recipes (imported by top-level justfile)
 
+# Install build dependencies on Fedora/RHEL
+[linux]
+install-deps-fedora:
+    ./dev/linux/install-deps-fedora.sh
+
 # Build AppImage (outputs to dist/)
 [linux]
 appimage:


### PR DESCRIPTION
## Summary

Fixes several issues that prevented `just build` from working on Linux aarch64 (tested on Asahi Fedora, Apple Silicon). Pre-built packages (AppImage, Flatpak) are x86_64-only, so native build is the only path for ARM64 Linux users.

**Root cause: CEF CMake ARM64 detection (`cmake/FindCEF.cmake`)**

`FindCEF.cmake` already passed `-DPROJECT_ARCH=arm64` when building the CEF wrapper — but only for Windows `ARM64`. On Linux, `CMAKE_SYSTEM_PROCESSOR` is `aarch64`, not `arm64`, so the condition was never true. The CEF wrapper was then configured with `-m64 -march=x86-64` flags (x86-only) and failed to compile on the first file.

Fix: match `aarch64|arm64|ARM64` on all platforms.

**Runtime: `EXTERNAL_MPV_DIR` auto-detect silently used system mpv (`CMakeLists.txt`)**

The auto-detect block defaulted to `/opt/jellyfin-desktop/libmpv` if that path existed. System mpv lacks the custom `wayland-display` / `wayland-surface` properties that the bundled fork exposes, causing `Platform init failed` at startup. Removed the auto-detect; `EXTERNAL_MPV_DIR` is now empty by default (build from submodule).

**Runtime: missing `cmake --install` rule for bundled `libmpv.so.2` (`CMakeLists.txt`)**

The POST_BUILD step correctly copies `libmpv.so.2` to the build directory, but there was no `install()` rule for the non-`EXTERNAL_MPV_DIR` case. `cmake --install` left stale files in place. Added `install(FILES ...)` + symlink creation for the bundled mpv path.

**Build: `-Dpipewire=disabled` in mpv meson setup (`CMakeLists.txt`)**

Prevents segfaults on systems where `libpipewire` is present (the fork's pipewire integration is not required since audio goes through alsa/pulseaudio).

**Fedora build deps (`dev/linux/install-deps-fedora.sh`)**

`plasma-wayland-protocols` and `xcb-util-devel` were not documented and caused build failures. Added a complete Fedora/RHEL dependency script with `just install-deps-fedora`.

## Test plan

- [x] `just build` succeeds on Linux x86_64 (existing CI)
- [x] `just build` succeeds on Linux aarch64 (Asahi Fedora, Apple M-series)
- [x] App launches and reaches Jellyfin web UI on Wayland/aarch64
- [x] `cmake --install` correctly places `libmpv.so.2` + `libmpv.so` symlink

🤖 Generated with [Claude Code](https://claude.ai/claude-code)