### PR TITLE
Fix Windows shutdown hang leaving lingering process

### DIFF
--- a/src/cef/cef_client.cpp
+++ b/src/cef/cef_client.cpp
@@ -594,8 +594,11 @@ void CefLayer::reset() {
         // so we don't need to (and must not) clear it ourselves.
         CefPostTask(TID_UI, CefRefPtr<CefTask>(new FnTask([self]() {
             // Go through create() so requested_url_ is cleared alongside the
-            // actual CreateBrowser call.
-            self->create("");
+            // actual CreateBrowser call. Skip during shutdown: CefShutdown()
+            // drains pending tasks, and creating a browser here would race
+            // with the shutdown teardown and cause a hang.
+            if (!g_shutting_down.load(std::memory_order_relaxed))
+                self->create("");
         })));
     });
 


### PR DESCRIPTION
When the app closes, CefLayer::reset() posts an OnBeforeClose callback that calls create("") to recreate the browser. During shutdown this races with CefShutdown()'s task drain, creating a new browser that never gets an OnBeforeClose, causing waitAllClosed() to hang indefinitely — leaving a lingering process and named pipe that blocks relaunch.

Fix: check g_shutting_down before posting the re-create task.

Fixes #380