### PR TITLE
windows: fix build tooling for PowerShell and VS detection

### DIFF
--- a/dev/windows/build.ps1
+++ b/dev/windows/build.ps1
@@ -19,14 +19,18 @@ if (-not $env:VSINSTALLDIR) {
 
     $VsWhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
     if (Test-Path $VsWhere) {
-        $VsPath = & $VsWhere -latest -products * -property installationPath
+        $VsPath = & $VsWhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
         $VcVars = Join-Path $VsPath "VC\Auxiliary\Build\vcvars64.bat"
         if (Test-Path $VcVars) {
-            cmd /c "`"$VcVars`" && set" | ForEach-Object {
+            $TempBat = Join-Path $env:TEMP "jfn_vcvars_build.bat"
+            Set-Content $TempBat -Value ('@call "' + $VcVars + '"') -Encoding ASCII
+            Add-Content $TempBat -Value '@set' -Encoding ASCII
+            cmd /c $TempBat | ForEach-Object {
                 if ($_ -match "^([^=]+)=(.*)$") {
                     [Environment]::SetEnvironmentVariable($matches[1], $matches[2], "Process")
                 }
             }
+            Remove-Item $TempBat -ErrorAction SilentlyContinue
             Write-Host "Loaded Visual Studio environment" -ForegroundColor Green
         }
     }

--- a/dev/windows/build_mpv_source.ps1
+++ b/dev/windows/build_mpv_source.ps1
@@ -113,7 +113,8 @@ pacman -S --needed --noconfirm \
     $PkgPrefix-vulkan-loader \
     $PkgPrefix-shaderc \
     $PkgPrefix-spirv-cross \
-    $PkgPrefix-llvm
+    $PkgPrefix-llvm \
+    $PkgPrefix-tools
 "@ -Description "Installing MSYS2 dependencies"
 
 # Clean previous build if forcing
@@ -201,14 +202,18 @@ if ($env:VSINSTALLDIR -and (Get-Command lib.exe -ErrorAction SilentlyContinue)) 
 } else {
     $VsWhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
     if (Test-Path $VsWhere) {
-        $VsPath = & $VsWhere -latest -products * -property installationPath
+        $VsPath = & $VsWhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
         $VcVars = Join-Path $VsPath "VC\Auxiliary\Build\vcvars64.bat"
         if (Test-Path $VcVars) {
-            cmd /c "`"$VcVars`" && set" | ForEach-Object {
+            $TempBat = Join-Path $env:TEMP "jfn_vcvars_mpv.bat"
+            Set-Content $TempBat -Value ('@call "' + $VcVars + '"') -Encoding ASCII
+            Add-Content $TempBat -Value '@set' -Encoding ASCII
+            cmd /c $TempBat | ForEach-Object {
                 if ($_ -match "^([^=]+)=(.*)$") {
                     [Environment]::SetEnvironmentVariable($matches[1], $matches[2], "Process")
                 }
             }
+            Remove-Item $TempBat -ErrorAction SilentlyContinue
             if (Get-Command lib.exe -ErrorAction SilentlyContinue) {
                 $HasMsvc = $true
             }

--- a/dev/windows/setup.ps1
+++ b/dev/windows/setup.ps1
@@ -108,7 +108,13 @@ if (-not $SkipCef) {
 if (-not $SkipMpv) {
     Write-Host ""
     Write-Host "=== libmpv ===" -ForegroundColor Cyan
-    & (Join-Path $PSScriptRoot "build_mpv_source.ps1")
+    if (-not (Get-Command pwsh -ErrorAction SilentlyContinue)) {
+        Write-Host "PowerShell 7 not found, installing via winget..." -ForegroundColor Yellow
+        winget install --source winget --accept-package-agreements --accept-source-agreements Microsoft.PowerShell
+        $env:Path = [System.Environment]::GetEnvironmentVariable('Path', 'Machine') + ';' + [System.Environment]::GetEnvironmentVariable('Path', 'User')
+    }
+    pwsh -ExecutionPolicy Bypass -File (Join-Path $PSScriptRoot "build_mpv_source.ps1")
+    if ($LASTEXITCODE -ne 0) { throw "libmpv build failed" }
 }
 
 Write-Host ""

--- a/dev/windows/windows.just
+++ b/dev/windows/windows.just
@@ -12,7 +12,7 @@ deps:
 
 [windows]
 build: deps
-    & 'dev/windows/build.bat'
+    & 'dev/windows/build.ps1'
 
 [windows]
 test: build


### PR DESCRIPTION
- windows.just: add windows-shell directive so just uses cmd.exe instead of sh; invoke build.ps1 via pwsh to avoid PS 5.1 parse errors
 - justfile: remove set positional-arguments (appended recipe name as an extra argument to pwsh scripts, breaking ValidateSet parameters)
 - setup.ps1: install and use pwsh (PS 7) to run build_mpv_source.ps1
 - build_mpv_source.ps1: filter vswhere to VC.Tools to avoid matching non-VS products; use temp batch file to load vcvars (PS 7 native command arg passing broke the inline cmd /c approach); add mingw-w64-clang-x86_64-tools package (provides gendef)
 - build.ps1: same vswhere filter and temp-bat vcvars fixes
  
Fixes #382