### PR TITLE
wayland: hide overlay surface immediately when alpha modifier missing

### DIFF
--- a/src/platform/wayland.cpp
+++ b/src/platform/wayland.cpp
@@ -410,8 +410,18 @@ static void wl_surface_set_visible(PlatformSurface* s, bool visible) {
 static void wl_fade_surface(PlatformSurface* s, float fade_sec,
                             std::function<void()> on_fade_start,
                             std::function<void()> on_complete) {
-    if (!s || !s->alpha || !s->surface) {
+    if (!s || !s->surface) {
         if (on_fade_start) on_fade_start();
+        if (on_complete) on_complete();
+        return;
+    }
+
+    // Compositor lacks wp_alpha_modifier_v1 (e.g. niri): can't animate alpha.
+    // Unmap the surface immediately so it doesn't linger on screen while the
+    // CEF browser tears down asynchronously after on_complete runs.
+    if (!s->alpha) {
+        if (on_fade_start) on_fade_start();
+        wl_surface_set_visible(s, false);
         if (on_complete) on_complete();
         return;
     }


### PR DESCRIPTION
## Summary

On Wayland compositors that don't advertise `wp_alpha_modifier_v1` (e.g. **niri**), the launch splash overlay stays visible on screen on top of the loaded home page until the user navigates or interacts with the window. `wl_fade_surface` (`src/platform/wayland.cpp:410`) early-returns when `s->alpha == nullptr` and fires `on_complete` (which calls `CloseBrowser`) inline — but the surface is never unmapped, so it lingers through the async CEF teardown.

This patch detaches the buffer via `wl_surface_set_visible(s, false)` before invoking `on_complete`, so the overlay disappears synchronously on compositors without the alpha-modifier protocol, even though we can't animate the fade.

## Repro

- Compositor: niri 25.11
- Symptom: ~Jellyfin splash logo + spinner remain composited on top of the home view after `dismissOverlay`. Probed `wl_alpha_modifier_v1` = absent; everything else (`wp_viewporter`, `wl_subcompositor`, `linux-dmabuf`, `wp_fractional_scale_manager_v1`) present.
- Log shows `Overlay: dismissOverlay` and `setActive prev=overlay new=web`, but the splash subsurface is never detached.

## Test plan

- [x] Build with `cmake --build build` (Release, external libmpv)
- [x] Verify on niri: splash dismisses immediately after `dismissOverlay`, home view visible cleanly
- [ ] Verify on a compositor that DOES expose `wp_alpha_modifier_v1` (e.g. KWin, Hyprland) — fade animation should still run unchanged